### PR TITLE
Add is_royal/is_transformed attrs and Boulder piece class

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,114 @@
+# Implementation Plan: New Piece Features
+
+## Phase 1: Piece Class Refactoring
+
+### 1.1 Add general attributes to the Piece base class
+**File: `src/piece.py`**
+- Add `is_royal` attribute (default `False`) — `True` for all Kings and promoted Royal Queens
+- Add `is_transformed` attribute (default `False`) — `True` for any piece that has been transformed by a queen's power
+- These attributes live on the base `Piece` class so all subclasses inherit them
+
+### 1.2 Update King subclass
+- Set `is_royal = True` in King's `__init__`
+
+### 1.3 Add Boulder subclass
+**File: `src/piece.py`**
+- New subclass `Boulder(Piece)` with name `'boulder'`, no color (neutral), value `0`
+- Boulders are immovable, non-capturable obstacles
+- They block movement and line-of-sight for all pieces
+
+---
+
+## Phase 2: Boulder Mechanics
+
+### 2.1 Board placement
+**File: `src/board.py`**
+- Place boulders at the 4 center squares: (3,3), (3,4), (4,3), (4,4)
+- Boulders occupy squares but belong to neither player
+
+### 2.2 Movement blocking
+**File: `src/board.py`**
+- Update `straightline_squares()` (line ~195): when a boulder is encountered, stop — do not add that square, just break
+- Update `straightline_of_sight_squares()` (line ~230): boulders block line-of-sight the same way
+- Boulders also block diagonal movement at the center intersection
+- Knights (Hippogriffs) can jump over boulders but cannot land on them
+- No piece can capture or move onto a boulder square
+
+### 2.3 Boulder rendering
+**File: `assets/`**
+- Add boulder texture image (a neutral-colored rock/stone)
+- Render boulders on the board like any other piece
+
+---
+
+## Phase 3: Pawn Promotion Menu
+
+### 3.1 Promotion selection UI
+**Files: `src/main.py`, `src/board.py`**
+- When a pawn reaches the last rank, show a selection menu asking which type of queen to promote to:
+  - **Royal Queen** (`is_royal = True`) — moves like current queen (1 square any direction), has queen powers (move enemy pieces, transform), and is a check/checkmate target like the king
+  - **Regular Queen** (`is_royal = False`) — moves like current queen but without royal status
+- After selection, replace the pawn with a Queen instance, setting `is_royal` accordingly
+- Mark promoted queens visually (e.g., a small crown icon or border glow) to distinguish them from the original queen
+
+---
+
+## Phase 4: Queen Transformation Power
+
+### 4.1 Transformation selection UI
+**Files: `src/main.py`, `src/board.py`**
+- When a queen uses its transformation power on a friendly piece, show a selection menu asking which piece type to transform into (e.g., Knight/Hippogriff, Bishop/Assassin, Rook/Chariot)
+- The transformed piece keeps its color but changes its type, movement rules, and texture
+- Set `is_transformed = True` on the transformed piece
+- Mark transformed pieces visually (e.g., a small indicator) to distinguish them from original pieces of that type
+
+### 4.2 Transformation logic
+**File: `src/board.py`**
+- Queen must be adjacent to the friendly piece (within line of sight)
+- Transformation replaces the piece object on the board with a new instance of the chosen subclass
+- Carry over: color, `is_transformed = True`, position
+- A piece can only be transformed once (check `is_transformed` before allowing)
+
+---
+
+## Phase 5: Knight (Hippogriff) Jump Capture
+
+### 5.1 Simplified interaction
+**Files: `src/main.py`, `src/board.py`**
+- When a knight lands on a square, if there are adjacent enemy pieces that could be captured:
+  - Highlight the adjacent capturable enemy pieces AND the landing square itself
+  - User clicks an adjacent enemy piece to capture it, OR clicks the landing square to decline capturing
+- No secondary selection step or action menu needed — just one click after landing
+
+---
+
+## Phase 6: Queen Enemy Piece Manipulation (Already Partially Implemented)
+
+### 6.1 Simplified interaction (already works this way)
+- The current flow already lets the user select an enemy piece and move it directly (no queen selection needed)
+- The queen's line-of-sight determines which enemy pieces can be manipulated
+- No additional action menu needed — the existing click-to-select, drag-to-move flow handles this
+
+---
+
+## Summary of Class Structure
+
+```
+Piece (base class)
+  - name, color, value, is_royal (default False), is_transformed (default False)
+  - moves, line_of_sight, moved, moved_by_queen, texture, texture_rect
+  ├── Pawn (value: 1.0)
+  ├── Knight / Hippogriff (value: 3.0)
+  ├── Bishop / Assassin (value: 3.001)
+  ├── Rook / Chariot (value: 5.0)
+  ├── Queen (value: 9.0) — is_royal set based on promotion choice
+  ├── King (value: 10000.0) — is_royal = True always
+  └── Boulder (value: 0, no color) — immovable, blocks movement/sight
+```
+
+## UI Additions Summary
+1. **Boulder rendering** — neutral stone graphic on center squares
+2. **Pawn promotion menu** — choose Royal Queen vs Regular Queen
+3. **Queen transformation menu** — choose which piece type to transform a friendly piece into
+4. **Visual markers** — promoted queens get a marker; transformed pieces get a marker
+5. **Knight jump capture** — highlight capturable adjacent pieces + landing square after landing

--- a/src/board.py
+++ b/src/board.py
@@ -139,7 +139,7 @@ class Board:
 
     def check_promotion(self, piece, final):
         if final.row == 0 or final.row == 7:
