### PR TITLE
Add human-vs-AI game mode (Goal 2)

### DIFF
--- a/src/ai_controller.py
+++ b/src/ai_controller.py
@@ -1,0 +1,196 @@
+"""
+AIController — drives one side of a `Game` with an AI player, for the
+human-vs-AI game mode.
+
+Design (Option A): the controller reuses `GameEngine` ONLY to *enumerate* the
+legal turns for the side to move, then *applies* the chosen turn through the
+exact same board-mutation path the human UI uses in `main.py`
+(`board.move` / `transform_queen` / `promote` / `execute_jump_capture` /
+`set_invulnerable_after_jump_decline`), and advances the turn with
+`Game.next_turn()`.
+
+`Game.next_turn()` therefore remains the single turn-lifecycle authority
+(undo history, repetition recording, freeze/invulnerability expiry, and the
+no-legal-moves loss check). The engine is NEVER used to advance the turn
+(that would double-advance against `Game.next_turn()`).
+
+The post-move bookkeeping below mirrors the human path in `main.py`
+(set_true_en_passant, clear_forbidden_squares, manipulation freeze,
+update_assassin_squares, decrement_boulder_cooldown, winner check, and the
+tiny-endgame distance-count update) so an AI turn is indistinguishable from a
+human turn as far as game state is concerned.
+"""
+
+from engine import GameEngine
+from players import RandomPlayer
+
+
+class AIController:
+    """Plays one color of a Game with an AI player.
+
+    Usage (in the UI loop):
+        ai = AIController('black')          # AI plays black
+        ...
+        if ai.is_ai_turn(game):
+            ai.take_turn(game)
+    """
+
+    def __init__(self, color, player=None, manipulation_mode='freeze'):
+        if color not in ('white', 'black'):
+            raise ValueError(f"color must be 'white' or 'black', got {color!r}")
+        self.color = color
+        self.player = player if player is not None else RandomPlayer()
+        # A GameEngine used *solely* as a turn-enumerator. It is re-bound to the
+        # live Game board on every call (see legal_turns). It is never asked to
+        # execute/advance a turn.
+        self._engine = GameEngine(manipulation_mode=manipulation_mode)
+
+    # ---- queries ---------------------------------------------------------
+
+    def is_ai_turn(self, game):
+        """True if the game is not over and it's this AI's color to move."""
+        return game.winner is None and game.next_player == self.color
+
+    def legal_turns(self, game):
+        """Enumerate all legal Turn objects for the side to move, by pointing
+        the enumeration engine at the live Game board.
+
+        Note: GameEngine.get_all_legal_turns() performs idempotent per-turn
+        setup (clearing the *opponent's* moved_by_queen freeze, recomputing
+        assassin squares). In 'freeze' mode this never clears the current
+        mover's own frozen pieces, so freeze lifecycles set up via
+        Game.next_turn() are preserved.
+        """
+        eng = self._engine
+        eng.board = game.board
+        eng.current_player = game.next_player
+        eng.turn_number = game.board.turn_number
+        return eng.get_all_legal_turns()
+
+    # ---- driving a turn --------------------------------------------------
+
+    def take_turn(self, game):
+        """If it's this AI's turn, choose and fully apply one legal turn.
+
+        Returns True if a turn was taken, False otherwise (not the AI's turn,
+        game already over, or no legal turn available — the latter having
+        already been flagged as a loss by Game.next_turn()).
+        """
+        if not self.is_ai_turn(game):
+            return False
+        turns = self.legal_turns(game)
+        if not turns:
+            return False
+        turn = self.player.choose_turn(turns)
+        if turn is None:
+            return False
+        self._apply_turn(game, turn)
+        return True
+
+    # ---- apply (mirrors the human UI path in main.py) --------------------
+
+    def _apply_turn(self, game, turn):
+        if turn.turn_type == 'transformation':
+            self._apply_transformation(game, turn)
+        else:  # 'move', 'boulder', 'manipulation' — all spatial via board.move
+            self._apply_spatial(game, turn)
+
+    def _apply_transformation(self, game, turn):
+        board = game.board
+        mover = game.next_player
+        row, col = turn.from_sq
+        board.transform_queen(board.squares[row][col].piece, row, col,
+                              turn.transform_target)
+        board.update_assassin_squares(mover)
+        board.decrement_boulder_cooldown()
+        if board.tiny_endgame_active:
+            board.update_distance_count(captured=False)
+        if not board.tiny_endgame_active and board.is_tiny_endgame():
+            board.init_tiny_endgame()
+        game.next_turn()
+
+    def _apply_spatial(self, game, turn):
+        board = game.board
+        mover = game.next_player
+        to_r, to_c = turn.to_sq
+        # Detect a normal capture BEFORE the move executes (mirrors main.py).
+        captured = board.squares[to_r][to_c].has_piece()
+
+        jump_targets = board.move(turn.piece, turn.move_obj)
+
+        if jump_targets:
+            self._resolve_jump_capture(game, turn, jump_targets)
+            return
+        if turn.promotion_options:
+            self._resolve_promotion(game, turn, captured)
+            return
+
+        # Normal move completion.
+        board.set_true_en_passant(turn.piece)
+        board.clear_forbidden_squares()
+        # Manipulation freeze: if the moved piece is an enemy of the mover, the
+        # mover manipulated it -> hold it in place for its owner's next turn.
+        # (Boulder is neutral, so has_enemy_piece is False -> never frozen.)
+        if board.squares[to_r][to_c].has_enemy_piece(mover):
+            board.squares[to_r][to_c].piece.moved_by_queen = True
+        board.update_assassin_squares(mover)
+        board.decrement_boulder_cooldown(moved_piece=turn.piece)
+        if captured:
+            game.winner = board.check_winner()
+        if board.tiny_endgame_active:
+            board.update_distance_count(captured=captured)
+        if not board.tiny_endgame_active and board.is_tiny_endgame():
+            board.init_tiny_endgame()
+        game.next_turn()
+
+    def _resolve_jump_capture(self, game, turn, jump_targets):
+        board = game.board
+        mover = game.next_player
+        targets = [(t[0], t[1]) for t in jump_targets]
+        choice = self.player.choose_jump_capture(targets)
+        jump_captured = choice is not None and tuple(choice) in targets
+        if jump_captured:
+            board.execute_jump_capture(choice[0], choice[1])
+        else:
+            # Declined: jumped piece survives; v2 knight may gain
+            # invulnerability for one opponent turn (board helper checks the
+            # adjacent-enemy condition). v2 jump_targets always has exactly one
+            # entry (the jumped piece).
+            landing_r, landing_c = turn.to_sq
+            jumped_r, jumped_c = jump_targets[0]
+            board.set_invulnerable_after_jump_decline(
+                turn.piece, landing_r, landing_c, jumped_r, jumped_c)
+        board.clear_forbidden_squares()
+        # If the knight was manipulated (an enemy of the mover), freeze it.
+        if turn.piece.color != mover:
+            turn.piece.moved_by_queen = True
+        board.update_assassin_squares(mover)
+        board.decrement_boulder_cooldown()
+        if jump_captured:
+            game.winner = board.check_winner()
+        if board.tiny_endgame_active:
+            board.update_distance_count(captured=jump_captured)
+        if not board.tiny_endgame_active and board.is_tiny_endgame():
+            board.init_tiny_endgame()
+        game.next_turn()
+
+    def _resolve_promotion(self, game, turn, captured):
+        board = game.board
+        mover = game.next_player
+        to_r, to_c = turn.to_sq
+        was_manipulation = turn.piece.color != mover
+        choice = self.player.choose_promotion(turn.promotion_options)
+        board.promote(turn.piece, to_r, to_c, choice)
+        if was_manipulation:
+            new_piece = board.squares[to_r][to_c].piece
+            if new_piece is not None:
+                new_piece.moved_by_queen = True
+        board.update_assassin_squares(mover)
+        board.decrement_boulder_cooldown()
+        if captured:
+            game.winner = board.check_winner()
+        # A pawn existed pre-move, so tiny endgame couldn't have been active;
+        # it may activate now that the last pawn promoted.
+        if board.is_tiny_endgame():
+            board.init_tiny_endgame()
+        game.next_turn()

