### PR TITLE
Goal 2: in-UI mode selector (Human vs Human / Random AI)

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -201,6 +201,16 @@ def _overlay_pixel_origin(row, col, position):
 
 class Game:
 
+    # Catalog of in-UI mode-selector options. Extensible — append entries to
+    # plug in future difficulty levels (e.g. {'key':'easy_black','label':...}).
+    # `key` is the stable identifier; `label` is the human-readable string the
+    # menu renders.
+    MODE_OPTIONS = [
+        {'key': 'off',          'label': 'Human vs Human'},
+        {'key': 'random_black', 'label': 'Human (White) vs Random (Black)'},
+        {'key': 'random_white', 'label': 'Random (White) vs Human (Black)'},
+    ]
+
     def __init__(self, knight_mode=Board.KNIGHT_MODE_V2):
         """Construct a Game. `knight_mode` controls which knight rules
         the board uses:
@@ -229,6 +239,16 @@ class Game:
         # Promotion menu state
         self.promotion_menu = None        # dict with 'pawn', 'row', 'col' or None
         self.promotion_menu_rects = []    # list of (rect, option_name) for click detection
+        # Mode-selector menu state (Goal 2): picks the opponent type. The menu
+        # itself is opened via a key in main.py (M); the selection is applied
+        # by `apply_mode_selection(option_key)`.
+        self.mode_menu = None             # dict with 'options' or None
+        self.mode_menu_rects = []         # list of (rect, option_key) for click detection
+        # Current mode / opponent. 'human_vs_human' = no AI; otherwise an
+        # AIController plays `ai_color`.
+        self.mode = 'human_vs_human'
+        self.ai_color = None              # 'white' / 'black' if AI plays that side
+        self.ai_controller = None
         self.winner = None                # 'white', 'black', or None
         # Record initial board state for repetition rule
         self.board.record_state(self.next_player)
@@ -480,6 +500,107 @@ class Game:
                 rect = (sc * SQSIZE, sr * SQSIZE, SQSIZE, SQSIZE)
                 # blit
                 pygame.draw.rect(surface, color, rect)
+
+    # ---- Mode selector (in-UI human-vs-AI menu) ---------------------------
+
+    def open_mode_menu(self):
+        """Open the mode-selection menu. Pure state change — no rendering."""
+        self.mode_menu = {'options': list(self.MODE_OPTIONS)}
+
+    def close_mode_menu(self):
+        """Close the mode-selection menu and drop its click rects."""
+        self.mode_menu = None
+        self.mode_menu_rects = []
+
+    def apply_mode_selection(self, option_key):
+        """Apply the selected mode by `key`. Always closes the menu on success.
+
+        Raises ValueError if `option_key` is not in MODE_OPTIONS. Selecting
+        'off' returns the game to human-vs-human; 'random_black' /
+        'random_white' configures an AIController of the named color with a
+        RandomPlayer. (Future difficulty levels plug in via the same path.)
+        """
+        valid_keys = {opt['key'] for opt in self.MODE_OPTIONS}
+        if option_key not in valid_keys:
+            raise ValueError(f"Unknown mode option: {option_key!r}")
+        if option_key == 'off':
+            self.mode = 'human_vs_human'
+            self.ai_color = None
+            self.ai_controller = None
+        elif option_key == 'random_black':
+            self._set_ai_mode(color='black', difficulty='random')
+        elif option_key == 'random_white':
+            self._set_ai_mode(color='white', difficulty='random')
+        else:  # pragma: no cover — guarded above by valid_keys, future-proofing
+            raise ValueError(f"Unhandled mode option: {option_key!r}")
+        self.close_mode_menu()
+
+    def _set_ai_mode(self, color, difficulty='random'):
+        """Configure the AI side. `difficulty` selects the underlying player
+        implementation. Only 'random' is wired today; future difficulties
+        plug in here without changing the menu/selection contract."""
+        from ai_controller import AIController
+        if difficulty == 'random':
+            player = None  # AIController defaults to RandomPlayer
+        else:
+            raise ValueError(f"Unsupported difficulty: {difficulty!r}")
+        self.mode = f'human_vs_{difficulty}'
+        self.ai_color = color
+        self.ai_controller = AIController(color, player=player)
+
+    def is_any_menu_open(self):
+        """True iff a UI selection menu is currently open. main.py uses this
+        to gate input/interactions while a menu is up."""
+        return (
+            self.transform_menu is not None
+            or self.promotion_menu is not None
+            or self.mode_menu is not None
+        )
+
+    def _current_mode_option_key(self):
+        """Return the MODE_OPTIONS `key` reflecting the current mode/ai_color,
+        for highlighting the active row in the menu."""
+        if self.mode == 'human_vs_human':
+            return 'off'
+        if self.mode == 'human_vs_random':
+            return f'random_{self.ai_color}'
+        return None
+
+    def show_mode_menu(self, surface):
+        """Render the mode-selection menu, if open, and populate
+        `mode_menu_rects` for click detection. No-op when closed."""
+        if self.mode_menu is None:
+            return
+        self.mode_menu_rects = []
+        w, h = surface.get_size()
+        # Dimmed backdrop so the board reads as "paused".
+        backdrop = pygame.Surface((w, h), pygame.SRCALPHA)
+        backdrop.fill((0, 0, 0, 170))
+        surface.blit(backdrop, (0, 0))
+        # Title.
+        title_font = pygame.font.SysFont('arial', 28, bold=True)
+        title = title_font.render('Select opponent  (M to close)', True,
+                                  (255, 255, 255))
+        surface.blit(title, title.get_rect(center=(w // 2, h // 4)))
+        # Options.
+        option_font = pygame.font.SysFont('arial', 22)
+        opts = self.mode_menu['options']
+        opt_h = 50
+        spacing = 12
+        total_h = len(opts) * opt_h + (len(opts) - 1) * spacing
+        top = h // 2 - total_h // 2
+        current_key = self._current_mode_option_key()
+        for i, opt in enumerate(opts):
+            rect = pygame.Rect(0, 0, min(int(w * 0.6), 480), opt_h)
+            rect.center = (w // 2, top + i * (opt_h + spacing) + opt_h // 2)
+            is_current = (opt['key'] == current_key)
+            bg = (80, 140, 200) if is_current else (60, 60, 60)
+            pygame.draw.rect(surface, bg, rect, border_radius=6)
+            pygame.draw.rect(surface, (200, 200, 200), rect, width=2,
+                             border_radius=6)
+            label = option_font.render(opt['label'], True, (255, 255, 255))
+            surface.blit(label, label.get_rect(center=rect.center))
+            self.mode_menu_rects.append((rect, opt['key']))
 
     def show_transform_menu(self, surface):
         """Draw the vertical strip transformation menu."""

--- a/src/main.py
+++ b/src/main.py
@@ -80,12 +80,12 @@ class Main:
         self.screen = pygame.display.set_mode( (WIDTH, HEIGHT) )
         pygame.display.set_caption('Chess (v2)')
         self.game = Game()
-        # Optional human-vs-AI mode: if ai_color is set, an AIController plays
-        # that color and the human plays the other. None => human-vs-human.
-        self.ai_controller = None
+        # The mode (opponent type) and its AIController live on the Game and
+        # are switched in-UI via the mode menu (M key). The optional --ai CLI
+        # flag is a startup shortcut that pre-selects a mode by calling
+        # apply_mode_selection() directly.
         if ai_color:
-            from ai_controller import AIController
-            self.ai_controller = AIController(ai_color)
+            self.game.apply_mode_selection(f'random_{ai_color}')
 
     def mainloop(self):
 
@@ -119,6 +119,7 @@ class Main:
             game.show_hover(screen)
             game.show_transform_menu(screen)
             game.show_promotion_menu(screen)
+            game.show_mode_menu(screen)
             game.show_winner(screen)
             board.update_lines_of_sight()
             board.update_threat_squares()
@@ -128,14 +129,16 @@ class Main:
 
             # Human-vs-AI: when it's the AI side's turn, let the AI take it.
             # Drain events first (handling QUIT) so the window stays responsive
-            # and closeable during the AI's brief turn.
-            if self.ai_controller and self.ai_controller.is_ai_turn(game):
+            # and closeable during the AI's brief turn. The mode menu (if open)
+            # blocks AI play so the user can finish selecting a mode.
+            if (game.ai_controller and game.ai_controller.is_ai_turn(game)
+                    and game.mode_menu is None):
                 for event in pygame.event.get():
                     if event.type == pygame.QUIT:
                         pygame.quit()
                         raise SystemExit
                 pygame.time.delay(250)  # brief pause so the move is watchable
-                self.ai_controller.take_turn(game)
+                game.ai_controller.take_turn(game)
                 continue  # re-render the resulting position
 
             for event in pygame.event.get():
@@ -162,6 +165,22 @@ class Main:
 
                     # Block all interactions when game is over
                     if game.winner:
+                        continue
+
+                    # Handle mode-selector menu clicks (left-click on option).
+                    # Open/close via the M key (see KEYDOWN handler). A click
+                    # outside any option closes the menu without changing mode.
+                    if game.mode_menu and event.button == 1:
+                        mx, my = event.pos
+                        selected = None
+                        for rect, option_key in game.mode_menu_rects:
+                            if rect.collidepoint(mx, my):
+                                selected = option_key
+                                break
+                        if selected is not None:
+                            game.apply_mode_selection(selected)
+                        else:
+                            game.close_mode_menu()
                         continue
 
                     # Handle transform menu clicks (left-click on menu option)
@@ -610,13 +629,27 @@ class Main:
                 # key press
                 elif event.type == pygame.KEYDOWN:
 
-                    # Esc: cancel an in-progress jump-capture second click.
-                    # If no jump-capture state is active, Esc does nothing
-                    # (we don't want it to also close menus or quit).
+                    # Esc: cancel an in-progress jump-capture second click,
+                    # OR close the mode menu if it's open. (If neither is
+                    # active, Esc does nothing — we don't want it to also
+                    # close other menus or quit.)
                     if event.key == pygame.K_ESCAPE:
                         if game.jump_capture_targets is not None:
                             game.cancel_jump_capture()
                             game.play_sound(captured=False)
+                        elif game.mode_menu is not None:
+                            game.close_mode_menu()
+                        continue
+
+                    # M: toggle the mode-selector menu (Goal 2 — pick the
+                    # opponent: Human, Random AI as Black/White, ...). The
+                    # mainloop pauses AI play while the menu is open so the
+                    # user can finish selecting.
+                    if event.key == pygame.K_m:
+                        if game.mode_menu is None:
+                            game.open_mode_menu()
+                        else:
+                            game.close_mode_menu()
                         continue
 
                     # U: undo the most recent completed turn. Disallowed

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -1,0 +1,248 @@
+"""Tests for the in-UI mode selector (Goal 2).
+
+The Game now owns mode state (which "computer opponent" the game is using)
+and an in-UI menu for switching it. This is the testable layer; main.py just
+opens the menu on a key press and dispatches clicks to it.
+
+The mode selector is designed to be extensible: it ships with `off`,
+`random_black`, and `random_white`, and future difficulty levels (Easy /
+Medium / Hard AI) plug in by adding entries to `Game.MODE_OPTIONS` and a
+factory for that player type.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Headless display/audio so Game (Config) and pygame work without a screen.
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import random
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+    try:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
+    except pygame.error:
+        pass
+
+
+from game import Game
+from ai_controller import AIController
+
+
+# --- defaults / initial state -----------------------------------------------
+
+def test_default_mode_is_human_vs_human():
+    g = Game()
+    assert g.mode == 'human_vs_human'
+    assert g.ai_color is None
+    assert g.ai_controller is None
+
+
+def test_mode_menu_starts_closed():
+    g = Game()
+    assert g.mode_menu is None
+    assert g.mode_menu_rects == []
+
+
+def test_mode_options_class_attr_includes_required_keys():
+    """Sanity: the catalog of selectable modes ships with the three baseline
+    entries the UI needs. Future difficulty levels can append to it."""
+    keys = [opt['key'] for opt in Game.MODE_OPTIONS]
+    assert 'off' in keys
+    assert 'random_black' in keys
+    assert 'random_white' in keys
+    # Each option carries a human-readable label for the menu.
+    for opt in Game.MODE_OPTIONS:
+        assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
+
+
+# --- open / close menu ------------------------------------------------------
+
+def test_open_mode_menu_populates_state():
+    g = Game()
+    g.open_mode_menu()
+    assert g.mode_menu is not None
+    assert 'options' in g.mode_menu
+    assert len(g.mode_menu['options']) >= 3
+
+
+def test_close_mode_menu_clears_state():
+    g = Game()
+    g.open_mode_menu()
+    g.close_mode_menu()
+    assert g.mode_menu is None
+    assert g.mode_menu_rects == []
+
+
+def test_open_menu_does_not_advance_or_mutate_game():
+    g = Game()
+    turn_no = g.board.turn_number
+    next_player = g.next_player
+    g.open_mode_menu()
+    g.close_mode_menu()
+    assert g.board.turn_number == turn_no
+    assert g.next_player == next_player
+
+
+# --- applying a selection ---------------------------------------------------
+
+def test_apply_mode_off_sets_human_vs_human():
+    g = Game()
+    g.apply_mode_selection('off')
+    assert g.mode == 'human_vs_human'
+    assert g.ai_color is None
+    assert g.ai_controller is None
+
+
+def test_apply_mode_random_black_creates_ai():
+    g = Game()
+    g.apply_mode_selection('random_black')
+    assert g.mode == 'human_vs_random'
+    assert g.ai_color == 'black'
+    assert isinstance(g.ai_controller, AIController)
+    assert g.ai_controller.color == 'black'
+
+
+def test_apply_mode_random_white_creates_ai():
+    g = Game()
+    g.apply_mode_selection('random_white')
+    assert g.mode == 'human_vs_random'
+    assert g.ai_color == 'white'
+    assert isinstance(g.ai_controller, AIController)
+    assert g.ai_controller.color == 'white'
+
+
+def test_apply_mode_invalid_option_raises():
+    g = Game()
+    with pytest.raises(ValueError):
+        g.apply_mode_selection('definitely_not_a_real_mode')
+
+
+def test_apply_mode_closes_menu():
+    g = Game()
+    g.open_mode_menu()
+    g.apply_mode_selection('random_black')
+    assert g.mode_menu is None
+    assert g.mode_menu_rects == []
+
+
+# --- switching modes --------------------------------------------------------
+
+def test_switching_between_ai_colors_replaces_controller():
+    g = Game()
+    g.apply_mode_selection('random_black')
+    first_controller = g.ai_controller
+    assert first_controller.color == 'black'
+
+    g.apply_mode_selection('random_white')
+    assert g.ai_controller.color == 'white'
+    # A fresh controller (or at least one configured for the new color).
+    assert g.ai_color == 'white'
+
+
+def test_switching_to_off_clears_controller():
+    g = Game()
+    g.apply_mode_selection('random_black')
+    assert g.ai_controller is not None
+    g.apply_mode_selection('off')
+    assert g.mode == 'human_vs_human'
+    assert g.ai_color is None
+    assert g.ai_controller is None
+
+
+# --- integration with AIController -----------------------------------------
+
+def test_take_ai_turn_after_selecting_random_white():
+    """White is AI under 'random_white'; white moves first, so the AI gets
+    the very first turn and should be able to apply it."""
+    random.seed(7)
+    g = Game()
+    g.apply_mode_selection('random_white')
+    assert g.ai_controller.is_ai_turn(g)
+    turn_no = g.board.turn_number
+    took = g.ai_controller.take_turn(g)
+    assert took is True
+    assert g.board.turn_number == turn_no + 1
+    assert g.next_player == 'black'
+    assert g.ai_controller.is_ai_turn(g) is False
+
+
+def test_take_ai_turn_only_on_ais_color():
+    """Under 'random_black' the AI does not act on white's turn."""
+    g = Game()
+    g.apply_mode_selection('random_black')
+    # White to move; AI plays black, so it's NOT the AI's turn.
+    assert g.ai_controller.is_ai_turn(g) is False
+    turn_no = g.board.turn_number
+    took = g.ai_controller.take_turn(g)
+    assert took is False
+    assert g.board.turn_number == turn_no
+
+
+def test_switching_to_ai_mode_mid_game_lets_ai_play():
+    """Start human-vs-human, advance one turn, then switch to 'random_black'.
+    Once it's black's turn, the AI takes over correctly."""
+    random.seed(101)
+    g = Game()
+    # Advance one turn (white) using a throwaway controller, so it's now black's turn.
+    AIController('white').take_turn(g)
+    assert g.next_player == 'black'
+
+    g.apply_mode_selection('random_black')
+    assert g.ai_controller.is_ai_turn(g) is True
+    turn_no = g.board.turn_number
+    g.ai_controller.take_turn(g)
+    assert g.board.turn_number == turn_no + 1
+
+
+# --- rendering smoke tests --------------------------------------------------
+
+def test_show_mode_menu_noop_when_closed():
+    g = Game()
+    surface = pygame.Surface((800, 800))
+    g.show_mode_menu(surface)  # must not raise; menu is closed
+    assert g.mode_menu_rects == []
+
+
+def test_show_mode_menu_populates_rects_when_open():
+    g = Game()
+    g.open_mode_menu()
+    surface = pygame.Surface((800, 800))
+    g.show_mode_menu(surface)
+    # One clickable rect per option in the catalog.
+    assert len(g.mode_menu_rects) == len(g.mode_menu['options'])
+    # Each entry is (rect, option_key).
+    for rect, key in g.mode_menu_rects:
+        assert isinstance(rect, pygame.Rect)
+        assert isinstance(key, str)
+
+
+# --- "any menu open" interaction -------------------------------------------
+
+def test_any_menu_open_includes_mode_menu():
+    """If main.py checks "is any menu open?" to gate other interactions,
+    the mode menu must be included alongside transform/promotion menus."""
+    g = Game()
+    assert g.is_any_menu_open() is False
+    g.open_mode_menu()
+    assert g.is_any_menu_open() is True
+    g.close_mode_menu()
+    assert g.is_any_menu_open() is False


