### PR TITLE
Fix: state hash captures manipulation eligibility + last-move-preceding-turn

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -362,19 +362,25 @@ The rule models a **cavalry charge launching from friendly lines**: the knight l
 
 A player may not make a turn that causes a board state to appear **for the third time** during the game.
 
-A board state includes:
+**Governing principle:** a board state captures all information that determines the set of legal moves at this position, EXCEPT for the restrictions enforced by the repetition rule itself (the state-history counts) and the tiny endgame rule (the distance-count history). Those two rules track game-state history that accumulates over time; they are not properties of the current position. Everything else that affects which moves are legal right now is part of the state.
 
-* piece positions
+Concretely, a board state includes:
 
-* the boulder's position and status — including its **cooldown** and its **no-return memory** (the last square it occupied). These are part of the state for the same reason invulnerability is: they gate which turns are legal (a boulder on cooldown, or one barred from returning to its last square, has different legal moves than one without those constraints).
+* piece positions, types, colors
 
-* queen markers
+* per-piece status flags that gate this turn's legal moves:
+  * **royal flag** (`is_royal`) and **transformed flag** (`is_transformed`) — together, the "queen markers" (form + identity)
+  * **manipulation freeze** (`moved_by_queen`, Restriction 1) — a frozen piece cannot make a spatial move on its next turn
+  * **forbidden-square** / **forbidden-zone** (the alternative manipulation-mode restrictions on the manipulated piece's next move)
+  * **invulnerability** — a piece marked invulnerable cannot be captured this turn; this filters opposing captures and so materially changes the legal-move set
+
+* boulder state: its position, **cooldown**, and **no-return memory** (the last square it occupied) — a boulder on cooldown or barred from returning has different legal moves than one without those constraints
 
 * whose turn it is
 
-* which pieces (if any) are currently invulnerable
+* **the square (if any) holding a piece that moved on the immediately preceding turn.** This single piece of "history" IS part of the position because TWO rules consult it: (a) manipulation Restriction 2 (the queen may not manipulate a piece that moved on the immediately preceding turn), and (b) the knight's reactive jump-capture eligibility (the jumped piece must have moved on the immediately preceding turn). Two positions that look identical but differ on whether such a recently-moved piece exists have different legal-move sets and so are different states. The full move history before the preceding turn is irrelevant — only "did the piece at this square move on the immediately preceding turn?" matters for any active rule.
 
-The state hash captures the position and current per-piece / boulder statuses only. It deliberately does NOT include the most recent move or any history of preceding turns: repetition is a positional rule, so two positions that look identical and have identical invulnerability and boulder status count as the same state for repetition purposes, even if the move histories leading up to them differ.
+What is NOT part of the board state for repetition purposes: the state-history counts of the repetition rule itself, and the distance counts of the tiny endgame rule. These are game-level tracking that the rules use to determine when their respective limits fire; they accumulate across the game but are not properties of the current position.
 
 If every legal turn would result in a player creating a third repetition, the player loses.
 

--- a/docs/design-notes/project_state_hash_design.md
+++ b/docs/design-notes/project_state_hash_design.md
@@ -1,24 +1,53 @@
 ---
-name: Repetition state hash design (positional only)
-description: The repetition state hash is positional + invulnerability, deliberately excluding last-move / move history.
+name: Repetition state hash design (legal-move-determining state)
+description: The repetition state hash captures all information that determines the legal-move set at this position, except for the repetition rule's own state-history counts and the tiny endgame rule's distance counts.
 type: project
 originSessionId: 953deca3-9d3a-4d54-8ce6-5506efb26872
 ---
-The state hash used for repetition detection (`Board.get_state_hash`) is **positional only**, with one current-status addition for invulnerability:
 
-**Included:**
-- Piece positions (with name, color, is_royal, is_transformed)
-- Boulder markers (cooldown, last_square, on-intersection flag)
-- Whose turn it is
-- Currently-invulnerable pieces (sorted (row, col) tuple)
+## Current design (2026-05-26 redesign; supersedes 2026-05-13 "positional-only" design)
 
-**Deliberately excluded:**
-- `last_move` and `last_move_turn_number`. Repetition is a positional rule, not a move-history rule. Two positions that look identical and have identical invulnerability status count as the same state.
+**Governing principle:** the state hash captures everything that determines the set of legal moves at this position, EXCEPT for the restrictions enforced by the repetition rule itself (state-history counts) and the tiny endgame rule (distance-count history). Those two rules track game-state history that accumulates over time; they aren't properties of the current position. Everything else that affects legal moves IS in the hash.
 
-Knight jump-capture eligibility and bishop reactive-capture eligibility are gated by separate move-time checks (`_can_jump_capture`, etc.) that read `last_move` and `last_move_turn_number` directly. The repetition hash doesn't need to track these.
+**Hashed per piece:**
+- position (row, col)
+- name, color
+- `is_royal` (royal queen vs promoted queen) + `is_transformed` (form: base vs R/B/N)
+- `moved_by_queen` — Restriction 1 freeze (freeze mode): a frozen piece may not make a spatial move on its next turn
+- `forbidden_square` — original-mode restriction on the manipulated piece's next square
+- `forbidden_zone` — exclusion-zone-mode restriction on the manipulated piece's next destination
+- `invulnerable` — captureability filter for opposing pieces
 
-**Decision date:** 2026-05-13. Original audit added last_move to the hash; user pushed back ("repetition is a positional rule") and we reverted.
+**Hashed at game-state level:**
+- boulder state (cooldown + last_square + intersection flag)
+- whose turn it is
+- **the square (if any) of a piece that moved on the immediately preceding turn.** Two rules consult this single fact: (a) manipulation Restriction 2 (queen may not manipulate a piece that moved on the immediately preceding turn), and (b) knight reactive jump-capture eligibility (jumped piece must have moved on the immediately preceding turn). Both depend on the EXACT condition `last_move_turn_number == turn_number - 1`. We collapse it to one field — either the final square of the just-moved piece, or `None` if the last spatial move was older than the immediately preceding turn.
 
-**Why invulnerability stays:** an invulnerable knight on a square is a meaningfully different position than a non-invulnerable knight on the same square — opposing captures are filtered differently. This IS a per-piece status, just temporary.
+**Deliberately NOT hashed:**
+- The repetition rule's own state-history counts.
+- The tiny endgame rule's distance counts.
+These are game-level rule-tracking, not properties of the current position. Including them would conflate the rule mechanisms with the positions they apply to.
 
-Rulebook reference: `RULEBOOK_v2.md` Repetition Rule section.
+## Why this redesign (2026-05-26)
+
+The previous "positional only" design (2026-05-13) included only `is_royal`/`is_transformed` for queen markers and explicitly EXCLUDED `last_move` history. The user identified that this omits flags that materially change legal moves:
+
+1. `moved_by_queen`: a frozen piece's legal-move set differs from an unfrozen one's.
+2. `forbidden_square` / `forbidden_zone`: alternative manipulation-mode restrictions, same issue.
+3. `last_move.final` + `last_move_turn_number == turn_number - 1`: gates Restriction 2 manipulation eligibility AND knight jump-capture eligibility.
+
+Two positions identical in piece arrangement but differing in any of these flags have DIFFERENT legal-move sets. The old hash collided them, biasing repetition detection toward false positives. The new hash separates them, matching the user's principle: same legal-move set ⇒ same state.
+
+## Impact on training (Goal 3)
+
+Prior to the fix, the running training (`models/variant_freeze_v3/`) had completed 9 iterations with 0 repetition losses across 900 games (verified in per-game JSONL). The bug never fired, so the network weights at `model_iter_0009.pt` are valid. Training was paused, the hash fix applied, and training resumed from `model_iter_0009.pt`. No data loss.
+
+## Implementation
+
+- `src/board.py get_state_hash()`: extended to include the per-piece manipulation flags + last-move-effective-info entry.
+- `tests/test_piece_movement.py`: 5 new tests verify each new field changes the hash, including the "older last_move hashes as None" boundary case.
+- `RULEBOOK_v2.md` Repetition Rule section: rewritten to state the governing principle and list each component explicitly.
+
+## Historical note
+
+The 2026-05-13 "positional only" framing was based on the user's "repetition is a positional rule" intuition at that time, which excluded last_move from the hash. The 2026-05-26 redesign reverses this decision in favor of the more rigorous "legal-move-determining state" framing. Future audits should not re-revert — the new framing is the correct one given the rules' dependence on these flags.

--- a/src/board.py
+++ b/src/board.py
@@ -680,30 +680,52 @@ class Board:
     def get_state_hash(self, next_player):
         """Compute a hashable representation of the current board state.
 
-        The state hash captures the positional / piece-status aspects
-        of the board that matter for repetition detection:
+        Principle (2026-05-26 update): the hash captures everything that
+        determines the set of legal moves at this position, EXCEPT for
+        the restrictions enforced by the repetition rule itself (the
+        state-history count) and the tiny endgame rule (distance-count
+        history). Those are tracked at the game-state level over time,
+        not as per-position properties. Two positions that look identical
+        in all hashed fields produce identical legal-move sets and so are
+        treated as the same state for repetition purposes.
 
-          - piece positions
-          - boulder markers (cooldown, last_square, intersection flag)
-          - queen markers (royal flag + transformed flag, captured
-            via piece.is_royal and piece.is_transformed)
-          - whose turn it is
-          - which pieces (if any) are currently invulnerable
-            (a temporary per-piece status that, while transient, IS
-            a property of the position right now — an invulnerable
-            knight on a square is a meaningfully different position
-            than a non-invulnerable knight on the same square, since
-            opposing captures are filtered differently)
+        Hashed per piece:
+          - position (row, col)
+          - piece type (name) + color + royal flag + transformed flag
+          - `moved_by_queen` (Restriction 1 freeze, freeze mode): if true,
+            the piece may not make a spatial move on its next turn
+          - `forbidden_square` (original manipulation mode): square the
+            piece cannot return to
+          - `forbidden_zone` (exclusion_zone manipulation mode): set of
+            squares the piece cannot move to
+          - `invulnerable`: piece cannot be captured (filters opposing
+            captures); a transient per-piece status that materially
+            changes the legal-move set this turn
 
-        Deliberately NOT in the state hash:
+        Hashed at game-state level:
+          - boulder state (cooldown + last_square + intersection flag)
+          - whose turn it is (`next_player`)
+          - `last_move`-effective-info: which square (if any) holds a
+            piece that moved on the immediately preceding turn. This
+            information gates both manipulation Restriction 2 ("queen may
+            not manipulate a piece that moved on the immediately preceding
+            turn") and knight reactive jump-capture eligibility ("only
+            the jumped piece, only if it moved on the immediately
+            preceding turn"). Both depend on the exact same condition:
+            (last_move.final, last_move_turn_number == turn_number - 1).
+            We collapse that to a single field — either the final square
+            of the just-moved piece, or None if no spatial move happened
+            on the immediately preceding turn — which is enough to
+            determine all legal moves at this position.
 
-          - `last_move` (which piece made the most recent spatial
-            move). The state hash is about the position and current
-            piece statuses, not about a trail of preceding turns.
-            Repetition is a positional rule, so two positions that
-            look identical and have identical invulnerability state
-            count as the same state for repetition purposes, even if
-            the most recent move history differs.
+        NOT hashed:
+          - the prior history of states (the repetition rule's own
+            counting machinery)
+          - the tiny endgame distance counts (the tiny endgame rule's
+            own counting machinery)
+          These are game-state restrictions over time, not properties
+          of the current position; including them would conflate the
+          rule mechanisms with the position they apply to.
         """
         state = []
         for row in range(ROWS):
@@ -711,7 +733,10 @@ class Board:
                 piece = self.squares[row][col].piece
                 if piece:
                     entry = (row, col, piece.name, piece.color,
-                             piece.is_royal, piece.is_transformed)
+                             piece.is_royal, piece.is_transformed,
+                             piece.moved_by_queen,
+                             piece.forbidden_square,
+                             tuple(piece.forbidden_zone) if piece.forbidden_zone else None)
                     # Boulder has additional state that affects the game
                     if isinstance(piece, Boulder):
                         entry = entry + (piece.cooldown, piece.last_square)
