### PR TITLE
Add boulder-as-legal-turn test; restore historical comments (drop TODO only)

### DIFF
--- a/src/board.py
+++ b/src/board.py
@@ -1912,6 +1912,8 @@ class Board:
                         piece.add_move(move)
 
     def king_moves(self, piece, row, col):
+        # not todo: Implement saving the queen after she is captured
+        # Implement the king's sword
         adjs = [
             (row-1, col+0), # up
             (row-1, col+1), # up-right
@@ -1951,10 +1953,8 @@ class Board:
                 piece.add_move(move)
 
     def queen_moves(self, piece, row, col):
-        # Base-form queen movement only: 1 square in any direction (king-like).
-        # Transformation is a separate ACTION (see get_transformation_options); a
-        # transformed queen is a Rook/Bishop/Knight instance with is_transformed=True
-        # and moves via that piece's own method, so no transformation logic belongs here.
+        # not todo: Implement jail after queen is captured, if in jail cannot move or be captured
+        # Implement transformation
         adjs = [
             (row-1, col+0), # up
             (row-1, col+1), # up-right

--- a/tests/test_v2_freeze.py
+++ b/tests/test_v2_freeze.py
@@ -170,6 +170,47 @@ def test_moved_by_queen_does_not_block_queen_actions():
     assert b.has_legal_moves('black') is True
 
 
+def test_boulder_move_counts_as_legal_turn():
+    """A player whose ONLY available legal turn is a boulder move is NOT stuck:
+    boulder moves count toward 'a legal turn exists' (RULEBOOK_v2.md No Legal
+    Moves Loss). Removing the boulder leaves the player with no legal turn.
+
+    Setup: black king cornered at (0,0) by INVULNERABLE white pieces (the king
+    cannot capture invulnerable pieces, so it has no move), plus a frozen black
+    knight (no spatial move, no action). Black's only possible turn is to move
+    the boulder."""
+    b = _make_board_with_pieces(
+        white_pieces=[
+            (lambda: King('white'), 7, 7),
+            (lambda: Knight('white'), 0, 1),  # blocks black king
+            (lambda: Knight('white'), 1, 0),  # blocks black king
+            (lambda: Knight('white'), 1, 1),  # blocks black king
+        ],
+        black_pieces=[
+            (lambda: King('black'), 0, 0),
+            (lambda: Knight('black'), 4, 4),  # frozen below; no actions
+        ],
+    )
+    # Make the three blockers invulnerable so the black king cannot capture them.
+    for (r, c) in [(0, 1), (1, 0), (1, 1)]:
+        b.squares[r][c].piece.invulnerable = True
+    # Freeze the black knight (manipulation aftermath): no spatial move; a knight
+    # has no actions, so it contributes no legal turn.
+    b.squares[4][4].piece.moved_by_queen = True
+
+    # Sanity: without a boulder, black has NO legal turn.
+    b.boulder = None
+    assert b.has_legal_moves('black') is False
+
+    # Place a movable boulder (cooldown 0) on an empty square with empty
+    # neighbours. Now black DOES have a legal turn — the boulder move.
+    boulder = Boulder()
+    boulder.cooldown = 0
+    b.squares[5][5].piece = boulder
+    b.boulder = boulder
+    assert b.has_legal_moves('black') is True
+
+
 # --- 3. clear_moved_by_queen_for_opponent ---
 
 def test_clear_moved_by_queen_for_opponent_clears_only_opponent_pieces():


### PR DESCRIPTION
## Summary
- **Adds the missing test** for the boulder / No-Legal-Moves clarification (PR #54): `test_boulder_move_counts_as_legal_turn` asserts `has_legal_moves` returns True when a player's only legal turn is a boulder move, and False once the boulder is removed. This locks the rule the prose now documents.
- **Restores the historical `king_moves` / `queen_moves` comments** that earlier PRs over-deleted/rewrote. They record old rule designs (king's sword, queen jail/saving) and are kept verbatim — only the "TODO" marker is dropped, since they're not action items. The transformed-queen comment in `queen_moves_enemy` stays as updated (authorized earlier).

## Test plan
- [x] `test_v2_freeze` (21, +1 new) passes.
- [x] `test_piece_movement` (333) passes.