### PR TITLE
Fix human-vs-AI: human's moved piece flashes invisible before AI moves

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -128,16 +128,37 @@ class Main:
                 dragger.update_blit(screen)
 
             # Human-vs-AI: when it's the AI side's turn, let the AI take it.
-            # Drain events first (handling QUIT) so the window stays responsive
-            # and closeable during the AI's brief turn. The mode menu (if open)
-            # blocks AI play so the user can finish selecting a mode.
+            # The mode menu (if open) blocks AI play so the user can finish
+            # selecting a mode.
             if (game.ai_controller and game.ai_controller.is_ai_turn(game)
                     and game.mode_menu is None):
-                for event in pygame.event.get():
-                    if event.type == pygame.QUIT:
-                        pygame.quit()
-                        raise SystemExit
-                pygame.time.delay(250)  # brief pause so the move is watchable
+                # CRUCIAL: push the (already-redrawn) post-human-move backbuffer
+                # to the screen BEFORE pausing.
+                #
+                # `show_pieces` (game.py) deliberately skips the dragger's piece
+                # so it isn't drawn twice during a drag. In the mouse-release
+                # handler, the post-move render is called BEFORE
+                # `dragger.undrag_piece()`, so iteration N's display.update
+                # shows the moved piece "missing" — the next iteration's normal
+                # render restores it. In human-vs-human that next render's
+                # display.update happens ~one frame later and the missing frame
+                # is imperceptible. But our AI hook ends with `continue`, which
+                # skips this iteration's display.update — without the explicit
+                # update below, the "missing piece" frame stays on screen for
+                # the entire pre-AI pause. Pushing the corrected render here
+                # eliminates that artefact.
+                pygame.display.update()
+                # Responsive wait: drain events during the pause so the OS
+                # doesn't mark the window unresponsive and QUIT is honoured.
+                # ~600 ms is long enough for the human to register their own
+                # move clearly before the AI responds.
+                start = pygame.time.get_ticks()
+                while pygame.time.get_ticks() - start < 600:
+                    for event in pygame.event.get():
+                        if event.type == pygame.QUIT:
+                            pygame.quit()
+                            raise SystemExit
+                    pygame.time.delay(15)
                 game.ai_controller.take_turn(game)
                 continue  # re-render the resulting position
 


### PR DESCRIPTION
## Bug
After releasing a move in human-vs-AI mode, the human's piece appeared to "disappear momentarily" until the computer's move completed.

## Root cause
`show_pieces` (`game.py:411`) deliberately skips `dragger.piece` to avoid double-drawing it during a drag. In `main.py`'s mouse-release handler, the post-move render runs **before** `dragger.undrag_piece()`, so iteration N's `display.update` shows the moved piece "missing." The next iteration's normal render restores it.

- In human-vs-human, that restoration happens ~one frame later — imperceptible (~16 ms).
- In human-vs-AI, the AI hook's `continue` skipped its own iteration's `display.update`, so the "missing piece" frame stayed on screen for the entire 250 ms pre-AI pause — clearly visible.

## Fix
- Push the (already-redrawn) post-human backbuffer to the screen at the start of the AI hook, **before** the pause — eliminates the artefact.
- Replace `pygame.time.delay` with a responsive wait loop that drains events (honours QUIT mid-pause, prevents the OS marking the window non-responsive).
- Bump the pre-AI pause from 250 ms to 600 ms so the human has time to clearly see their own move before the AI responds.

## Tests
- Real-pygame regression: 141 pass.
- Mocked-pygame: 333 pass.
- The fix is timing/rendering only; manual play to confirm visually.