### PR TITLE
Remove stale king_moves comments (king's sword / saving the queen)

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -1912,8 +1912,6 @@ class Board:
                         piece.add_move(move)
 
     def king_moves(self, piece, row, col):
-        # not todo: Implement saving the queen after she is captured
-        # TODO: Implement the king's sword
         adjs = [
             (row-1, col+0), # up
             (row-1, col+1), # up-right


### PR DESCRIPTION
## Summary
Final cleanup for the stale-marker sweep. Removes two stale comments in the active `king_moves` that referenced non-v2 mechanics ("king's sword", "saving the queen after she is captured"). The king's real special-capture is already implemented and documented inline.

- Comment-only; no behavior change.
- The frozen v0 "Status" block (`calc_moves_v0`) is left untouched per the snapshot-freeze convention.
- Git history preserves the "king's sword" marker if it's ever revisited.

## Test plan
- [x] `test_piece_movement` (333) and `test_v2_freeze` (20) pass.