--- a/src/main.py
+++ b/src/main.py
@@ -75,11 +75,17 @@ from move import Move
 
 class Main:
 
-    def __init__(self):
+    def __init__(self, ai_color=None):
         pygame.init()
         self.screen = pygame.display.set_mode( (WIDTH, HEIGHT) )
         pygame.display.set_caption('Chess (v2)')
         self.game = Game()
+        # Optional human-vs-AI mode: if ai_color is set, an AIController plays
+        # that color and the human plays the other. None => human-vs-human.
+        self.ai_controller = None
+        if ai_color:
+            from ai_controller import AIController
+            self.ai_controller = AIController(ai_color)
 
     def mainloop(self):
 
@@ -119,6 +125,18 @@ class Main:
 
             if dragger.dragging:
                 dragger.update_blit(screen)
+
+            # Human-vs-AI: when it's the AI side's turn, let the AI take it.
+            # Drain events first (handling QUIT) so the window stays responsive
+            # and closeable during the AI's brief turn.
+            if self.ai_controller and self.ai_controller.is_ai_turn(game):
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        pygame.quit()
+                        raise SystemExit
+                pygame.time.delay(250)  # brief pause so the move is watchable
+                self.ai_controller.take_turn(game)
+                continue  # re-render the resulting position
 
             for event in pygame.event.get():
 