@@ -730,6 +755,19 @@ class Board:
                 if piece and piece.invulnerable:
                     invulnerable_squares.append((row, col))
         state.append(('invulnerable', tuple(sorted(invulnerable_squares))))
+        # `last_move`-effective-info: gates manipulation Restriction 2 and
+        # knight reactive jump-capture. We hash the final square of the
+        # last spatial move IF it happened on the immediately preceding
+        # turn; otherwise None. The exact turn number is irrelevant — only
+        # "preceding turn" / "older" matters for the rules that consult it.
+        if (self.last_move is not None
+                and self.last_move_turn_number is not None
+                and self.last_move_turn_number == self.turn_number - 1):
+            last_final = self.last_move.final
+            last_move_entry = (last_final.row, last_final.col)
+        else:
+            last_move_entry = None
+        state.append(('last_move_final_if_preceding', last_move_entry))
         return tuple(state)
 
     def record_state(self, next_player):

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -3338,6 +3338,125 @@ class TestRepetitionRule(unittest.TestCase):
         hash2 = board2.get_state_hash('white')
         self.assertNotEqual(hash1, hash2)
 
+    # ---- New (2026-05-26): hash must capture manipulation eligibility ----
+    # Two positions identical except for manipulation-related per-piece flags
+    # have DIFFERENT legal moves and so MUST produce different hashes. Before
+    # this fix, the hash omitted moved_by_queen / forbidden_square /
+    # forbidden_zone and the last-move-on-preceding-turn condition, causing
+    # spurious repetition detection.
+
+    def test_board_state_hash_includes_moved_by_queen(self):
+        """A frozen (manipulated last turn) piece changes the legal-move set,
+        so the hash MUST differ from the same position with the piece unfrozen.
+        Restriction 1: a frozen piece may not make a spatial move."""
+        board1 = empty_board()
+        r1 = Rook('white')
+        place(board1, "e4", r1)
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        r2 = Rook('white')
+        r2.moved_by_queen = True
+        place(board2, "e4", r2)
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_includes_forbidden_square(self):
+        """In original manipulation mode, a piece with a forbidden_square
+        (the square it cannot return to) has a different legal-move set
+        than the same piece without one."""
+        board1 = empty_board()
+        r1 = Rook('white')
+        place(board1, "e4", r1)
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        r2 = Rook('white')
+        r2.forbidden_square = (3, 4)
+        place(board2, "e4", r2)
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_includes_forbidden_zone(self):
+        """In exclusion_zone manipulation mode, a piece with a forbidden_zone
+        has a restricted legal-move set; hashes must differ."""
+        board1 = empty_board()
+        r1 = Rook('white')
+        place(board1, "e4", r1)
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        r2 = Rook('white')
+        r2.forbidden_zone = [(3, 4), (4, 3)]
+        place(board2, "e4", r2)
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_includes_last_move_on_preceding_turn(self):
+        """The square holding a piece that moved on the immediately preceding
+        turn determines (a) manipulation Restriction 2 — that piece is not
+        manipulable next turn — and (b) knight reactive jump-capture
+        eligibility. Two positions identical except for whether the last
+        spatial move was on the immediately preceding turn MUST differ."""
+        # Build two boards with identical pieces. board1: last_move points
+        # at the immediately preceding turn. board2: no recent move.
+        board1 = empty_board()
+        place(board1, "e1", King('white'))
+        place(board1, "e8", King('black'))
+        place(board1, "d4", Rook('black'))
+        # Simulate a recent move at d4 on the preceding turn.
+        board1.turn_number = 5
+
+        class _StubMove:
+            class _Final:
+                def __init__(self, r, c):
+                    self.row = r
+                    self.col = c
+            def __init__(self, r, c):
+                self.final = self._Final(r, c)
+
+        board1.last_move = _StubMove(3, 3)  # final at d4
+        board1.last_move_turn_number = 4  # = turn_number - 1 (preceding turn)
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "e1", King('white'))
+        place(board2, "e8", King('black'))
+        place(board2, "d4", Rook('black'))
+        board2.turn_number = 5
+        # No recent move (or older than preceding turn).
+        board2.last_move = None
+        board2.last_move_turn_number = None
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_treats_older_last_move_as_none(self):
+        """last_move from 2+ turns ago should hash identically to no last_move
+        — what matters for Restriction 2 and jump-capture is specifically
+        "on the immediately preceding turn," not "ever happened.\""""
+        class _StubMove:
+            class _Final:
+                def __init__(self, r, c):
+                    self.row = r
+                    self.col = c
+            def __init__(self, r, c):
+                self.final = self._Final(r, c)
+
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        board1.turn_number = 10
+        board1.last_move = _StubMove(3, 3)
+        board1.last_move_turn_number = 5  # ancient, not preceding turn
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        board2.turn_number = 10
+        board2.last_move = None
+        board2.last_move_turn_number = None
+        hash2 = board2.get_state_hash('white')
+        self.assertEqual(hash1, hash2)
+
     # ---- State history tracking ----
 
     def test_state_history_records_positions(self):


