### PR TITLE
Tighten tiny endgame valuation 1-to-3 → 1-to-2 + preserve draw data in trainer

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -390,7 +390,7 @@ This rule applies only when ALL of the following hold:
 
 * there are **6 or fewer non-king non-neutral pieces** on the board, and
 
-* the position **balances** under the cancel-queens + 1-to-3 valuation defined below.
+* the position **balances** under the cancel-queens + 1-to-2 valuation defined below.
 
 The boulder is neutral and does not count toward the piece total. Kings are ignored from the count (so the count is of queens and non-queen non-king pieces only).
 
@@ -402,7 +402,7 @@ For this rule:
 
 * a **promoted queen** also counts as a **queen** regardless of form
 
-### **Cancel-queens + 1-to-3 valuation**
+### **Cancel-queens + 1-to-2 valuation**
 
 For each side, count:
 
@@ -412,7 +412,7 @@ For each side, count:
 
 **Step 1 — Cancel queens.** Let `q = min(Q_W, Q_B)`. Subtract `q` from both `Q_W` and `Q_B`. After cancellation, one side (call it M) has `r = |Q_W − Q_B|` remaining queens; the other side (call it L) has zero queens.
 
-**Step 2 — Valuation.** Each of M's `r` remaining queens is independently assigned a value from `{1, 2, 3}`. Each non-king non-queen piece counts as `1`. The position **balances** iff there exists an assignment of queen values such that the two sides' totals are equal:
+**Step 2 — Valuation.** Each of M's `r` remaining queens is independently assigned a value from `{1, 2}`. Each non-king non-queen piece counts as `1`. The position **balances** iff there exists an assignment of queen values such that the two sides' totals are equal:
 
 ```
 Σ (queen values) + N_M  =  N_L
@@ -422,16 +422,18 @@ If `r = 0` (both sides had the same number of queens before Step 1), the conditi
 
 ### **Equivalent numerical condition**
 
-Since each queen value lies in `{1, 2, 3}` and there are `r` queens, the sum ranges over the integer interval `[r, 3r]`. The balance condition is:
+Since each queen value lies in `{1, 2}` and there are `r` queens, the sum ranges over the integer interval `[r, 2r]`. The balance condition is:
 
 ```