@@ -644,5 +662,12 @@ class Main:
             pygame.display.update()
 
 if __name__ == '__main__':
-    main = Main()
+    import argparse
+    parser = argparse.ArgumentParser(description='Chess variant (v2)')
+    parser.add_argument(
+        '--ai', choices=['white', 'black'], default=None,
+        help="Let an AI play this color (human plays the other). "
+             "Omit for human-vs-human.")
+    args = parser.parse_args()
+    main = Main(ai_color=args.ai)
     main.mainloop()

--- a/tests/test_ai_controller.py
+++ b/tests/test_ai_controller.py
@@ -1,0 +1,132 @@
+"""Tests for AIController — the human-vs-AI integration (Goal 2).
+
+The AIController reuses GameEngine only to ENUMERATE legal turns, then applies
+the chosen turn through the same board path the human UI uses and advances via
+Game.next_turn(). These tests verify, headlessly:
+
+1. is_ai_turn() reflects whose color is to move and whether the game is over.
+2. take_turn() applies exactly one legal turn for the AI's color and advances
+   the game (turn_number increments, the side to move flips), and is a no-op
+   when it isn't the AI's turn.
+3. A full random AI-vs-AI game runs to completion without raising — exercising
+   moves, captures, transformations, manipulations, boulder moves,
+   jump-captures, promotions, the tiny endgame rule, and the repetition rule
+   across a real game. This is the strong integration check that the apply
+   path stays consistent with Game.next_turn() over many turns.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Headless display/audio so Game (which constructs Config -> fonts/sounds) and
+# pygame.display are not required.
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import random
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+    try:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
+    except pygame.error:
+        pass
+
+
+from game import Game
+from ai_controller import AIController
+from players import RandomPlayer
+
+
+def test_is_ai_turn_reflects_color_and_game_over():
+    game = Game()  # white to move at the start
+    white_ai = AIController('white')
+    black_ai = AIController('black')
+    assert white_ai.is_ai_turn(game) is True
+    assert black_ai.is_ai_turn(game) is False
+    # When the game is over, it's nobody's AI turn.
+    game.winner = 'white'
+    assert white_ai.is_ai_turn(game) is False
+    assert black_ai.is_ai_turn(game) is False
+
+
+def test_constructor_rejects_bad_color():
+    with pytest.raises(ValueError):
+        AIController('green')
+
+
+def test_take_turn_applies_one_legal_turn_and_advances():
+    random.seed(1234)
+    game = Game()
+    ai = AIController('white')
+
+    turn_number_before = game.board.turn_number
+    mover_before = game.next_player           # 'white'
+    assert ai.is_ai_turn(game)
+
+    took = ai.take_turn(game)
+
+    assert took is True
+    # Exactly one turn advanced: turn_number incremented and side-to-move flipped.
+    assert game.board.turn_number == turn_number_before + 1
+    assert game.next_player != mover_before   # now 'black'
+    # It's no longer white's AI turn.
+    assert ai.is_ai_turn(game) is False
+
+
+def test_take_turn_is_noop_when_not_ai_turn():
+    game = Game()                 # white to move
+    ai = AIController('black')    # AI plays black, so it's NOT the AI's turn
+    turn_number_before = game.board.turn_number
+    assert ai.is_ai_turn(game) is False
+    took = ai.take_turn(game)
+    assert took is False
+    assert game.board.turn_number == turn_number_before
+    assert game.next_player == 'white'
+
+
+def test_full_random_ai_vs_ai_game_runs_to_completion():
+    """Two AIControllers play a full game. The game must terminate (a winner,
+    or the no-legal-moves loss, or the turn cap) without raising, and real
+    turns must be taken. Exercises every turn type over a real game."""
+    random.seed(2024)
+    game = Game()
+    white_ai = AIController('white')
+    black_ai = AIController('black')
+    controllers = {'white': white_ai, 'black': black_ai}
+
+    cap = 400
+    turns_taken = 0
+    while game.winner is None and turns_taken < cap:
+        controller = controllers[game.next_player]
+        took = controller.take_turn(game)
+        if not took:
+            # No legal turn was available; Game.next_turn() should have set a
+            # winner via the no-legal-moves loss when this turn began.
+            break
+        turns_taken += 1
+
+    # The game advanced through real turns without raising.
+    assert turns_taken > 0
+    assert game.board.turn_number == turns_taken
+    # It either produced a winner or is still legally in progress at the cap
+    # (random play frequently fails to force a decisive result quickly).
+    assert game.winner in (None, 'white', 'black')
+    if game.winner is None:
+        assert turns_taken == cap


### PR DESCRIPTION
## Summary
Adds a **human-vs-AI** game mode. Run `python3 src/main.py --ai black` (or `--ai white`); omit the flag for the unchanged human-vs-human default.

- New `src/ai_controller.py` — `AIController` drives one color with an AI player.
- **Option A design (as confirmed):** reuse `GameEngine` only to *enumerate* legal turns; *apply* the chosen turn via the same board path the human UI uses (`board.move` / `transform_queen` / `promote` / `execute_jump_capture` / `set_invulnerable_after_jump_decline`) and advance with `Game.next_turn()`. `Game.next_turn()` stays the single turn-lifecycle authority; the engine never advances the turn (no double-advance). Post-move bookkeeping mirrors `main.py`'s human path exactly.
- **Baseline AI = `RandomPlayer`** (no model needed). The controller accepts any player with `choose_turn` / `choose_jump_capture` / `choose_promotion`, so a `NeuralPlayer` plugs in once Goal 3 retrains on the finalized rules.
- `main.py`: `Main(ai_color=...)` + a loop hook that takes the AI's turn when it's the AI side to move (draining QUIT first so the window stays closeable) + a `--ai` CLI flag.

## Test plan
- [x] New `tests/test_ai_controller.py` (headless): `is_ai_turn` semantics, single-turn apply+advance, no-op when not AI's turn, bad-color rejection, and a full 400-turn random AI-vs-AI game that runs to completion without raising (exercises every turn type + tiny endgame + repetition).
- [x] Regression: real-pygame suites 122 passed (ai_controller 5 + v2_freeze 21 + v2_knight 96); mocked-pygame `test_piece_movement` 333 passed.
- [x] `main.py` compiles; `Main(ai_color='black')` builds the controller; `Main()` stays human-vs-human.