-            self.squares[final.row][final.col].piece = Queen(piece.color)
+            self.squares[final.row][final.col].piece = Queen(piece.color, is_royal=False)
 
     def castling(self, initial, final):
         return abs(initial.col - final.col) == 2

--- a/src/piece.py
+++ b/src/piece.py
@@ -7,6 +7,8 @@ class Piece:
         self.color = color
         value_sign = 1 if color == 'white' else -1
         self.value = value * value_sign
+        self.is_royal = False
+        self.is_transformed = False
         self.line_of_sight = []
         self.moves = []
         self.moved = False
@@ -50,8 +52,21 @@ class Rook(Piece):
 
 class Queen(Piece):
 
-    def __init__(self, color):
+    def __init__(self, color, is_royal=True):
         super().__init__('queen', color, 9.0)
+        self.is_royal = is_royal
+
+class Boulder(Piece):
+
+    def __init__(self):
+        self.cooldown = 0
+        self.last_square = None
+        self.first_move = True
+        super().__init__('boulder', 'none', 0)
+
+    def set_texture(self, size=80):
+        self.texture = os.path.join(
+            f'assets/images/imgs-{size}px/boulder.png')
 
 class King(Piece):
 
@@ -59,3 +74,4 @@ class King(Piece):
         self.left_rook = None
         self.right_rook = None
         super().__init__('king', color, 10000.0)
+        self.is_royal = True

--- a/tests/test_piece.py
+++ b/tests/test_piece.py
@@ -1,0 +1,137 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from piece import Piece, Pawn, Knight, Bishop, Rook, Queen, King, Boulder
+
+
+# --- Base Piece class ---
+
+def test_piece_default_attributes():
+    p = Piece('test', 'white', 1.0)
+    assert p.name == 'test'
+    assert p.color == 'white'
+    assert p.value == 1.0
+    assert p.is_royal is False
+    assert p.is_transformed is False
+    assert p.moved is False
+    assert p.moved_by_queen is False
+    assert p.moves == []
+    assert p.line_of_sight == []
+
+def test_piece_black_value_sign():
+    p = Piece('test', 'black', 5.0)
+    assert p.value == -5.0
+
+
+# --- Pawn ---
+
+def test_pawn_attributes():
+    pw = Pawn('white')
+    assert pw.name == 'pawn'
+    assert pw.color == 'white'
+    assert pw.dir == -1
+    assert pw.en_passant is False
+    assert pw.is_royal is False
+    assert pw.is_transformed is False
+
+def test_pawn_black_direction():
+    pb = Pawn('black')
+    assert pb.dir == 1
+
+
+# --- Knight ---
+
+def test_knight_attributes():
+    k = Knight('white')
+    assert k.name == 'knight'
+    assert k.value == 3.0
+    assert k.is_royal is False
+    assert k.is_transformed is False
+
+
+# --- Bishop ---
+
+def test_bishop_attributes():
+    b = Bishop('black')
+    assert b.name == 'bishop'
+    assert b.assassin_squares == []
+    assert b.is_royal is False
+    assert b.is_transformed is False
+
+
+# --- Rook ---
+
+def test_rook_attributes():
+    r = Rook('white')
+    assert r.name == 'rook'
+    assert r.value == 5.0
+    assert r.is_royal is False
+    assert r.is_transformed is False
+
+
+# --- Queen ---
+
+def test_queen_default_is_royal():
+    q = Queen('white')
+    assert q.name == 'queen'
+    assert q.is_royal is True
+    assert q.is_transformed is False
+
+def test_queen_explicit_royal():
+    q = Queen('black', is_royal=True)
+    assert q.is_royal is True
+
+def test_queen_non_royal_promoted():
+    q = Queen('white', is_royal=False)
+    assert q.is_royal is False
+    assert q.is_transformed is False
+
+
+# --- King ---
+
+def test_king_is_royal():
+    k = King('white')
+    assert k.name == 'king'
+    assert k.is_royal is True
+    assert k.left_rook is None
+    assert k.right_rook is None
+    assert k.is_transformed is False
+
+
+# --- Boulder ---
+
+def test_boulder_attributes():
+    b = Boulder()
+    assert b.name == 'boulder'
+    assert b.color == 'none'
+    assert b.value == 0
+    assert b.is_royal is False
+    assert b.is_transformed is False
+    assert b.cooldown == 0
+    assert b.last_square is None
+    assert b.first_move is True
+
+def test_boulder_texture_path():
+    b = Boulder()
+    assert 'boulder.png' in b.texture
+    assert b.color not in b.texture  # no color prefix
+
+
+# --- is_transformed attribute ---
+
+def test_is_transformed_can_be_set():
+    r = Rook('white')
+    assert r.is_transformed is False
+    r.is_transformed = True
+    assert r.is_transformed is True
+
+
+# --- Piece methods ---
+
+def test_add_and_clear_moves():
+    p = Pawn('white')
+    p.add_move('fake_move')
+    assert len(p.moves) == 1
+    p.clear_moves()
+    assert p.moves == []


### PR DESCRIPTION
## Changes

- **Piece base class**: Added `is_royal` (default `False`) and `is_transformed` (default `False`) attributes to all pieces
- **King subclass**: Set `is_royal = True` in `__init__`
- **Queen subclass**: Added `is_royal` parameter to `__init__` (defaults to `True` for original queen, can be set to `False` for promoted pawns)
- **Boulder subclass**: New neutral piece with `color='none'`, `value=0`, immovable obstacle
- **Board**: Updated pawn promotion to create non-royal queens with `is_royal=False`
- **Tests**: Added comprehensive test suite covering all piece attributes and the new Boulder class
- **Documentation**: Added implementation plan for phased feature rollout