### PR TITLE
Clarify repetition state includes boulder cooldown and no-return memory

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -364,7 +364,7 @@ A board state includes:
 
 * piece positions
 
-* boulder markers
+* the boulder's position and status — including its **cooldown** and its **no-return memory** (the last square it occupied). These are part of the state for the same reason invulnerability is: they gate which turns are legal (a boulder on cooldown, or one barred from returning to its last square, has different legal moves than one without those constraints).
 
 * queen markers
 
@@ -372,7 +372,7 @@ A board state includes:
 
 * which pieces (if any) are currently invulnerable
 
-The state hash captures the position and current per-piece statuses only. It deliberately does NOT include the most recent move or any history of preceding turns: repetition is a positional rule, so two positions that look identical and have identical invulnerability status count as the same state for repetition purposes, even if the move histories leading up to them differ.
+The state hash captures the position and current per-piece / boulder statuses only. It deliberately does NOT include the most recent move or any history of preceding turns: repetition is a positional rule, so two positions that look identical and have identical invulnerability and boulder status count as the same state for repetition purposes, even if the move histories leading up to them differ.
 
 If every legal turn would result in a player creating a third repetition, the player loses.
 

--- a/docs/key-rule-differences.md
+++ b/docs/key-rule-differences.md
@@ -181,7 +181,7 @@ A neutral piece, not present in standard chess.
 ### Repetition rule
 
 - A board state cannot occur 3 times during the game.
-- **State hash includes**: piece positions, boulder markers, queen markers (is_royal / is_transformed), whose turn, and currently-invulnerable pieces.
+- **State hash includes**: piece positions, boulder state (position + cooldown + no-return last-square memory), queen markers (is_royal / is_transformed / current form), whose turn, and currently-invulnerable pieces.
 - **State hash does NOT include**: last-move history. Repetition is a purely positional rule.
 - If all legal turns produce a 3rd repetition, the player loses.
 


### PR DESCRIPTION
## Summary
`Board.get_state_hash` already hashes the boulder's `cooldown`, `last_square` (no-return memory), and intersection flag — by the same "it gates which turns are legal" rationale used to include invulnerability. The rulebook prose only said "boulder markers" (position), under-specifying the state. This aligns the prose with the existing implementation.

- **No behavior change** (the code already does this).
- Matters for training determinism (Goal 3) and GDL formalization (Goal 4).
- Cheat sheet updated to match.

## Test plan
- [ ] Docs-only; no code touched.