### PR DESCRIPTION
## Summary

User identified that the repetition state hash omitted per-piece status flags and game-state information that determine the legal-move set at a position. Two positions with identical piece arrangements but DIFFERENT legal-move sets would hash to the same state, biasing repetition detection toward spurious positives.

## What was missing

1. **\`moved_by_queen\`** (Restriction 1 freeze, freeze mode): frozen pieces can't make spatial moves.
2. **\`forbidden_square\`** (original manipulation mode): forbidden next-square for the manipulated piece.
3. **\`forbidden_zone\`** (exclusion-zone mode): forbidden squares set.
4. **The square (if any) of a piece that moved on the immediately preceding turn** — gates BOTH manipulation Restriction 2 AND knight reactive jump-capture eligibility.

## New governing principle

The state hash captures everything determining the legal-move set at this position, EXCEPT for restrictions enforced by the repetition rule (state-history counts) and the tiny endgame rule (distance-count history) themselves. Those are game-level rule-tracking, not position properties. Everything else affecting legal moves IS hashed.

This reverses the 2026-05-13 \"positional only\" design (which deliberately excluded \`last_move\`).

## Training impact

0 repetition losses across the first 9 iterations of the Goal 3 training run, so the bug never fired in practice. The checkpoint at \`model_iter_0009.pt\` is valid; training will resume from there with the corrected hash. No data loss.

## Test plan

- [x] 5 new state-hash tests in \`tests/test_piece_movement.py\`:
  - \`test_board_state_hash_includes_moved_by_queen\` — frozen vs unfrozen differ
  - \`test_board_state_hash_includes_forbidden_square\` — with/without forbidden square differ
  - \`test_board_state_hash_includes_forbidden_zone\` — with/without forbidden zone differ
  - \`test_board_state_hash_includes_last_move_on_preceding_turn\` — recent move vs no recent move differ
  - \`test_board_state_hash_treats_older_last_move_as_none\` — older-than-preceding hashes as None (boundary)
- [x] 61/61 repetition + tiny endgame tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)