### PR TITLE
Record analysis-rigor clarifications and correct strategic facts

### DIFF
--- a/docs/design-notes/MEMORY.md
+++ b/docs/design-notes/MEMORY.md
@@ -32,6 +32,10 @@ Then `git log --oneline -20` for recent design context (commit bodies contain ra
 - [Project roadmap & goals](project_roadmap.md) — the 4 goals: (1) finish >6 stall analysis, (2) human-vs-AI game mode, (3) train AI on new rules (finalize rules first!), (4) ambitious GDL/GGP research (aimed at ISEF, ROBO category). Read for "what are we building toward."
 - [Chess variant overview](project_chess_variant_overview.md) — one-page summary of the variant. Read this if you've forgotten what kind of project this is.
 
+### How to work (feedback)
+
+- [Analysis rigor](feedback_analysis_rigor.md) — **READ before any rule-strategy / tiny-endgame analysis.** Do NOT jump to under-coverage/stall-prone conclusions; verify reversals with the user BEFORE recording; self-check assumptions against the rulebook + optimal-play definition many times.
+
 ### Topic-specific notes
 
 - [Helper semantics: `has_enemy_piece` vs `has_capturable_enemy_piece`](project_helper_semantics.md) — broad-vs-narrow Square helpers; using the wrong one has caused several bugs.

--- a/docs/design-notes/feedback_analysis_rigor.md
+++ b/docs/design-notes/feedback_analysis_rigor.md
@@ -1,0 +1,26 @@
+---
+name: feedback-analysis-rigor
+description: "How to approach strategic/rule analysis on this project — do NOT jump to under-coverage/stall-prone conclusions, verify with the user before recording reversals, self-check assumptions against the rulebook many times. Read before any tiny-endgame or rule-strategy analysis."
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: e3b1db7b-ec7f-4a43-9b69-568c3971b17d
+---
+
+# Do not jump to conclusions from unverified strategic analysis
+
+**Rule:** When strategic/rule analysis leads to a conclusion — especially one that **overturns a prior recorded conclusion** or claims **under-coverage / stall-prone** — present it to the user as **tentative** and get explicit verification **BEFORE** updating memory, docs, the rulebook, or code. Self-check every assumption and strategy against `RULEBOOK_v2.md` and the optimal-play definition **many times** before presenting. Default to NOT claiming under-coverage.
+
+**Why:** I make accuracy mistakes in strategic analysis **frequently**, and the errors compound into confidently-wrong conclusions. The user has corrected this pattern repeatedly:
+- I have a recurring bias toward eagerly declaring positions "stall-prone" / the rule "under-covers," based on reasoning that turns out to be flawed.
+- Concrete instance (2026-05-20): I tried to reverse the "K+RQ+PQ+B+B vs same likely rule-sufficient" lean to "stall-prone" using three arguments — **all three were wrong**:
+  1. "No-check makes a mirror/copycat defense un-loseable because one capture never wins" — WRONG: no-check is only a legality difference; you capture both royals one at a time and win, even from symmetry; first-mover tempo converts.
+  2. "Under no-check, a defender can simply decline a fork and accept the loss" — WRONG: optimal players never move into a worse position, so threats must be addressed/captured; forks DO force.
+  3. "A bishop pin is a stable trap, and the pin/tempo race favors the defender" — WRONG/incomplete: a base-form queen can manipulate the pinning bishop away (R3 doesn't protect bishops; manipulation is non-spatial so no reactive trigger).
+- The correct strategic facts are recorded in [[Piece strategic dynamics — bishop active-pin, queen lock-down, queen-as-bishop escape, action stalling]] ("User clarifications 2026-05-20"). The optimal-play definition is in [[Tiny endgame rule — operational stall definition and analysis methodology]].
+
+**How to apply:**
+- Treat the recorded leans (e.g. "dense symmetric >6 likely rule-sufficient") as the standing position. Do NOT silently overturn them.
+- Before presenting any analytical conclusion: re-derive it, then try to BREAK it yourself (look for the holes), then check it against the rulebook and the optimal-play definition. Only present after it survives self-refutation.
+- When presenting a conclusion that changes a recorded one, label it tentative, show the reasoning, and ask the user to verify before recording anything.
+- Never record incorrect analysis into memory/docs, even as a foil — record only the verified correction/clarification.

--- a/docs/design-notes/project_piece_strategic_dynamics.md
+++ b/docs/design-notes/project_piece_strategic_dynamics.md
@@ -383,3 +383,22 @@ Rulebook (Boulder): "Boulder Memory — the boulder may not move to the immediat
 **My lean: ALLOW the capture-return.** Rationale: the no-return rule's intent is to prevent pointless oscillation (infinite back-and-forth shuffling with no progress). A CAPTURE is irreversible progress (removes a pawn, changes material) — not pointless oscillation — so it doesn't create a degenerate loop and shouldn't be forbidden by a rule aimed at loop-prevention. Strict reading of the current text forbids it (a capture is still a "move to that square"), so the rulebook is AMBIGUOUS and needs clarification.
 
 **Scope note:** only matters in positions WITH pawns; irrelevant to the pawnless tiny-endgame analysis. STATUS: pending user decision; if "allow," update RULEBOOK_v2.md (carve-out: no-return rule does not apply to a capturing move) + check/fix code + add tests. Have NOT checked current code behavior yet.
+
+# User clarifications: no-check, optimal-play declining, manipulation pin-breaking (2026-05-20) — AUTHORITATIVE
+
+These three clarifications were given by the user to correct three INCORRECT arguments I made while wrongly attempting to reverse the "K+RQ+PQ+B+B vs same likely rule-sufficient" lean to "stall-prone." Treat the clarifications below as authoritative; the analysis they corrected was wrong and is not recorded. See [[feedback-analysis-rigor]].
+
+## No-check is ONLY a legality difference — NOT a strategic shield
+- The win condition (capture BOTH enemy royals) does NOT mean "one capture never wins." You capture one royal, then the other; the game ends on the **second** capture. Capturing the two royals one at a time still wins — **even from a symmetric position.**
+- The absence of check is **purely a legality difference**: you are not FORCED to move a royal out of danger. There is **no significant strategic difference** — royals are still in danger when attacked, and saving them is almost always favorable (optimal).
+- Consequence: any "mirror/copycat is un-loseable because one capture never wins" argument is **FALSE**. First-mover tempo can still convert to capturing both royals one at a time, exactly as a check-race converts in standard chess.
+
+## Optimal play CANNOT simply "decline" a threat
+- Optimal players **never** make a move that brings them into a worse position than their current one.
+- Losing a non-royal piece without capturing back is almost never optimal. A defender facing a fork **cannot** just decline/ignore it and accept the loss — that worsens their position. They MUST address the threat (move, defend, block) or capture.
+- Consequence: forks and threats **do** carry forcing power. "The defender can simply decline the fork" is **WRONG**.
+
+## Manipulation can BREAK a pin
+- A pinned queen can (be in / transform to) **base form** and **manipulate the pinning bishop away**: the pinning bishop sits on the queen's diagonal LOS, and manipulation Restriction 3 does not protect bishops. Manipulation is a non-spatial action, so it does NOT trigger the bishop's reactive capture. Pin broken.
+- The bishop's only counter is to have **moved on the immediately preceding turn** (manipulation Restriction 2 forbids manipulating a just-moved piece). So to stay manipulation-immune the bishop must move **every** turn — which costs tempo, and during those turns other pieces can be manipulated / other dynamics arise.
+- Consequence: a bishop pin is **NOT a stable trap** against a queen. Any pin/tempo "race" analysis that ignores manipulation pin-breaking is incomplete and unreliable.

--- a/docs/design-notes/project_tiny_endgame_analysis_methodology.md
+++ b/docs/design-notes/project_tiny_endgame_analysis_methodology.md
@@ -225,6 +225,20 @@ Strategic tools I keep under-weighting:
 
 **Before concluding stall-prone, exhaustively check whether manipulation + multi-piece coordination forces a piece capture in finite turns.** If a single piece can be captured via forcing tactics, the position simplifies, often into a ≤4 catch-all or a clearly-forceable smaller position.
 
+# Optimal-play definition (user, 2026-05-20) — AUTHORITATIVE
+
+Optimal play = given ALL current rules **including the tiny endgame rule**, both players make optimal moves: **force a win as quickly as possible, or delay a loss as long as possible.**
+
+Corollary: an optimal player **never** makes a move that brings them into a worse position than their current one. So a defender cannot "simply decline" a threat/fork and accept an unforced material loss — threats must be addressed or captured. (See [[Piece strategic dynamics — bishop active-pin, queen lock-down, queen-as-bishop escape, action stalling]] "User clarifications 2026-05-20".)
+
+Note: the operational stall-vs-forceable test still assumes the **repetition rule is absent** for CLASSIFICATION purposes, but the optimality principle above governs how both sides choose moves.
+
+# Meta-lesson (2026-05-20): do NOT record reversals from unverified analysis
+
+On 2026-05-20 I attempted to reverse the recorded "K+RQ+PQ+B+B vs same likely rule-sufficient" lean to "stall-prone" using three arguments (a no-check "mirror is un-loseable" argument; a "defender can decline forks" argument; a pin/tempo "race" argument). **All three were WRONG** and were refuted by the user (clarifications recorded in `project_piece_strategic_dynamics.md`). No memory/docs were changed to reflect the incorrect reversal.
+
+Lesson: when analysis overturns a prior recorded conclusion — ESPECIALLY an "under-coverage"/stall-prone claim — present it as **tentative** and get **user verification BEFORE** editing memory/docs. Self-check every assumption against `RULEBOOK_v2.md` and the optimal-play definition multiple times. Default to NOT claiming under-coverage. See [[feedback-analysis-rigor]].
+
 # Date created
 
 2026-05-14, after the user identified that my pressure-test analysis was systematically biased toward declaring every position forceable using surface-level reasoning, ignoring the actual strategic dynamics of bishops, queen transformations, and queen-as-bishop teleport escape.


### PR DESCRIPTION
## Summary
Records the user's verified clarifications (and the optimal-play definition) into the agent design-notes mirror. Does **not** record the incorrect analysis those clarifications corrected.

- **No-check is only a legality difference** — capturing both royals one at a time still wins, even from a symmetric position; first-mover tempo converts. The "mirror is un-loseable" argument is false.
- **Optimal play never moves into a worse position** — a defender cannot "simply decline" a fork/threat; threats must be addressed or captured. Forks carry forcing power.
- **Manipulation can break a bishop pin** — a base-form queen manipulates the pinning bishop away (R3 doesn't protect bishops; non-spatial action = no reactive trigger). A pin is not a stable trap.
- Adds the **optimal-play definition** and a new **feedback_analysis_rigor.md** (don't jump to under-coverage; verify reversals with the user first; self-check against the rulebook + optimal-play many times).

## Test plan
- [ ] Docs-only change (design-notes mirror); no code touched, no tests affected.
- [ ] Verify docs/design-notes/ matches the agent memory files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)