-r ≤ N_L − N_M ≤ 3r           (when r ≥ 1)
+r ≤ N_L − N_M ≤ 2r           (when r ≥ 1)
 N_M = N_L                    (when r = 0)
 ```
 
 ### **Rationale**
 
-The cancel-queens framing encodes that two opposing queens largely neutralize each other in tiny endgames via mutual bishop-form pinning. The 1-to-3 valuation reflects that a queen's effective material worth ranges from ~1 (when constrained) to ~3 (when full transformation/manipulation toolkit applies). The combined check activates the rule precisely on positions where neither side has enough material to force a win in practical turn counts.
+The cancel-queens framing encodes that two opposing queens largely neutralize each other in tiny endgames via mutual bishop-form pinning. The 1-to-2 valuation reflects that a queen's effective material worth ranges from ~1 (when constrained) to ~2 (when its transformation/manipulation toolkit and bishop-form escape apply). The combined check activates the rule precisely on positions where neither side has enough material to force a win in practical turn counts.
+
+**Why 1-to-2, not 1-to-3 (2026-05-26 update):** the previous 1-to-3 cap allowed positions like `K + Q vs K + 3 non-queen pieces` (e.g., K+Q vs K+2R+N) to count as balanced. Closer analysis showed all such positions are forceable for the +material side under optimal play. The hardest case is K+Q vs K+2R+N, which is the only 3-non-queen composition with 0 bishops — and even there, W can construct a square-coverage trap (Kf2, Rb7, Rc2, Nf6 covers all squares except h2 when K is at f2, forcing B's Q-as-B into oscillation between h2 and e2, terminating via repetition). With 1 or 2 bishops in the 3-non-queen mix, the bishops continuously pin B's queen, making the trap easier. The 1-to-2 cap removes over-coverage of these positions; they win on material rather than via rule-driven termination.
 
 ## **Royal Pieces**
 

--- a/docs/design-notes/project_tiny_endgame_status.md
+++ b/docs/design-notes/project_tiny_endgame_status.md
@@ -656,3 +656,49 @@ After analyzing K+2Q+2B vs same (8 non-king symmetric), K+3Q+2B vs same (10 non-
 4. Pre-activation phase has rich strategic depth — pin setup vs disruption, manipulation defense vs transformation timing — without stalling.
 
 **GOAL 1 FULLY CLOSED. Threshold ≤6 confirmed. Proceeding to Goal 3 training.**
+
+## Queen valuation tightened: 1-to-3 → 1-to-2 (2026-05-26)
+
+User-led analysis of K+2R+N vs K+Q (the hardest case in the r=1 surplus=3 reclassification space) showed the +material side wins via square-coverage trap + repetition loss for B. By extension, all 7 (R,B,N)-triple compositions vs K+Q are forceable for the +material side.
+
+### Structural argument (partition by bishop count)
+
+The 7 compositions of "3 non-queens vs K+Q":
+- 0 bishops: {R,R,N} = 2R+N, {R,N,N} = 2N+R.
+- 1 bishop: {R,R,B} = 2R+B, {R,B,N}, {N,N,B} = 2N+B.
+- 2 bishops: {R,B,B} = R+2B, {N,B,B} = N+2B.
+- 3 bishops: impossible (max 2 real bishops; queen-only promotion).
+
+**2 bishops + 1 attacker:** W's 2 bishops both pin (one on Q, one on K). B's Q can manipulate only 1 bishop per turn → continuous pin on at least 1 royal. The lone attacker (R or N) captures the pinned royal.
+
+**1 bishop + 2 attackers:** Bishop pins B's Q. 2 attackers target B's K. B's manipulation breaks pin once per cycle but 2 attackers continue grinding. W wins by material grind.
+
+**0 bishops + 3 attackers (2R+N or 2N+R):** No pin power. Trap relies on square-coverage.
+- 2N+R (e.g., Nc3, Nf6, Rb7, Kg2): knights' chebyshev-1 jump-capture range + chebyshev-2 movement range together cover 24 squares each. Bishop teleport-safety EXCLUDES knight-jump-capturable squares (per rulebook). Total coverage hits all 60 non-W squares — Q-as-B has ZERO safe teleport destinations and dies.
+- 2R+N (e.g., Rb7, Rc2, Nf6, Kf2): rook geometry leaves exactly 1 square uncovered (h2 when K at f2, e2 when K at g2). Q-as-B oscillates between h2 and e2. Repetition cycle 4 turns long. State S0 reaches 3rd occurrence at move 8 (B's move) → B loses by repetition rule. The HARDEST case but still forceable.
+
+Since 2R+N (the hardest case) is forceable, all 7 compositions are forceable. r=1 surplus=3 positions don't need rule activation — they win by material.
+
+### What 1-to-2 changes mechanically
+
+Balance check: `r ≤ N_L − N_M ≤ 2r` (was 3r). Positions affected:
+- r=1, surplus=3: previously balanced, now UNBALANCED. Includes K+Q vs K+R+R+N and all 6 other (R,B,N)-triple compositions.
+- r=2, surplus=5 or 6: theoretically affected but only reachable at total non-king ≥ 7, above the ≤6 activation threshold. So this change doesn't affect any actually-activating positions in this r=2 range.
+
+### Risk assessment
+
+If some r=1 surplus=3 composition turns out to be stall-prone in practice (contradicting the structural argument), the rule under-covers and games may drift. Monitorable via Goal 3 self-play data: the per-game JSONL (added in same PR) captures `loss_reason` for every game, including draws, so we can spot K+Q-vs-3-non-queens stalls if they occur.
+
+The change is reversible — single-line code change in `src/board.py is_tiny_endgame()`.
+
+### Implementation
+
+Combined PR (claude/tiny-endgame-1to2-and-trainer-draws):
+1. `src/board.py is_tiny_endgame()`: cap 3 → 2 in valuation check.
+2. `RULEBOOK_v2.md`: section retitled, rationale rewritten with the K+2R+N forceability argument.
+3. `docs/key-rule-differences.md`: cheat sheet updated.
+4. `tests/test_piece_movement.py`: r=1 surplus=3 tests flipped from `assertTrue` to `assertFalse` for activation; docstrings updated.
+5. `src/trainer.py`: per-game summary JSONL saved to `<save_dir>/games/iter_NNNN.jsonl` for every game (decisive + draw). Includes winner, loss_reason, total_turns, turn_cap. Loss-reason breakdown also added to `training_history.json` per iteration.
+6. `tests/test_ai.py`: new test verifying draw games return the metadata fields the JSONL writer needs.
+
+22/22 tiny endgame tests pass. 121/121 manipulation + piece tests pass.

--- a/docs/key-rule-differences.md
+++ b/docs/key-rule-differences.md
@@ -193,15 +193,13 @@ The active rulebook version (in `RULEBOOK_v2.md`):
 - Non-capture move that would push the resulting royal distance count over 3 is illegal.
 - If all legal turns would do so, player loses.
 
-**Leading proposed refinement (as of 2026-05-16, see `docs/potential-rule-changes.md` Section 8):**
-- Catch-all: **≤4 total** pieces (unconditional, boulder excluded).
-- Balance-check scope: **≤6 non-king** pieces (boulder excluded, kings ignored), AND cancel-queens + 1-to-3 valuation balances.
+**Current adopted form (2026-05-26):**
+- Activation: no pawns AND **≤6 non-king** pieces (boulder excluded, kings ignored) AND cancel-queens + **1-to-2** valuation balances.
+- Balance check: cancel queens (q = min(Q_W, Q_B)); r = |Q_W − Q_B|; check `r ≤ N_L − N_M ≤ 2r` (for r≥1) or `N_M = N_L` (for r=0), where N is non-queen non-king count.
 
-The asymmetry between the two clauses (total vs non-king) is principled: the catch-all is unconditional, so expanding it picks up forceable king-pin-resolvable positions; the balance check still applies its analytical filter, so expanding its scope only activates the genuinely-balanced (stall-prone) subset like symmetric/near-symmetric positions with extra kings.
+The 1-to-2 cap (vs the earlier 1-to-3) reflects the analysis that all r=1 surplus=3 positions (K+Q vs K + 3-non-queens) are forceable for the +material side under optimal play, so they don't need rule activation.
 
 **Important framing:** Tiny endgame **NEVER causes a draw**. It's a "ticking time bomb" — when active, the game must resolve in finite turns with a winner. The player who runs out of legal moves first loses. The rule's PURPOSE is to prevent infinite drift.
-
-**Important caveat:** This rule is under active design discussion. Multiple alternative formulations exist; treat `RULEBOOK_v2.md` as authoritative for the current rule, and `docs/potential-rule-changes.md` as the design backlog. The leading proposal under discussion is the "cancel-queens + 1-to-3 valuation" variant (Section 8); design principles guiding all proposals are documented in Section 7. The pressure-testing methodology and goal (100% no-draws, minimize over-coverage, prefer simplicity) live in Section 7.
 
 **Design-goal one-liner for tiny endgame proposals:** under-coverage is unacceptable (drift-prone position → potential draw → rule failure); over-coverage of forced positions is acceptable (winner still wins, just faster); simpler rules preferred when coverage is equivalent. When in doubt, err toward activating. Optimality is self-referential — "optimal play" assumes both sides know all rules including this one.
 

--- a/src/board.py
+++ b/src/board.py
@@ -508,19 +508,30 @@ class Board:
     def is_tiny_endgame(self):
         """Check if the tiny endgame rule is active.
 
-        New rule (2026-05-18 redesign): activates iff ALL of:
+        Rule (2026-05-26 valuation tightening; supersedes 2026-05-18 rule):
+        activates iff ALL of:
           - no pawns remain,
           - at most 6 NON-KING non-neutral pieces remain (boulder excluded),
-          - the position balances under the cancel-queens + 1-to-3
+          - the position balances under the cancel-queens + 1-to-2
             valuation (RULEBOOK_v2.md "Tiny Endgame Rule").
 
         Cancel-queens: let q = min(Q_W, Q_B). Reduce both queen counts
         by q. One side M has r = |Q_W - Q_B| remaining queens; the other
         L has 0 queens. Each remaining queen takes a free value in
-        {1, 2, 3}; each non-king non-queen piece counts as 1. The
+        {1, 2}; each non-king non-queen piece counts as 1. The
         position balances iff ∃ assignment with Σ v_i + N_M = N_L.
-        Equivalent numerical: r ≤ N_L - N_M ≤ 3r (when r ≥ 1), or
+        Equivalent numerical: r ≤ N_L - N_M ≤ 2r (when r ≥ 1), or
         N_M = N_L (when r = 0).
+
+        Rationale (2026-05-26): the previous 1-to-3 cap was loosened
+        from the empirical claim that a queen is sometimes worth ~3
+        non-queen pieces. Closer analysis shows that K+Q vs K+(any
+        3 non-queen pieces) is forceable for the +material side under
+        optimal play (see project_tiny_endgame_status.md for the
+        full structural argument), so r=1 surplus=3 positions are
+        already won by material and don't need rule activation. 1-to-2
+        avoids over-coverage while preserving the rule's termination
+        guarantee for positions that genuinely need it.
 
         Royal queens count as queens regardless of transformation form.
         Promoted queens count as queens regardless of form.
@@ -569,9 +580,9 @@ class Board:
         # Balance check
         if r == 0:
             return n_M == n_L
-        # r ≥ 1: need r ≤ n_L - n_M ≤ 3r
+        # r ≥ 1: need r ≤ n_L - n_M ≤ 2r (1-to-2 valuation)
         diff = n_L - n_M
-        return r <= diff <= 3 * r
+        return r <= diff <= 2 * r
 
     def get_royal_distance(self):
         """Get the Manhattan distance between the closest pair of opposing royal pieces."""

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -545,6 +545,14 @@ def training_loop(
         iter_outcomes = []
         iter_wins = {'white': 0, 'black': 0, 'draw': 0}
         iter_lengths = []
+        # Per-game summaries (preserved for analysis — includes draws).
+        # Each entry: {winner, loss_reason, total_turns, turn_cap, game_index_in_iter}.
+        # Captures BOTH decisive and draw games. Not used for training; used for
+        # post-hoc statistical analysis (stall-pattern detection, loss-reason
+        # distribution, draw-rate trends, etc.).
+        iter_game_summaries = []
+        # Loss-reason breakdown for the iteration log line.
+        loss_reason_counts = {}
 
         # Move network to CPU for self-play (avoids GPU contention)
         network_cpu = ValueNetwork(
@@ -573,6 +581,20 @@ def training_loop(
             else:
                 iter_wins['draw'] += 1
 
+            # Per-game summary (preserved for both decisive AND draw games).
+            # NOT used for training — only for analysis. Draw games have
+            # winner=None and a loss_reason like 'turn_cap', 'repetition',
+            # 'no_legal_moves', etc., depending on how they ended.
+            iter_game_summaries.append({
+                'game_index_in_iter': total_games - 1,
+                'winner': info['winner'],
+                'loss_reason': info.get('loss_reason'),
+                'total_turns': info['total_turns'],
+                'turn_cap': info['turn_cap'],
+            })
+            loss_reason = info.get('loss_reason') or 'decisive'
+            loss_reason_counts[loss_reason] = loss_reason_counts.get(loss_reason, 0) + 1
+
             # Only add to training buffer for decisive games (outcomes non-empty).
             # Draw states are returned for data collection but not used for training.
             if outcomes:
@@ -587,6 +609,20 @@ def training_loop(
               f"{total_games} total, {total_games/play_elapsed:.1f} games/s)")
         print(f"  Results: W={iter_wins['white']} B={iter_wins['black']} "
               f"D={iter_wins['draw']} | avg_len={sum(iter_lengths)/len(iter_lengths):.0f}")
+        # Print loss-reason breakdown (useful for spotting unusual patterns).
+        if loss_reason_counts:
+            reasons_str = ', '.join(f'{k}={v}' for k, v in sorted(loss_reason_counts.items()))
+            print(f"  Loss-reason breakdown: {reasons_str}")
+
+        # Persist per-game summaries for THIS iteration (includes draws).
+        # File format: JSON Lines (one game per line). Read by analysis tools
+        # via `[json.loads(l) for l in open(path)]`.
+        games_dir = os.path.join(save_dir, 'games')
+        os.makedirs(games_dir, exist_ok=True)
+        games_path = os.path.join(games_dir, f'iter_{iteration + 1:04d}.jsonl')
+        with open(games_path, 'w') as f:
+            for game_summary in iter_game_summaries:
+                f.write(json.dumps(game_summary) + '\n')
 
         # Add to buffer
         all_states.extend(iter_states)
@@ -616,7 +652,8 @@ def training_loop(
         checkpoint_path = os.path.join(save_dir, f'model_iter_{iteration + 1:04d}.pt')
         network.save(checkpoint_path)
 
-        # Record history
+        # Record history (incl. per-iteration loss-reason breakdown for
+        # post-hoc analysis without re-reading per-game JSONL).
         iter_info = {
             'iteration': iteration + 1,
             'epsilon': epsilon,
@@ -628,6 +665,7 @@ def training_loop(
             'white_wins': iter_wins['white'],
             'black_wins': iter_wins['black'],
             'draws': iter_wins['draw'],
+            'loss_reason_counts': dict(loss_reason_counts),
             'avg_game_length': sum(iter_lengths) / len(iter_lengths),
             'play_time': play_elapsed,
             'train_time': train_elapsed,

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -324,6 +324,30 @@ class TestTrainingData:
         # Most games at max_turns=10 should be draws
         assert False, "Could not find a draw game"
 
+    def test_draw_game_info_has_metadata_for_preservation(self):
+        """Draw games must return enough metadata for the training loop to
+        persist them in the per-iteration JSONL file. The trainer's per-game
+        summary writer relies on these fields: winner (None for draws),
+        loss_reason (string), total_turns (int), turn_cap (bool)."""
+        network = ValueNetwork(conv_channels=32, num_res_blocks=2, fc_size=64)
+        network.eval()
+
+        for _ in range(50):
+            states, outcomes, info = play_training_game(
+                network, 'cpu', max_turns=10, epsilon=1.0)
+            if info['winner'] is None:
+                # All four fields required by the trainer's JSONL writer.
+                assert 'winner' in info and info['winner'] is None
+                assert 'loss_reason' in info
+                assert 'total_turns' in info and isinstance(info['total_turns'], int)
+                assert 'turn_cap' in info and isinstance(info['turn_cap'], bool)
+                # loss_reason for a turn_cap draw should be a string (or None,
+                # but the trainer falls back to 'decisive' if None — so any
+                # value is acceptable for the JSONL writer).
+                return
+
+        assert False, "Could not find a draw game in 50 attempts"
+
     def test_draw_states_not_in_training_buffer(self):
         """Training buffer should only contain decisive game data."""
         network = ValueNetwork(conv_channels=32, num_res_blocks=2, fc_size=64)

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -3784,8 +3784,11 @@ class TestTinyEndgameRule(unittest.TestCase):
 
     # ---- Activation condition tests ----
 
-    # New rule (2026-05-18): no ≤4 catch-all; activates iff no pawns AND
-    # ≤6 non-king pieces AND cancel-queens + 1-to-3 valuation balances.
+    # Rule (2026-05-26 valuation tightening): activates iff no pawns AND
+    # ≤6 non-king pieces AND cancel-queens + 1-to-2 valuation balances.
+    # (Supersedes 2026-05-18 1-to-3 rule; closer analysis showed r=1 surplus=3
+    # positions like K+Q vs K+3-non-queens are forceable for the +material side
+    # under optimal play, so don't need rule activation.)
 
     def test_rule_not_active_with_pawns(self):
         """Rule does not activate if any pawns remain on the board."""
@@ -3805,9 +3808,9 @@ class TestTinyEndgameRule(unittest.TestCase):
         self.assertTrue(board.is_tiny_endgame())
 
     def test_rule_NOT_active_K_vs_KQ_lone_queen_advantage(self):
-        """K vs K+Q: Q_W=0, Q_B=1, r=1, N=0=0; need v=0 ∉ [1,3]. NOT activated.
-        New rule: ≤4 catch-all removed. K vs K+Q is forceable for the queen side
-        (knight chase + slow king cornering) — rule activation not needed."""
+        """K vs K+Q: Q_W=0, Q_B=1, r=1, N=0=0; need v=0 ∉ [1,2]. NOT activated.
+        K vs K+Q is forceable for the queen side (knight chase + slow king
+        cornering) — rule activation not needed."""
         board = empty_board()
         place(board, "e1", King('white'))
         place(board, "e8", King('black'))
@@ -3869,11 +3872,15 @@ class TestTinyEndgameRule(unittest.TestCase):
         # 0 non-king pieces on each side. Balanced (r=0, N=0=0). ACTIVATES.
         self.assertTrue(board.is_tiny_endgame())
 
-    # ---- Cancel-queens + 1-to-3 valuation tests (new rule, 2026-05-18) ----
+    # ---- Cancel-queens + 1-to-2 valuation tests (rule 2026-05-26) ----
 
-    def test_rule_active_lone_queen_vs_3_attackers(self):
-        """K+Q vs K+R+R+N (5 pieces, 5 non-king): r=1, N_W=0, N_B=3. v=3 ∈ [1,3]. ACTIVATES.
-        Drift-prone via queen-as-bishop escape (K+R+R+N covers ≤63 squares)."""
+    def test_rule_NOT_active_lone_queen_vs_3_attackers(self):
+        """K+Q vs K+R+R+N (5 pieces, 5 non-king): r=1, N_W=0, N_B=3. v=3 ∉ [1,2]. NOT activated.
+        Under 1-to-2 valuation: this position is reclassified as forceable for the
+        +material side (3-attacker side wins via square coverage + repetition,
+        per 2026-05-26 analysis of K+2R+N vs K+Q forceability). Previously
+        classified as balanced under 1-to-3 valuation; the closer analysis shows
+        no rule activation needed."""
         board = empty_board()
         place(board, "e1", King('white'))
         place(board, "d1", Queen('white'))
@@ -3881,10 +3888,10 @@ class TestTinyEndgameRule(unittest.TestCase):
         place(board, "a8", Rook('black'))
         place(board, "h8", Rook('black'))
         place(board, "g8", Knight('black'))
-        self.assertTrue(board.is_tiny_endgame())
+        self.assertFalse(board.is_tiny_endgame())
 
     def test_rule_NOT_active_lone_queen_vs_4_attackers(self):
-        """K+Q vs K+R+R+N+B (6 pieces, 6 non-king): r=1, N_W=0, N_B=4. v=4 ∉ [1,3]. NOT activated.
+        """K+Q vs K+R+R+N+B (6 pieces, 6 non-king): r=1, N_W=0, N_B=4. v=4 ∉ [1,2]. NOT activated.
         Forceable for the 4-attacker side (overwhelming material)."""
         board = empty_board()
         place(board, "e1", King('white'))
@@ -3897,7 +3904,7 @@ class TestTinyEndgameRule(unittest.TestCase):
         self.assertFalse(board.is_tiny_endgame())
 
     def test_rule_active_double_queen_balance(self):
-        """K+Q+Q vs K+R+R+N: Q_W=2, Q_B=0, r=2, N_W=0, N_B=3. v1+v2=3 ∈ [2,6]. ACTIVATES."""
+        """K+Q+Q vs K+R+R+N: Q_W=2, Q_B=0, r=2, N_W=0, N_B=3. v1+v2=3 ∈ [2,4]. ACTIVATES."""
         board = empty_board()
         place(board, "e1", King('white'))
         place(board, "d1", Queen('white'))
@@ -3909,7 +3916,7 @@ class TestTinyEndgameRule(unittest.TestCase):
         self.assertTrue(board.is_tiny_endgame())
 
     def test_rule_NOT_active_double_queen_vs_lone(self):
-        """K+Q+Q vs K+Q: r=1, N_W=0, N_B=0. Need v=0 ∉ [1,3]. NOT activated.
+        """K+Q+Q vs K+Q: r=1, N_W=0, N_B=0. Need v=0 ∉ [1,2]. NOT activated.
         Forceable for the +Q side."""
         board = empty_board()
         place(board, "e1", King('white'))


### PR DESCRIPTION
## Summary

Two coordinated changes ahead of Goal 3 training kickoff:

### 1. Rule change: queen valuation 1-to-3 → 1-to-2

Closer analysis showed all r=1 surplus=3 positions (K+Q vs K + 3-non-queens, e.g., K+Q vs K+R+R+N) are forceable for the +material side under optimal play. The previous 1-to-3 cap over-covered these positions.

**Structural argument** partitions the 7 (R,B,N)-triple compositions by bishop count:
- **2 bishops + 1 attacker:** bishops both pin Q+K; manipulation breaks 1 pin/turn but the other stays; lone attacker captures.
- **1 bishop + 2 attackers:** bishop pins Q; 2 attackers grind.
- **0 bishops + 3 attackers (2R+N, 2N+R):** square-coverage trap.
  - 2N+R: knights cover chebyshev-≤2 (movement + jump-capture range = 24 squares each). All 60 non-W squares covered — Q-as-B has zero safe teleport, dies.
  - 2R+N (HARDEST CASE): 1 square uncovered (h2 vs e2 alternating). Q-as-B oscillates → 4-state cycle → B loses to repetition rule at move 8.

Hardest case forceable → all 7 forceable. r=1 surplus=3 doesn't need rule activation.

Mechanically: `r ≤ N_L − N_M ≤ 2r` (was 3r). Only affects positions at the ≤6 activation threshold (r=1 surplus=3 cases). r=2 surplus=5,6 positions only exist at total non-king ≥ 7, outside activation anyway.

### 2. Trainer: preserve draw data for analysis

Per-game JSONL saved for every game (decisive + draw) at `<save_dir>/games/iter_NNNN.jsonl`. Fields: `game_index_in_iter`, `winner`, `loss_reason`, `total_turns`, `turn_cap`. Loss-reason breakdown also added to `training_history.json` per iteration.

Training behavior unchanged — only decisive games still feed training buffer. Draw data preserved purely for post-hoc analysis: stall-pattern detection, loss-reason distribution trends, draw-rate by iteration. Particularly useful for monitoring whether the 1-to-2 rule change introduces stalls in any r=1 surplus=3 composition (if so, the JSONL data will show K+Q-vs-3-non-queens games stalling).

## Test plan

- [x] `tests/test_piece_movement.py::TestTinyEndgameRule` — 22/22 pass (r=1 surplus=3 tests flipped from assertTrue to assertFalse for activation; docstrings updated).
- [x] `tests/test_ai.py::TestTrainingData` — 5/5 pass (incl. new `test_draw_game_info_has_metadata_for_preservation`).
- [x] `tests/test_manipulation_variants.py` + `tests/test_piece.py` — 121/121 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)