### PR TITLE
Document that queen transform availability depends on captures

### DIFF
--- a/docs/design-notes/project_piece_strategic_dynamics.md
+++ b/docs/design-notes/project_piece_strategic_dynamics.md
@@ -123,6 +123,14 @@ If the queen-side relies on queen-as-bishop escape:
 
 This is why queens are "flexible material worth 1-3 pieces" in the cancel-queens + 1-to-3 valuation framing. A queen that can transform to bishop and teleport-escape is much more valuable than a static piece — it gains the bishop's global mobility AND survives indefinitely against limited-coverage attackers.
 
+# Transform availability depends on what was CAPTURED (verified 2026-05-20)
+
+A queen can transform into a form (rook / bishop / knight) **only if a friendly piece of that type was captured earlier** (`RULEBOOK_v2.md` line 212/148). This is easy to forget and changes escape/lock-down analysis:
+
+- If both of a side's **bishops are still on the board**, NO friendly bishop was captured → that side's queens **cannot take bishop form** → they **cannot use the queen-as-bishop teleport escape** (or queen-as-bishop pinning). Same logic for rook-form (needs a captured friendly rook) and knight-form (needs a captured friendly knight).
+- **Worked example — K+RQ+PQ+B+B vs same:** both bishops survive ⇒ queens have NO bishop form ⇒ the RQ and PQ **cannot teleport-escape**; they are stuck as base / rook / knight (all catchable). This makes the **queens the vulnerable pieces** in this composition, not the bishops. (To reach this composition both rooks AND both knights were captured, so rook-form and knight-form ARE available to the queens.)
+- **Rule for analysis:** before invoking queen-as-bishop escape, lock-down, or pinning in ANY position, first check the captured-piece history to confirm bishop-form is actually available. Do the same for rook/knight forms.
+
 # Action stalling (queens-only mechanic)
 
 Queens can take infinite actions (transformations, manipulations) on the same square without ever spatial-moving:

--- a/docs/key-rule-differences.md
+++ b/docs/key-rule-differences.md
@@ -59,6 +59,7 @@ wins; update this file to match.
 
 **Transformation:**
 - Queen → rook / bishop / knight (only if that type has been captured friendly).
+- **Availability depends on captures:** a form is available only if a friendly piece of that type was **captured earlier**. So if both bishops are still on the board, the queens **cannot** take bishop form (hence no queen-as-bishop teleport escape); likewise rook/knight forms require a friendly rook/knight to have been captured. (E.g. in K+RQ+PQ+B+B both bishops survive → queens have no bishop form → the queens cannot teleport-escape.)
 - Queen can return to base form on a later turn.
 - Transformation is a non-spatial action — doesn't change position, doesn't update `last_move`.
 - A queen-transformed-to-knight is a `Knight` Python instance with `is_transformed=True`. NOT a `Queen` instance. Important for `isinstance` checks.


### PR DESCRIPTION
## Summary
Records a verified rule consequence: a queen can take a form (rook/bishop/knight) only if a friendly piece of that type was **captured earlier**. So if both bishops survive, the queens cannot take bishop form — hence no queen-as-bishop teleport escape. Same for rook/knight forms.

- Adds the note to `docs/key-rule-differences.md` (the cheat sheet).
- Mirrors the strategic-dynamics memory note into `docs/design-notes/`.

## Test plan
- [ ] Docs-only; no code touched.