### PR TITLE
Play move/capture sounds when AI takes a turn

### DIFF
--- a/src/ai_controller.py
+++ b/src/ai_controller.py
@@ -141,6 +141,11 @@ class AIController:
             board.update_distance_count(captured=captured)
         if not board.tiny_endgame_active and board.is_tiny_endgame():
             board.init_tiny_endgame()
+        # Audio feedback for the human watching the AI's turn — mirrors the
+        # human-move path in main.py (capture vs move sound). Sound is a
+        # no-op in the headless code path used by tests / training (Game
+        # play_sound is guarded by config.sounds_loaded).
+        game.play_sound(captured=captured)
         game.next_turn()
 
     def _resolve_jump_capture(self, game, turn, jump_targets):
@@ -172,6 +177,9 @@ class AIController:
             board.update_distance_count(captured=jump_captured)
         if not board.tiny_endgame_active and board.is_tiny_endgame():
             board.init_tiny_endgame()
+        # Audio feedback — capture sound if the jump-capture was taken,
+        # move sound if declined. Mirrors human path (main.py lines 475/492).
+        game.play_sound(captured=jump_captured)
         game.next_turn()
 
     def _resolve_promotion(self, game, turn, captured):
@@ -193,4 +201,7 @@ class AIController:
         # it may activate now that the last pawn promoted.
         if board.is_tiny_endgame():
             board.init_tiny_endgame()
+        # Audio feedback — sound reflects whether the promoting move was a
+        # capture. Mirrors human path (main.py line 599 plays at promotion).
+        game.play_sound(captured=captured)
         game.next_turn()


### PR DESCRIPTION
## Summary

The AI's turns in human-vs-AI mode were silent because `AIController._apply_spatial`, `_resolve_jump_capture`, and `_resolve_promotion` did the move logic but never called `game.play_sound()`. The human path plays sound inline at multiple spots in `main.py` (lines 463, 475, 492, 571, 599, 631, etc.) but the AI path skipped it.

This PR adds `game.play_sound(captured=...)` calls at the end of each AI move path, mirroring the human path:
- `_apply_spatial` normal completion: `play_sound(captured=captured)` — mirrors main.py line 631.
- `_resolve_jump_capture`: `play_sound(captured=jump_captured)` — mirrors lines 475 (capture taken) / 492 (declined).
- `_resolve_promotion`: `play_sound(captured=captured)` — mirrors line 599.

`_apply_transformation` intentionally stays silent: the human transformation path in `main.py` (lines 218-240) also plays no sound — transformation is an action, not a spatial move.

## Test plan

- [x] `tests/test_ai_controller.py` — 5/5 pass. Headless pygame stub's `sound.play()` is a no-op, so the new calls don't break tests or training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)