### PR DESCRIPTION
## Summary
The actual Goal 2 deliverable — an **in-UI mode selector**, not just a CLI flag. Press **M** to open the menu, click a row to apply, **Esc** or **M** to close.

- New `Game.MODE_OPTIONS` catalog is extensible: append entries (e.g. `{'key':'easy_black','label':...}`) when Easy/Medium/Hard AI players exist. `_set_ai_mode(color, difficulty)` is the single extension point.
- Game owns the mode state (`mode`, `ai_color`, `ai_controller`, `mode_menu`, `mode_menu_rects`); `main.py` is a thin driver (open/close on `M`, dispatch clicks).
- The `--ai` CLI flag is kept as a startup shortcut and now calls `game.apply_mode_selection(...)`.
- The mainloop AI hook reads `game.ai_controller` and **pauses while the mode menu is open** so the user can finish selecting.

## Tests (tests-first)
19 headless tests in `tests/test_mode_selection.py`: default state, open/close, all three apply paths, invalid-key raises, menu auto-close on apply, switching between AI colors, switching to Off, taking an AI turn after selection, AI-only-on-its-color, mid-game switching, render smoke (closed = noop, open = populates rects), and the new `is_any_menu_open()` helper.

## Regression
- Real-pygame: 141 pass (mode_selection 19 + ai_controller 5 + v2_freeze 21 + v2_knight 96).
- Mocked-pygame: `test_piece_movement` 333 pass.
- `Main()` (default) and `Main(ai_color='black'/'white')` headless smoke OK.