### PR TITLE
Menu: side + opponent independent; undo/redo skip AI turns

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -201,14 +201,19 @@ def _overlay_pixel_origin(row, col, position):
 
 class Game:
 
-    # Catalog of in-UI mode-selector options. Extensible — append entries to
-    # plug in future difficulty levels (e.g. {'key':'easy_black','label':...}).
-    # `key` is the stable identifier; `label` is the human-readable string the
-    # menu renders.
-    MODE_OPTIONS = [
-        {'key': 'off',          'label': 'Human vs Human'},
-        {'key': 'random_black', 'label': 'Human (White) vs Random (Black)'},
-        {'key': 'random_white', 'label': 'Random (White) vs Human (Black)'},
+    # Mode selector — two INDEPENDENT dimensions, rendered as two button
+    # rows in the in-UI menu. SIDE_OPTIONS is which colour the human plays;
+    # OPPONENT_OPTIONS is what plays the other colour. Selecting one updates
+    # only that dimension, leaving the other in place. Extensible: append
+    # entries to OPPONENT_OPTIONS to plug in future difficulty levels
+    # (Easy / Medium / Hard AI) and add a matching branch in `_make_ai_player`.
+    SIDE_OPTIONS = [
+        {'key': 'white', 'label': 'White'},
+        {'key': 'black', 'label': 'Black'},
+    ]
+    OPPONENT_OPTIONS = [
+        {'key': 'human',  'label': 'Human (2 players)'},
+        {'key': 'random', 'label': 'Random'},
     ]
 
     def __init__(self, knight_mode=Board.KNIGHT_MODE_V2):
@@ -239,15 +244,18 @@ class Game:
         # Promotion menu state
         self.promotion_menu = None        # dict with 'pawn', 'row', 'col' or None
         self.promotion_menu_rects = []    # list of (rect, option_name) for click detection
-        # Mode-selector menu state (Goal 2): picks the opponent type. The menu
-        # itself is opened via a key in main.py (M); the selection is applied
-        # by `apply_mode_selection(option_key)`.
-        self.mode_menu = None             # dict with 'options' or None
-        self.mode_menu_rects = []         # list of (rect, option_key) for click detection
-        # Current mode / opponent. 'human_vs_human' = no AI; otherwise an
-        # AIController plays `ai_color`.
-        self.mode = 'human_vs_human'
-        self.ai_color = None              # 'white' / 'black' if AI plays that side
+        # Mode-selector menu state (Goal 2). Opened via M in main.py. The
+        # menu lets the user pick their side AND their opponent independently;
+        # each click applies that one dimension and leaves the menu open
+        # (live-settings model) so the user can also change the other.
+        self.mode_menu = None             # dict with 'sides' + 'opponents', or None
+        self.mode_menu_rects = []         # [(rect, 'side'|'opponent', key), ...]
+        # User choices — the two dimensions the menu exposes.
+        self.user_side = 'white'          # the colour the human plays
+        self.opponent = 'human'           # 'human' or an AI key (e.g. 'random')
+        # Derived from (user_side, opponent); kept in sync by `_refresh_ai`.
+        self.mode = 'human_vs_human'      # string for display/logging
+        self.ai_color = None              # opposite of user_side when AI is active
         self.ai_controller = None
         self.winner = None                # 'white', 'black', or None
         # Record initial board state for repetition rule
@@ -505,48 +513,60 @@ class Game:
 
     def open_mode_menu(self):
         """Open the mode-selection menu. Pure state change — no rendering."""
-        self.mode_menu = {'options': list(self.MODE_OPTIONS)}
+        self.mode_menu = {
+            'sides': list(self.SIDE_OPTIONS),
+            'opponents': list(self.OPPONENT_OPTIONS),
+        }
 
     def close_mode_menu(self):
         """Close the mode-selection menu and drop its click rects."""
         self.mode_menu = None
         self.mode_menu_rects = []
 
-    def apply_mode_selection(self, option_key):
-        """Apply the selected mode by `key`. Always closes the menu on success.
+    def apply_mode_selection(self, side=None, opponent=None):
+        """Apply a mode-menu selection. Each argument is optional — pass only
+        `side` to switch the human's colour, only `opponent` to switch the
+        computer opponent, or both. Raises ValueError on unknown keys. Does
+        NOT auto-close the menu (live-settings model — the user closes via
+        M / Esc / `close_mode_menu()`)."""
+        if side is not None:
+            valid = {opt['key'] for opt in self.SIDE_OPTIONS}
+            if side not in valid:
+                raise ValueError(
+                    f"Unknown side: {side!r}; valid: {sorted(valid)}")
+            self.user_side = side
+        if opponent is not None:
+            valid = {opt['key'] for opt in self.OPPONENT_OPTIONS}
+            if opponent not in valid:
+                raise ValueError(
+                    f"Unknown opponent: {opponent!r}; valid: {sorted(valid)}")
+            self.opponent = opponent
+        self._refresh_ai()
 
-        Raises ValueError if `option_key` is not in MODE_OPTIONS. Selecting
-        'off' returns the game to human-vs-human; 'random_black' /
-        'random_white' configures an AIController of the named color with a
-        RandomPlayer. (Future difficulty levels plug in via the same path.)
-        """
-        valid_keys = {opt['key'] for opt in self.MODE_OPTIONS}
-        if option_key not in valid_keys:
-            raise ValueError(f"Unknown mode option: {option_key!r}")
-        if option_key == 'off':
+    def _refresh_ai(self):
+        """Recompute `mode`, `ai_color`, `ai_controller` from the current
+        (user_side, opponent) selection. Called after every state change so
+        the derived AI state stays in sync."""
+        if self.opponent == 'human':
             self.mode = 'human_vs_human'
             self.ai_color = None
             self.ai_controller = None
-        elif option_key == 'random_black':
-            self._set_ai_mode(color='black', difficulty='random')
-        elif option_key == 'random_white':
-            self._set_ai_mode(color='white', difficulty='random')
-        else:  # pragma: no cover — guarded above by valid_keys, future-proofing
-            raise ValueError(f"Unhandled mode option: {option_key!r}")
-        self.close_mode_menu()
-
-    def _set_ai_mode(self, color, difficulty='random'):
-        """Configure the AI side. `difficulty` selects the underlying player
-        implementation. Only 'random' is wired today; future difficulties
-        plug in here without changing the menu/selection contract."""
+            return
         from ai_controller import AIController
-        if difficulty == 'random':
-            player = None  # AIController defaults to RandomPlayer
-        else:
-            raise ValueError(f"Unsupported difficulty: {difficulty!r}")
-        self.mode = f'human_vs_{difficulty}'
-        self.ai_color = color
-        self.ai_controller = AIController(color, player=player)
+        self.mode = f'human_vs_{self.opponent}'
+        self.ai_color = 'black' if self.user_side == 'white' else 'white'
+        self.ai_controller = AIController(
+            self.ai_color, player=self._make_ai_player(self.opponent))
+
+    def _make_ai_player(self, opponent_key):
+        """Construct the AI player for a given opponent key. Extension point:
+        add branches here for future difficulty levels (Easy / Medium / Hard
+        AI). Returning None lets AIController default to its RandomPlayer
+        baseline."""
+        if opponent_key == 'random':
+            return None  # AIController defaults to RandomPlayer
+        raise ValueError(
+            f"No player implementation for opponent {opponent_key!r}")
 
     def is_any_menu_open(self):
         """True iff a UI selection menu is currently open. main.py uses this
@@ -557,50 +577,61 @@ class Game:
             or self.mode_menu is not None
         )
 
-    def _current_mode_option_key(self):
-        """Return the MODE_OPTIONS `key` reflecting the current mode/ai_color,
-        for highlighting the active row in the menu."""
-        if self.mode == 'human_vs_human':
-            return 'off'
-        if self.mode == 'human_vs_random':
-            return f'random_{self.ai_color}'
-        return None
-
     def show_mode_menu(self, surface):
         """Render the mode-selection menu, if open, and populate
-        `mode_menu_rects` for click detection. No-op when closed."""
+        `mode_menu_rects` for click detection. No-op when closed.
+
+        Renders two button rows: 'Your side' and 'Opponent'. The currently-
+        selected button in each row is highlighted. Each entry pushed onto
+        `mode_menu_rects` is a (pygame.Rect, group_key, option_key) tuple
+        where group_key is 'side' or 'opponent'."""
         if self.mode_menu is None:
             return
         self.mode_menu_rects = []
         w, h = surface.get_size()
-        # Dimmed backdrop so the board reads as "paused".
         backdrop = pygame.Surface((w, h), pygame.SRCALPHA)
         backdrop.fill((0, 0, 0, 170))
         surface.blit(backdrop, (0, 0))
-        # Title.
-        title_font = pygame.font.SysFont('arial', 28, bold=True)
-        title = title_font.render('Select opponent  (M to close)', True,
-                                  (255, 255, 255))
-        surface.blit(title, title.get_rect(center=(w // 2, h // 4)))
-        # Options.
-        option_font = pygame.font.SysFont('arial', 22)
-        opts = self.mode_menu['options']
-        opt_h = 50
-        spacing = 12
-        total_h = len(opts) * opt_h + (len(opts) - 1) * spacing
-        top = h // 2 - total_h // 2
-        current_key = self._current_mode_option_key()
-        for i, opt in enumerate(opts):
-            rect = pygame.Rect(0, 0, min(int(w * 0.6), 480), opt_h)
-            rect.center = (w // 2, top + i * (opt_h + spacing) + opt_h // 2)
-            is_current = (opt['key'] == current_key)
-            bg = (80, 140, 200) if is_current else (60, 60, 60)
-            pygame.draw.rect(surface, bg, rect, border_radius=6)
-            pygame.draw.rect(surface, (200, 200, 200), rect, width=2,
-                             border_radius=6)
-            label = option_font.render(opt['label'], True, (255, 255, 255))
-            surface.blit(label, label.get_rect(center=rect.center))
-            self.mode_menu_rects.append((rect, opt['key']))
+        title_font = pygame.font.SysFont('arial', 26, bold=True)
+        section_font = pygame.font.SysFont('arial', 20, bold=True)
+        option_font = pygame.font.SysFont('arial', 20)
+        title = title_font.render(
+            'Select side and opponent  (M / Esc to close)', True,
+            (255, 255, 255))
+        surface.blit(title, title.get_rect(center=(w // 2, h // 6)))
+
+        def render_section(label, opts, group_key, current_key, section_top):
+            section_label = section_font.render(label, True, (220, 220, 220))
+            surface.blit(section_label, section_label.get_rect(
+                center=(w // 2, section_top)))
+            btn_h = 44
+            btn_w = min(180, int(w * 0.22))
+            gap = 16
+            row_y = section_top + 38
+            n = len(opts)
+            row_w = n * btn_w + (n - 1) * gap
+            row_left = (w - row_w) // 2
+            for i, opt in enumerate(opts):
+                rect = pygame.Rect(
+                    row_left + i * (btn_w + gap), row_y, btn_w, btn_h)
+                active = (opt['key'] == current_key)
+                pygame.draw.rect(
+                    surface, (80, 140, 200) if active else (60, 60, 60),
+                    rect, border_radius=6)
+                pygame.draw.rect(
+                    surface, (200, 200, 200), rect, width=2, border_radius=6)
+                label_surf = option_font.render(
+                    opt['label'], True, (255, 255, 255))
+                surface.blit(label_surf, label_surf.get_rect(center=rect.center))
+                self.mode_menu_rects.append((rect, group_key, opt['key']))
+            return row_y + btn_h
+
+        bottom = render_section(
+            'Your side', self.mode_menu['sides'], 'side',
+            self.user_side, h // 3)
+        render_section(
+            'Opponent', self.mode_menu['opponents'], 'opponent',
+            self.opponent, bottom + 40)
 
     def show_transform_menu(self, surface):
         """Draw the vertical strip transformation menu."""
@@ -774,6 +805,7 @@ class Game:
         - knight leap awaiting capture/decline (`jump_capture_targets`),
         - open transformation menu (`transform_menu`),
         - open promotion menu (`promotion_menu`),
+        - open mode-selector menu (`mode_menu`),
         - active drag (`dragger.dragging`) — the dragger holds a piece
           reference; restoring would orphan it (the piece would no longer
           exist on the post-restore board's squares array, but the
@@ -783,6 +815,7 @@ class Game:
             self.jump_capture_targets is not None
             or self.transform_menu is not None
             or self.promotion_menu is not None
+            or self.mode_menu is not None
             or (self.dragger is not None and self.dragger.dragging)
         )
 
@@ -796,24 +829,54 @@ class Game:
         return len(self._redo_stack) > 0 and not self._in_intermediate_state()
 
     def undo(self):
-        """Roll back to the state at the start of the current turn (i.e.,
-        the result of the previous turn). Pushes the current state onto
-        the redo stack. Returns True on success, False if there's nothing
-        to undo or we're in an intermediate state."""
+        """Roll back to the previous USER turn.
+
+        Standard behavior (human-vs-human): pops one snapshot off the history
+        so the game returns to the state at the start of the current turn.
+
+        Human-vs-AI extension: when an AI is active (`ai_controller is not
+        None`), continue popping while `next_player` is the AI's color, so
+        undo always lands on the user's PREVIOUS turn (rolling back both the
+        AI's most recent move and the user's own most recent move in one
+        keypress). Stops if no further snapshots are available — in that
+        case the game returns to the earliest reachable state (which may be
+        the initial position even when it's the AI's turn there, e.g. when
+        the user plays black and the AI moves first).
+        """
         if not self.can_undo():
             return False
         self._redo_stack.append(self._history.pop())
         self._restore(self._history[-1])
+        # Skip over the AI's turn so undo lands on the user's previous turn.
+        # Guard with `len(...)>1` (not `can_undo()`) — we already passed the
+        # intermediate-state check; we just need at least one earlier state.
+        if self.ai_controller is not None:
+            while (self.next_player != self.user_side
+                   and len(self._history) > 1):
+                self._redo_stack.append(self._history.pop())
+                self._restore(self._history[-1])
         return True
 
     def redo(self):
-        """Re-apply a turn that was just undone. Returns True on success,
-        False if the redo stack is empty or we're in an intermediate state."""
+        """Re-apply a previously-undone turn, advancing to the next USER turn.
+
+        Standard behavior: pops one state off the redo stack.
+
+        Human-vs-AI extension: keeps redoing while `next_player` is the AI's
+        color, so redo symmetrically lands on the user's NEXT turn (re-
+        applying both the user's move and the AI's response in one keypress).
+        """
         if not self.can_redo():
             return False
         state = self._redo_stack.pop()
         self._history.append(state)
         self._restore(state)
+        if self.ai_controller is not None:
+            while (self.next_player != self.user_side
+                   and len(self._redo_stack) > 0):
+                state = self._redo_stack.pop()
+                self._history.append(state)
+                self._restore(state)
         return True
 
     def cancel_jump_capture(self):

--- a/src/main.py
+++ b/src/main.py
@@ -85,7 +85,11 @@ class Main:
         # flag is a startup shortcut that pre-selects a mode by calling
         # apply_mode_selection() directly.
         if ai_color:
-            self.game.apply_mode_selection(f'random_{ai_color}')
+            # --ai BLACK means the AI plays black → the human plays white.
+            self.game.apply_mode_selection(
+                side='white' if ai_color == 'black' else 'black',
+                opponent='random',
+            )
 
     def mainloop(self):
 
@@ -189,19 +193,20 @@ class Main:
                         continue
 
                     # Handle mode-selector menu clicks (left-click on option).
-                    # Open/close via the M key (see KEYDOWN handler). A click
-                    # outside any option closes the menu without changing mode.
+                    # Each menu_rects entry is (rect, group_key, option_key)
+                    # where group_key is 'side' or 'opponent'. Clicking a
+                    # button updates only that dimension and leaves the menu
+                    # open (live-settings model) so the user can also change
+                    # the other dimension. Close via M / Esc (KEYDOWN handler).
                     if game.mode_menu and event.button == 1:
                         mx, my = event.pos
-                        selected = None
-                        for rect, option_key in game.mode_menu_rects:
+                        for rect, group_key, option_key in game.mode_menu_rects:
                             if rect.collidepoint(mx, my):
-                                selected = option_key
+                                if group_key == 'side':
+                                    game.apply_mode_selection(side=option_key)
+                                elif group_key == 'opponent':
+                                    game.apply_mode_selection(opponent=option_key)
                                 break
-                        if selected is not None:
-                            game.apply_mode_selection(selected)
-                        else:
-                            game.close_mode_menu()
                         continue
 
                     # Handle transform menu clicks (left-click on menu option)

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -1,20 +1,25 @@
-"""Tests for the in-UI mode selector (Goal 2).
+"""Tests for the in-UI mode selector AND AI-aware undo/redo.
 
-The Game now owns mode state (which "computer opponent" the game is using)
-and an in-UI menu for switching it. This is the testable layer; main.py just
-opens the menu on a key press and dispatches clicks to it.
+The Game owns:
 
-The mode selector is designed to be extensible: it ships with `off`,
-`random_black`, and `random_white`, and future difficulty levels (Easy /
-Medium / Hard AI) plug in by adding entries to `Game.MODE_OPTIONS` and a
-factory for that player type.
+  - `user_side` ('white' or 'black') — which side the human plays.
+  - `opponent`  ('human' or an AI key like 'random') — who plays the OTHER side.
+
+These two choices are INDEPENDENT in the in-UI menu (you don't have to pick
+between "Human (W) vs Random (B)" and "Random (W) vs Human (B)" — you pick a
+side AND an opponent). `mode`, `ai_color`, and `ai_controller` are derived
+from those two and are kept in sync automatically.
+
+Undo/redo respect the AI: in human-vs-AI mode the user expects the undo key
+to take them back to their PREVIOUS turn (rolling back both the AI's last
+move and the user's last move), not just the AI's last move. Redo
+symmetrically advances to the next user turn.
 """
 
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
-# Headless display/audio so Game (Config) and pygame work without a screen.
 os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
 os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
 
@@ -47,202 +52,334 @@ from game import Game
 from ai_controller import AIController
 
 
-# --- defaults / initial state -----------------------------------------------
+# --- defaults / catalog -----------------------------------------------------
 
-def test_default_mode_is_human_vs_human():
+def test_default_state():
     g = Game()
+    assert g.user_side == 'white'   # default = human plays white
+    assert g.opponent == 'human'
     assert g.mode == 'human_vs_human'
     assert g.ai_color is None
     assert g.ai_controller is None
-
-
-def test_mode_menu_starts_closed():
-    g = Game()
     assert g.mode_menu is None
     assert g.mode_menu_rects == []
 
 
-def test_mode_options_class_attr_includes_required_keys():
-    """Sanity: the catalog of selectable modes ships with the three baseline
-    entries the UI needs. Future difficulty levels can append to it."""
-    keys = [opt['key'] for opt in Game.MODE_OPTIONS]
-    assert 'off' in keys
-    assert 'random_black' in keys
-    assert 'random_white' in keys
-    # Each option carries a human-readable label for the menu.
-    for opt in Game.MODE_OPTIONS:
+def test_side_options_catalog():
+    keys = [opt['key'] for opt in Game.SIDE_OPTIONS]
+    assert keys == ['white', 'black']
+    for opt in Game.SIDE_OPTIONS:
+        assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
+
+
+def test_opponent_options_catalog_has_human_and_random():
+    keys = [opt['key'] for opt in Game.OPPONENT_OPTIONS]
+    assert 'human' in keys
+    assert 'random' in keys
+    for opt in Game.OPPONENT_OPTIONS:
         assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
 
 
 # --- open / close menu ------------------------------------------------------
 
-def test_open_mode_menu_populates_state():
+def test_open_close_mode_menu():
     g = Game()
     g.open_mode_menu()
     assert g.mode_menu is not None
-    assert 'options' in g.mode_menu
-    assert len(g.mode_menu['options']) >= 3
-
-
-def test_close_mode_menu_clears_state():
-    g = Game()
-    g.open_mode_menu()
+    assert 'sides' in g.mode_menu and 'opponents' in g.mode_menu
     g.close_mode_menu()
     assert g.mode_menu is None
     assert g.mode_menu_rects == []
 
 
-def test_open_menu_does_not_advance_or_mutate_game():
+def test_open_menu_does_not_advance_game():
     g = Game()
     turn_no = g.board.turn_number
-    next_player = g.next_player
     g.open_mode_menu()
     g.close_mode_menu()
     assert g.board.turn_number == turn_no
-    assert g.next_player == next_player
 
 
-# --- applying a selection ---------------------------------------------------
-
-def test_apply_mode_off_sets_human_vs_human():
-    g = Game()
-    g.apply_mode_selection('off')
-    assert g.mode == 'human_vs_human'
-    assert g.ai_color is None
-    assert g.ai_controller is None
-
-
-def test_apply_mode_random_black_creates_ai():
-    g = Game()
-    g.apply_mode_selection('random_black')
-    assert g.mode == 'human_vs_random'
-    assert g.ai_color == 'black'
-    assert isinstance(g.ai_controller, AIController)
-    assert g.ai_controller.color == 'black'
-
-
-def test_apply_mode_random_white_creates_ai():
-    g = Game()
-    g.apply_mode_selection('random_white')
-    assert g.mode == 'human_vs_random'
-    assert g.ai_color == 'white'
-    assert isinstance(g.ai_controller, AIController)
-    assert g.ai_controller.color == 'white'
-
-
-def test_apply_mode_invalid_option_raises():
-    g = Game()
-    with pytest.raises(ValueError):
-        g.apply_mode_selection('definitely_not_a_real_mode')
-
-
-def test_apply_mode_closes_menu():
-    g = Game()
-    g.open_mode_menu()
-    g.apply_mode_selection('random_black')
-    assert g.mode_menu is None
-    assert g.mode_menu_rects == []
-
-
-# --- switching modes --------------------------------------------------------
-
-def test_switching_between_ai_colors_replaces_controller():
-    g = Game()
-    g.apply_mode_selection('random_black')
-    first_controller = g.ai_controller
-    assert first_controller.color == 'black'
-
-    g.apply_mode_selection('random_white')
-    assert g.ai_controller.color == 'white'
-    # A fresh controller (or at least one configured for the new color).
-    assert g.ai_color == 'white'
-
-
-def test_switching_to_off_clears_controller():
-    g = Game()
-    g.apply_mode_selection('random_black')
-    assert g.ai_controller is not None
-    g.apply_mode_selection('off')
-    assert g.mode == 'human_vs_human'
-    assert g.ai_color is None
-    assert g.ai_controller is None
-
-
-# --- integration with AIController -----------------------------------------
-
-def test_take_ai_turn_after_selecting_random_white():
-    """White is AI under 'random_white'; white moves first, so the AI gets
-    the very first turn and should be able to apply it."""
-    random.seed(7)
-    g = Game()
-    g.apply_mode_selection('random_white')
-    assert g.ai_controller.is_ai_turn(g)
-    turn_no = g.board.turn_number
-    took = g.ai_controller.take_turn(g)
-    assert took is True
-    assert g.board.turn_number == turn_no + 1
-    assert g.next_player == 'black'
-    assert g.ai_controller.is_ai_turn(g) is False
-
-
-def test_take_ai_turn_only_on_ais_color():
-    """Under 'random_black' the AI does not act on white's turn."""
-    g = Game()
-    g.apply_mode_selection('random_black')
-    # White to move; AI plays black, so it's NOT the AI's turn.
-    assert g.ai_controller.is_ai_turn(g) is False
-    turn_no = g.board.turn_number
-    took = g.ai_controller.take_turn(g)
-    assert took is False
-    assert g.board.turn_number == turn_no
-
-
-def test_switching_to_ai_mode_mid_game_lets_ai_play():
-    """Start human-vs-human, advance one turn, then switch to 'random_black'.
-    Once it's black's turn, the AI takes over correctly."""
-    random.seed(101)
-    g = Game()
-    # Advance one turn (white) using a throwaway controller, so it's now black's turn.
-    AIController('white').take_turn(g)
-    assert g.next_player == 'black'
-
-    g.apply_mode_selection('random_black')
-    assert g.ai_controller.is_ai_turn(g) is True
-    turn_no = g.board.turn_number
-    g.ai_controller.take_turn(g)
-    assert g.board.turn_number == turn_no + 1
-
-
-# --- rendering smoke tests --------------------------------------------------
-
-def test_show_mode_menu_noop_when_closed():
-    g = Game()
-    surface = pygame.Surface((800, 800))
-    g.show_mode_menu(surface)  # must not raise; menu is closed
-    assert g.mode_menu_rects == []
-
-
-def test_show_mode_menu_populates_rects_when_open():
-    g = Game()
-    g.open_mode_menu()
-    surface = pygame.Surface((800, 800))
-    g.show_mode_menu(surface)
-    # One clickable rect per option in the catalog.
-    assert len(g.mode_menu_rects) == len(g.mode_menu['options'])
-    # Each entry is (rect, option_key).
-    for rect, key in g.mode_menu_rects:
-        assert isinstance(rect, pygame.Rect)
-        assert isinstance(key, str)
-
-
-# --- "any menu open" interaction -------------------------------------------
-
-def test_any_menu_open_includes_mode_menu():
-    """If main.py checks "is any menu open?" to gate other interactions,
-    the mode menu must be included alongside transform/promotion menus."""
+def test_is_any_menu_open_includes_mode_menu():
     g = Game()
     assert g.is_any_menu_open() is False
     g.open_mode_menu()
     assert g.is_any_menu_open() is True
     g.close_mode_menu()
     assert g.is_any_menu_open() is False
+
+
+# --- apply_mode_selection: side / opponent independently --------------------
+
+def test_apply_side_only_updates_user_side():
+    g = Game()
+    g.apply_mode_selection(side='black')
+    assert g.user_side == 'black'
+    assert g.opponent == 'human'         # unchanged
+    assert g.ai_controller is None       # still no AI
+
+
+def test_apply_opponent_human_keeps_human_vs_human():
+    g = Game()
+    g.apply_mode_selection(opponent='human')
+    assert g.opponent == 'human'
+    assert g.mode == 'human_vs_human'
+    assert g.ai_color is None
+    assert g.ai_controller is None
+
+
+def test_apply_opponent_random_with_default_side_makes_ai_black():
+    g = Game()  # user_side defaults to 'white'
+    g.apply_mode_selection(opponent='random')
+    assert g.opponent == 'random'
+    assert g.mode == 'human_vs_random'
+    assert g.ai_color == 'black'
+    assert isinstance(g.ai_controller, AIController)
+    assert g.ai_controller.color == 'black'
+
+
+def test_apply_opponent_random_with_user_side_black_makes_ai_white():
+    g = Game()
+    g.apply_mode_selection(side='black')
+    g.apply_mode_selection(opponent='random')
+    assert g.ai_color == 'white'
+    assert g.ai_controller.color == 'white'
+
+
+def test_switching_user_side_with_active_ai_updates_ai_color():
+    g = Game()
+    g.apply_mode_selection(opponent='random')   # AI = black
+    assert g.ai_color == 'black'
+    g.apply_mode_selection(side='black')        # now user = black; AI must flip
+    assert g.user_side == 'black'
+    assert g.ai_color == 'white'
+    assert g.ai_controller.color == 'white'
+
+
+def test_switching_opponent_to_human_clears_ai_controller():
+    g = Game()
+    g.apply_mode_selection(opponent='random')
+    assert g.ai_controller is not None
+    g.apply_mode_selection(opponent='human')
+    assert g.opponent == 'human'
+    assert g.ai_color is None
+    assert g.ai_controller is None
+
+
+def test_apply_mode_with_both_side_and_opponent():
+    g = Game()
+    g.apply_mode_selection(side='black', opponent='random')
+    assert g.user_side == 'black'
+    assert g.opponent == 'random'
+    assert g.ai_color == 'white'
+    assert isinstance(g.ai_controller, AIController)
+
+
+def test_apply_mode_with_no_args_is_a_noop():
+    g = Game()
+    g.apply_mode_selection()  # nothing changes
+    assert g.user_side == 'white'
+    assert g.opponent == 'human'
+    assert g.ai_controller is None
+
+
+def test_apply_invalid_side_raises():
+    g = Game()
+    with pytest.raises(ValueError):
+        g.apply_mode_selection(side='green')
+
+
+def test_apply_invalid_opponent_raises():
+    g = Game()
+    with pytest.raises(ValueError):
+        g.apply_mode_selection(opponent='galaxy_brain_ai')
+
+
+# --- menu rendering / click rects -------------------------------------------
+
+def test_apply_mode_selection_does_not_auto_close_menu():
+    """Live-settings model: clicking a button updates the mode but leaves the
+    menu open so the user can also change the other dimension. Menu closes
+    only on M / Esc / close_mode_menu()."""
+    g = Game()
+    g.open_mode_menu()
+    g.apply_mode_selection(side='black')
+    assert g.mode_menu is not None
+    g.apply_mode_selection(opponent='random')
+    assert g.mode_menu is not None
+
+
+def test_show_mode_menu_noop_when_closed():
+    g = Game()
+    surface = pygame.Surface((800, 800))
+    g.show_mode_menu(surface)
+    assert g.mode_menu_rects == []
+
+
+def test_show_mode_menu_populates_rects_for_both_groups_when_open():
+    g = Game()
+    g.open_mode_menu()
+    surface = pygame.Surface((800, 800))
+    g.show_mode_menu(surface)
+    # Entries are (rect, group_key, option_key)
+    groups = set(g for (_r, g, _k) in g.mode_menu_rects)
+    assert 'side' in groups
+    assert 'opponent' in groups
+    n_sides = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'side')
+    n_opps = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'opponent')
+    assert n_sides == len(Game.SIDE_OPTIONS)
+    assert n_opps == len(Game.OPPONENT_OPTIONS)
+    for rect, group, key in g.mode_menu_rects:
+        assert isinstance(rect, pygame.Rect)
+        assert group in ('side', 'opponent')
+        assert isinstance(key, str)
+
+
+# --- integration with AIController -----------------------------------------
+
+def test_take_ai_turn_after_apply():
+    random.seed(7)
+    g = Game()
+    g.apply_mode_selection(side='black', opponent='random')   # AI is white, moves first
+    assert g.ai_controller.is_ai_turn(g)
+    turn_no = g.board.turn_number
+    assert g.ai_controller.take_turn(g) is True
+    assert g.board.turn_number == turn_no + 1
+    assert g.next_player == 'black'  # now user's turn
+
+
+def test_take_ai_turn_only_on_ai_color():
+    g = Game()
+    g.apply_mode_selection(opponent='random')  # user white, AI black
+    assert g.ai_controller.is_ai_turn(g) is False  # white to move = user
+    assert g.ai_controller.take_turn(g) is False
+    assert g.board.turn_number == 0
+
+
+# --- undo / redo: human-vs-human (existing single-step behavior preserved) --
+
+def _advance(g, n):
+    """Apply n random legal turns using a throwaway random pick, mirroring
+    how the human path would advance turns. (We can't run the actual UI
+    event loop here, so we drive Game.next_turn via a helper AIController
+    on whichever color is to move.)"""
+    helpers = {'white': AIController('white'), 'black': AIController('black')}
+    for _ in range(n):
+        if g.winner is not None:
+            return
+        helpers[g.next_player].take_turn(g)
+
+
+def test_undo_redo_human_vs_human_single_step():
+    random.seed(11)
+    g = Game()  # human-vs-human
+    _advance(g, 4)  # turns 1..4
+    assert g.board.turn_number == 4
+
+    assert g.undo() is True
+    assert g.board.turn_number == 3   # single-step undo
+
+    assert g.redo() is True
+    assert g.board.turn_number == 4
+
+
+# --- undo / redo: human-vs-AI (skip the AI's turn) -------------------------
+
+def test_undo_in_ai_mode_skips_to_previous_user_turn_user_white():
+    """User plays white; AI plays black. Each user move is followed by an AI
+    move. Undo from the user's turn should roll back BOTH the AI's most recent
+    move and the user's most recent move, landing on the user's PREVIOUS turn."""
+    random.seed(13)
+    g = Game()
+    g.apply_mode_selection(opponent='random')   # AI = black, AI moves second
+    _advance(g, 4)  # turn 1 user, turn 2 AI, turn 3 user, turn 4 AI → user to move
+    assert g.next_player == 'white'             # user's turn
+    assert g.board.turn_number == 4
+
+    assert g.undo() is True
+    assert g.next_player == 'white'             # still user's turn (skipped AI's)
+    assert g.board.turn_number == 2             # rolled back BOTH last moves
+
+
+def test_undo_in_ai_mode_skips_to_previous_user_turn_user_black():
+    random.seed(17)
+    g = Game()
+    g.apply_mode_selection(side='black', opponent='random')   # AI = white, moves first
+    _advance(g, 4)  # turn 1 AI, turn 2 user, turn 3 AI, turn 4 user → AI to move
+    assert g.next_player == 'white'             # AI's turn
+    assert g.board.turn_number == 4
+
+    # Advance one more turn (AI) so the user is about to play.
+    _advance(g, 1)
+    assert g.next_player == 'black'             # user's turn
+    assert g.board.turn_number == 5
+
+    assert g.undo() is True
+    assert g.next_player == 'black'             # still user's turn
+    assert g.board.turn_number == 3             # rolled back BOTH last moves
+
+
+def test_redo_in_ai_mode_advances_to_next_user_turn():
+    random.seed(19)
+    g = Game()
+    g.apply_mode_selection(opponent='random')   # AI = black
+    _advance(g, 4)
+    assert g.board.turn_number == 4
+    assert g.next_player == 'white'
+
+    # Undo: turn 4 → turn 2.
+    g.undo()
+    assert g.board.turn_number == 2
+    assert g.next_player == 'white'
+
+    # Redo: turn 2 → turn 4 (skip back over the AI's turn).
+    assert g.redo() is True
+    assert g.board.turn_number == 4
+    assert g.next_player == 'white'
+
+
+def test_undo_at_game_start_when_user_is_black():
+    """When the user is black and the AI plays white (moves first), undoing
+    from the user's first turn should NOT crash and should stop at the earliest
+    available state."""
+    random.seed(23)
+    g = Game()
+    g.apply_mode_selection(side='black', opponent='random')
+    _advance(g, 1)  # AI moves; now user's turn
+    assert g.next_player == 'black'
+    assert g.board.turn_number == 1
+
+    # Undo from here: we want a user-turn state, but the only earlier state is
+    # the initial state (AI's turn). The implementation should stop gracefully
+    # and not raise.
+    result = g.undo()
+    # It either undid to the initial state (next_player='white') or refused —
+    # but it must not raise, and it must not leave the game in a corrupt state.
+    assert result is True
+    assert g.board.turn_number == 0
+
+
+def test_undo_blocked_in_intermediate_state():
+    """Existing invariant preserved: undo refuses while a UI menu is open."""
+    random.seed(29)
+    g = Game()
+    g.apply_mode_selection(opponent='random')
+    _advance(g, 4)
+    g.open_mode_menu()
+    assert g.undo() is False   # mode menu is open
+    g.close_mode_menu()
+    assert g.undo() is True    # now allowed
+
+
+def test_redo_stack_cleared_on_new_turn():
+    """Existing invariant preserved: making a new turn invalidates the redo
+    stack (the timeline diverges)."""
+    random.seed(31)
+    g = Game()
+    g.apply_mode_selection(opponent='random')
+    _advance(g, 4)
+    g.undo()
+    assert g.can_redo() is True
+    # Make a new turn (user) — diverges from the undone timeline.
+    _advance(g, 1)
+    assert g.can_redo() is False


### PR DESCRIPTION
## Summary
Two related changes you requested.

### Menu redesign
The mode menu now has **two independent dimensions** instead of bundled rows: pick your **side** (White / Black) and your **opponent** (Human / Random / future levels) separately. No more "Human (W) vs Random (B)" + "Random (W) vs Human (B)" duplication.

- `Game.SIDE_OPTIONS` and `Game.OPPONENT_OPTIONS` — extensible catalogs.
- `apply_mode_selection(side=None, opponent=None)` updates either or both.
- Live-settings UX: clicking a button updates that dimension immediately, menu stays open until **M** or **Esc**.
- `mode_menu_rects` entries are `(rect, group_key, option_key)`.

### AI-aware undo / redo
Previously, `Undo` in human-vs-AI just popped the AI's last move → the AI would immediately replay (often differently with RandomPlayer) and the user got no useful take-back.

- `Game.undo()` now, while an AI is active, keeps popping until `next_player == user_side` — so undo lands on the user's PREVIOUS turn (rolling back both moves). Stops at the earliest snapshot gracefully.
- `Game.redo()` is the symmetric advance.
- Human-vs-human single-step behavior preserved.
- `mode_menu` added to `_in_intermediate_state` so undo/redo are blocked while the menu is open.

## Tests (tests-first)
`tests/test_mode_selection.py` rewritten — 28 headless tests:
- New API (side + opponent, derived AI state, mid-game switching, live-settings no-auto-close, invalid-input rejection, click-rect group keying).
- Undo/redo: human-vs-human single-step preserved; AI-mode undo skips AI turn (both user-white and user-black cases); redo symmetric; undo at game start with user-black handled; intermediate-state guard; redo-stack-cleared invariant.

## Regression
- Real-pygame: 150 pass (mode_selection 28 + ai_controller 5 + v2_freeze 21 + v2_knight 96).
- Mocked-pygame: 333 pass.
- Headless `Main()` and `Main(ai_color=...)` smoke OK.