### PR TITLE
Fix: state hash includes last-move info only when it affects legal moves

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -371,16 +371,17 @@ Concretely, a board state includes:
 * per-piece status flags that gate this turn's legal moves:
   * **royal flag** (`is_royal`) and **transformed flag** (`is_transformed`) — together, the "queen markers" (form + identity)
   * **manipulation freeze** (`moved_by_queen`, Restriction 1) — a frozen piece cannot make a spatial move on its next turn
-  * **forbidden-square** / **forbidden-zone** (the alternative manipulation-mode restrictions on the manipulated piece's next move)
   * **invulnerability** — a piece marked invulnerable cannot be captured this turn; this filters opposing captures and so materially changes the legal-move set
 
 * boulder state: its position, **cooldown**, and **no-return memory** (the last square it occupied) — a boulder on cooldown or barred from returning has different legal moves than one without those constraints
 
 * whose turn it is
 
-* **the square (if any) holding a piece that moved on the immediately preceding turn.** This single piece of "history" IS part of the position because TWO rules consult it: (a) manipulation Restriction 2 (the queen may not manipulate a piece that moved on the immediately preceding turn), and (b) the knight's reactive jump-capture eligibility (the jumped piece must have moved on the immediately preceding turn). Two positions that look identical but differ on whether such a recently-moved piece exists have different legal-move sets and so are different states. The full move history before the preceding turn is irrelevant — only "did the piece at this square move on the immediately preceding turn?" matters for any active rule.
+* **last-move information IF AND ONLY IF it affects some rule's eligibility at this position.** Three rules consult the immediately preceding move: (a) manipulation Restriction 2 (queen may not manipulate a piece that moved on the immediately preceding turn) — consults `last_move.final`; (b) knight reactive jump-capture (jumped piece must have moved on the immediately preceding turn) — also consults `last_move.final`; (c) bishop reactive capture (eligible only if the captured piece began its move on the bishop's diagonal LoS) — consults `last_move.initial`. The state hash includes the relevant square(s) IF some enemy queen/knight/bishop is positioned to actually consult them, and OMITS them otherwise. So two positions identical in all per-piece statuses but differing only in `last_move.final` (or `.initial`) hash to the SAME state when no rule actually consults the change. This avoids over-differentiation: same legal-move set ⇒ same state.
 
 What is NOT part of the board state for repetition purposes: the state-history counts of the repetition rule itself, and the distance counts of the tiny endgame rule. These are game-level tracking that the rules use to determine when their respective limits fire; they accumulate across the game but are not properties of the current position.
+
+(Implementation note: the code's `get_state_hash` also includes two per-piece flags — `forbidden_square` and `forbidden_zone` — that belong to ALTERNATE manipulation-mode variants (not part of the active rule, which uses `moved_by_queen` freeze). They're hashed for variant correctness but are always `None` under the active rule and so have no effect here.)
 
 If every legal turn would result in a player creating a third repetition, the player loses.
 

--- a/docs/design-notes/project_state_hash_design.md
+++ b/docs/design-notes/project_state_hash_design.md
@@ -21,7 +21,12 @@ originSessionId: 953deca3-9d3a-4d54-8ce6-5506efb26872
 **Hashed at game-state level:**
 - boulder state (cooldown + last_square + intersection flag)
 - whose turn it is
-- **the square (if any) of a piece that moved on the immediately preceding turn.** Two rules consult this single fact: (a) manipulation Restriction 2 (queen may not manipulate a piece that moved on the immediately preceding turn), and (b) knight reactive jump-capture eligibility (jumped piece must have moved on the immediately preceding turn). Both depend on the EXACT condition `last_move_turn_number == turn_number - 1`. We collapse it to one field — either the final square of the just-moved piece, or `None` if the last spatial move was older than the immediately preceding turn.
+- **last-move info IF AND ONLY IF some rule consults it at this position.** Three rules consult the immediately preceding move:
+  1. Manipulation Restriction 2 — current player's base-form queen may not manipulate a piece that moved on the preceding turn. Consults `last_move.final`. RELEVANT iff an enemy-of-moved-piece base-form queen has unblocked rank/file/diagonal LoS to `last_move.final`.
+  2. Knight reactive jump-capture — a piece that moved on the preceding turn can be jump-captured by an enemy knight positioned at chebyshev-1. Consults `last_move.final`. RELEVANT iff an enemy-of-moved-piece knight (real or queen-as-knight) is at chebyshev-1 of `last_move.final`.
+  3. Bishop reactive capture — captured piece must have begun its move on the bishop's diagonal LoS. Consults `last_move.initial`. RELEVANT iff an enemy-of-moved-piece bishop (real or queen-as-bishop) has unblocked diagonal LoS to `last_move.initial`.
+- The state hash includes the relevant square(s) IF any of (1)/(2)/(3) applies, and OMITS them otherwise. Two states with identical per-piece statuses but differing only in `last_move.final` / `.initial` (where no rule consults the difference) hash to the SAME state — no spurious over-differentiation.
+- Note: boulder moves never trigger any of the three rules (queens can't manipulate boulder; knight/bishop can't capture boulder). If the moved piece is the boulder, no last-move info is hashed.
 
 **Deliberately NOT hashed:**
 - The repetition rule's own state-history counts.
@@ -34,13 +39,19 @@ The previous "positional only" design (2026-05-13) included only `is_royal`/`is_
 
 1. `moved_by_queen`: a frozen piece's legal-move set differs from an unfrozen one's.
 2. `forbidden_square` / `forbidden_zone`: alternative manipulation-mode restrictions, same issue.
-3. `last_move.final` + `last_move_turn_number == turn_number - 1`: gates Restriction 2 manipulation eligibility AND knight jump-capture eligibility.
+3. `last_move.final` + `last_move_turn_number == turn_number - 1`: gates Restriction 2 manipulation eligibility AND knight jump-capture eligibility. Additionally, `last_move.initial` gates bishop reactive-capture eligibility.
 
-Two positions identical in piece arrangement but differing in any of these flags have DIFFERENT legal-move sets. The old hash collided them, biasing repetition detection toward false positives. The new hash separates them, matching the user's principle: same legal-move set ⇒ same state.
+Two positions identical in piece arrangement but differing in any of these flags can have DIFFERENT legal-move sets. The old hash collided them, biasing repetition detection toward false positives. The new hash separates them — but ONLY when the difference actually changes the legal-move set, to avoid the opposite bias (over-differentiation that causes spurious misses). The new framing matches the user's principle exactly: same legal-move set ⇒ same state.
+
+### Conditional inclusion of last-move info
+
+An initial fix (committed earlier on 2026-05-26) included `last_move.final` unconditionally whenever it pointed to a piece that moved on the immediately preceding turn. User identified this over-differentiated: two states where `last_move.final` differs but neither difference affects ANY rule's eligibility would still hash differently. The refined design includes last-move info ONLY when one of the three rules (manipulation Restriction 2, knight reactive jump-capture, bishop reactive capture) has an enemy piece positioned to consult it. See `Board._last_move_relevance_for_hash` in `src/board.py`.
 
 ## Impact on training (Goal 3)
 
-Prior to the fix, the running training (`models/variant_freeze_v3/`) had completed 9 iterations with 0 repetition losses across 900 games (verified in per-game JSONL). The bug never fired, so the network weights at `model_iter_0009.pt` are valid. Training was paused, the hash fix applied, and training resumed from `model_iter_0009.pt`. No data loss.
+Prior to the original "positional only" → "all legal-move-affecting state" fix on 2026-05-26, the training (`models/variant_freeze_v3/`) had completed 9 iterations with 0 repetition losses across 900 games (verified in per-game JSONL). The original bug never fired, so the network weights at `model_iter_0009.pt` are valid. Training was paused, the hash fix applied, training resumed from `model_iter_0009.pt`.
+
+After the over-differentiation refinement (conditional inclusion of last-move info), iter 10 had been completed with the over-differentiating hash. Iter 10 also produced 0 repetitions (per `iter_0010.jsonl`), so its data is fine — the over-differentiation doesn't matter when no repetitions actually fire. Training was paused again, the refinement applied, and training resumed from `model_iter_0010.pt`. No data loss across both fixes.
 
 ## Implementation
 

--- a/src/board.py
+++ b/src/board.py
@@ -692,12 +692,14 @@ class Board:
         Hashed per piece:
           - position (row, col)
           - piece type (name) + color + royal flag + transformed flag
-          - `moved_by_queen` (Restriction 1 freeze, freeze mode): if true,
-            the piece may not make a spatial move on its next turn
-          - `forbidden_square` (original manipulation mode): square the
-            piece cannot return to
-          - `forbidden_zone` (exclusion_zone manipulation mode): set of
-            squares the piece cannot move to
+          - `moved_by_queen` (Restriction 1 freeze under the active
+            "freeze" manipulation rule): if true, the piece may not make
+            a spatial move on its next turn
+          - `forbidden_square` and `forbidden_zone`: per-piece flags used
+            by alternate manipulation-mode variants (not the active rule
+            set in RULEBOOK_v2.md, but kept in the hash so variant runs
+            under `--manipulation-mode original` / `exclusion_zone`
+            also have correct repetition detection)
           - `invulnerable`: piece cannot be captured (filters opposing
             captures); a transient per-piece status that materially
             changes the legal-move set this turn
@@ -705,18 +707,21 @@ class Board:
         Hashed at game-state level:
           - boulder state (cooldown + last_square + intersection flag)
           - whose turn it is (`next_player`)
-          - `last_move`-effective-info: which square (if any) holds a
-            piece that moved on the immediately preceding turn. This
-            information gates both manipulation Restriction 2 ("queen may
-            not manipulate a piece that moved on the immediately preceding
-            turn") and knight reactive jump-capture eligibility ("only
-            the jumped piece, only if it moved on the immediately
-            preceding turn"). Both depend on the exact same condition:
-            (last_move.final, last_move_turn_number == turn_number - 1).
-            We collapse that to a single field — either the final square
-            of the just-moved piece, or None if no spatial move happened
-            on the immediately preceding turn — which is enough to
-            determine all legal moves at this position.
+          - `last_move`-relevance: conditionally included info about the
+            move on the immediately preceding turn (if any) — but only
+            when it actually affects a rule's eligibility at this
+            position. Three rules consult last_move:
+              * Manipulation Restriction 2 — queen may not manipulate a
+                piece that moved on the immediately preceding turn
+              * Knight reactive jump-capture — eligible only if jumped
+                piece moved on the immediately preceding turn
+              * Bishop reactive capture — eligible only if the captured
+                piece began its move on the bishop's diagonal LoS
+            If NO enemy queen / knight / bishop is positioned to consult
+            last_move at this state, the last_move info is omitted from
+            the hash — otherwise two states with identical per-piece
+            statuses but different last_move would spuriously
+            differentiate. See _last_move_relevance_for_hash.
 
         NOT hashed:
           - the prior history of states (the repetition rule's own
@@ -755,20 +760,154 @@ class Board:
                 if piece and piece.invulnerable:
                     invulnerable_squares.append((row, col))
         state.append(('invulnerable', tuple(sorted(invulnerable_squares))))
-        # `last_move`-effective-info: gates manipulation Restriction 2 and
-        # knight reactive jump-capture. We hash the final square of the
-        # last spatial move IF it happened on the immediately preceding
-        # turn; otherwise None. The exact turn number is irrelevant — only
-        # "preceding turn" / "older" matters for the rules that consult it.
-        if (self.last_move is not None
-                and self.last_move_turn_number is not None
-                and self.last_move_turn_number == self.turn_number - 1):
-            last_final = self.last_move.final
-            last_move_entry = (last_final.row, last_final.col)
-        else:
-            last_move_entry = None
-        state.append(('last_move_final_if_preceding', last_move_entry))
+        # Last-move-affecting-legal-moves info. Only included if last_move
+        # actually affects a rule's eligibility at this position — see
+        # _last_move_relevance_for_hash. Two states with identical per-piece
+        # statuses but different last_move final squares should NOT
+        # differentiate unless one of the three relevant rules (manipulation
+        # Restriction 2, knight reactive jump-capture, bishop reactive
+        # capture) actually consults that information here.
+        last_move_relevance = self._last_move_relevance_for_hash()
+        if last_move_relevance is not None:
+            state.append(('last_move_relevant', last_move_relevance))
         return tuple(state)
+
+    def _last_move_relevance_for_hash(self):
+        """Summary of last_move's relevance to legal moves at this position,
+        or None if last_move doesn't affect any rule's eligibility.
+
+        The three rules that consult last_move:
+          1. Manipulation Restriction 2 — current player's queen cannot
+             manipulate a piece that moved on the immediately preceding turn.
+             RELEVANT iff some enemy-of-moved-piece base-form queen has
+             unblocked rank/file/diagonal LoS to last_move.final.
+          2. Knight reactive jump-capture — knight (real or queen-as-knight)
+             jump-captures a piece that moved on the immediately preceding turn.
+             RELEVANT iff some enemy-of-moved-piece knight is at chebyshev-1
+             distance from last_move.final.
+          3. Bishop reactive capture — bishop (real or queen-as-bishop)
+             captures a piece that began its move on the bishop's diagonal LoS.
+             RELEVANT iff some enemy-of-moved-piece bishop has unblocked
+             diagonal LoS to last_move.initial.
+
+        Returns None if (a) last_move was not on the immediately preceding
+        turn, (b) the moved piece is the boulder (none of the three rules
+        apply to boulder), (c) the moved piece was captured mid-resolution
+        and is no longer present, or (d) none of the three rules has any
+        eligibility-consulting enemy piece in position.
+
+        Otherwise returns (final_or_none, initial_or_none) where:
+          - final_or_none = (r, c) of last_move.final if rule 1 or 2 applies,
+            else None
+          - initial_or_none = (r, c) of last_move.initial if rule 3 applies,
+            else None
+        """
+        if (self.last_move is None or self.last_move_turn_number is None
+                or self.last_move_turn_number != self.turn_number - 1):
+            return None
+        final_r = self.last_move.final.row
+        final_c = self.last_move.final.col
+        initial_r = self.last_move.initial.row
+        initial_c = self.last_move.initial.col
+        moved_piece = self.squares[final_r][final_c].piece
+        if moved_piece is None:
+            # Moved piece was captured during resolution; no rule can consult it now.
+            return None
+        if moved_piece.color == 'none':
+            # Boulder: queens cannot manipulate it, knight cannot jump-capture
+            # it, bishop cannot reactive-capture it (only kings capture boulder).
+            return None
+        enemy_color = 'black' if moved_piece.color == 'white' else 'white'
+        final_relevant = (
+            self._enemy_base_queen_has_los_to(enemy_color, final_r, final_c)
+            or self._enemy_knight_at_chebyshev_1(enemy_color, final_r, final_c)
+        )
+        initial_relevant = self._enemy_bishop_has_los_to(
+            enemy_color, initial_r, initial_c)
+        if not final_relevant and not initial_relevant:
+            return None
+        return (
+            (final_r, final_c) if final_relevant else None,
+            (initial_r, initial_c) if initial_relevant else None,
+        )
+
+    def _enemy_base_queen_has_los_to(self, enemy_color, target_r, target_c):
+        """True iff some base-form queen of `enemy_color` has unblocked
+        rank/file/diagonal LoS to (target_r, target_c). Only base-form
+        queens can manipulate (Restriction 3 — manipulation is base-form-only)."""
+        for r in range(ROWS):
+            for c in range(COLS):
+                piece = self.squares[r][c].piece
+                if piece is None or piece.color != enemy_color:
+                    continue
+                if not (isinstance(piece, Queen) and not piece.is_transformed):
+                    continue
+                if self._has_unblocked_queen_los(r, c, target_r, target_c):
+                    return True
+        return False
+
+    def _enemy_knight_at_chebyshev_1(self, enemy_color, target_r, target_c):
+        """True iff some knight (Knight instance covers real knights AND
+        queen-as-knight, since transformation produces a Knight instance) of
+        `enemy_color` is at chebyshev-1 of (target_r, target_c)."""
+        for r in range(max(0, target_r - 1), min(ROWS, target_r + 2)):
+            for c in range(max(0, target_c - 1), min(COLS, target_c + 2)):
+                if (r, c) == (target_r, target_c):
+                    continue
+                piece = self.squares[r][c].piece
+                if piece is None or piece.color != enemy_color:
+                    continue
+                if isinstance(piece, Knight):
+                    return True
+        return False
+
+    def _enemy_bishop_has_los_to(self, enemy_color, target_r, target_c):
+        """True iff some bishop (Bishop instance covers real bishops AND
+        queen-as-bishop, since transformation produces a Bishop instance) of
+        `enemy_color` has unblocked diagonal LoS to (target_r, target_c)."""
+        for r in range(ROWS):
+            for c in range(COLS):
+                piece = self.squares[r][c].piece
+                if piece is None or piece.color != enemy_color:
+                    continue
+                if not isinstance(piece, Bishop):
+                    continue
+                dr = target_r - r
+                dc = target_c - c
+                if abs(dr) != abs(dc) or dr == 0:
+                    continue
+                step_r = 1 if dr > 0 else -1
+                step_c = 1 if dc > 0 else -1
+                rr, cc = r + step_r, c + step_c
+                blocked = False
+                while (rr, cc) != (target_r, target_c):
+                    if self.squares[rr][cc].has_piece():
+                        blocked = True
+                        break
+                    rr += step_r
+                    cc += step_c
+                if not blocked:
+                    return True
+        return False
+
+    def _has_unblocked_queen_los(self, from_r, from_c, to_r, to_c):
+        """True iff (from) and (to) are on the same rank/file/diagonal AND
+        all squares strictly between them are empty."""
+        if from_r == to_r and from_c == to_c:
+            return False
+        dr = to_r - from_r
+        dc = to_c - from_c
+        if not (dr == 0 or dc == 0 or abs(dr) == abs(dc)):
+            return False
+        step_r = 0 if dr == 0 else (1 if dr > 0 else -1)
+        step_c = 0 if dc == 0 else (1 if dc > 0 else -1)
+        r, c = from_r + step_r, from_c + step_c
+        while (r, c) != (to_r, to_c):
+            if self.squares[r][c].has_piece():
+                return False
+            r += step_r
+            c += step_c
+        return True
 
     def record_state(self, next_player):
         """Record the current board state in history. Returns the count."""

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -3392,31 +3392,105 @@ class TestRepetitionRule(unittest.TestCase):
         hash2 = board2.get_state_hash('white')
         self.assertNotEqual(hash1, hash2)
 
-    def test_board_state_hash_includes_last_move_on_preceding_turn(self):
-        """The square holding a piece that moved on the immediately preceding
-        turn determines (a) manipulation Restriction 2 — that piece is not
-        manipulable next turn — and (b) knight reactive jump-capture
-        eligibility. Two positions identical except for whether the last
-        spatial move was on the immediately preceding turn MUST differ."""
-        # Build two boards with identical pieces. board1: last_move points
-        # at the immediately preceding turn. board2: no recent move.
+    # 2026-05-26 refinement: last_move only differentiates states when it
+    # actually affects a rule's eligibility (manipulation Restriction 2,
+    # knight reactive jump-capture, or bishop reactive capture). If no
+    # rule consults it, the hash treats it as irrelevant.
+    #
+    # Coordinate convention (verified via test_piece_movement's place):
+    #   d4 → (row=4, col=3); col = file (a=0..h=7), row = rank-1.
+
+    class _StubMove:
+        """Minimal Move-shaped stub for state-hash tests. Constructed with
+        the initial and final (row, col) coordinates of the move."""
+        class _Square:
+            def __init__(self, r, c):
+                self.row = r
+                self.col = c
+        def __init__(self, ir, ic, fr, fc):
+            self.initial = self._Square(ir, ic)
+            self.final = self._Square(fr, fc)
+
+    def test_board_state_hash_includes_last_move_when_queen_los_relevant(self):
+        """Enemy base-form queen with LoS to last_move.final — Restriction 2
+        would block manipulation. The hash MUST differentiate from no-last-move."""
+        # Black rook just moved e4→d4. White base-form queen at a4 has rank LoS
+        # to d4 → Restriction 2 affects white's manipulation legal moves.
+        # a4=(4,0), d4=(4,3), e4=(4,4).
+        board1 = empty_board()
+        place(board1, "a4", Queen('white'))  # base-form queen
+        place(board1, "d4", Rook('black'))
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(4, 4, 4, 3)  # e4(4,4) → d4(4,3)
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "a4", Queen('white'))
+        place(board2, "d4", Rook('black'))
+        board2.turn_number = 5
+        board2.last_move = None
+        board2.last_move_turn_number = None
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_includes_last_move_when_knight_chebyshev_1(self):
+        """Enemy knight at chebyshev-1 of last_move.final — jump-capture is
+        eligible. Hash MUST differentiate."""
+        # c3=(2,2), d4=(4,3); chebyshev distance from c3 to d4 = max(|2-4|,|2-3|)=2. NOT chebyshev-1.
+        # Need a knight closer. Use c5=(4,2) (chebyshev-1 of d4): max(|4-4|,|2-3|)=1. ✓
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        place(board1, "c5", Knight('white'))   # chebyshev-1 of d4
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(4, 4, 4, 3)
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        place(board2, "c5", Knight('white'))
+        board2.turn_number = 5
+        board2.last_move = None
+        board2.last_move_turn_number = None
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_includes_last_move_when_bishop_initial_los(self):
+        """Enemy bishop with diagonal LoS to last_move.initial — bishop
+        reactive eligible. Hash MUST differentiate based on the initial square."""
+        # Rook moved e4→d4. White bishop at h1=(0,7) has diagonal LoS to
+        # e4=(4,4) (the e4-h1 diagonal: e4, f3, g2, h1 with Δfile=Δrank).
+        # f3=(2,5), g2=(1,6), h1=(0,7). Path e4→h1 needs f3 and g2 empty. ✓
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        place(board1, "h1", Bishop('white'))
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4 → final d4
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        place(board2, "h1", Bishop('white'))
+        board2.turn_number = 5
+        board2.last_move = None
+        board2.last_move_turn_number = None
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_omits_last_move_when_no_rule_consults(self):
+        """When NO enemy queen/knight/bishop is in position to consult
+        last_move, the hash MUST be identical to a state with no recent
+        move — last_move doesn't affect any legal move here."""
+        # Only kings + the moved rook — no enemy queen/knight/bishop nearby.
         board1 = empty_board()
         place(board1, "e1", King('white'))
         place(board1, "e8", King('black'))
         place(board1, "d4", Rook('black'))
-        # Simulate a recent move at d4 on the preceding turn.
         board1.turn_number = 5
-
-        class _StubMove:
-            class _Final:
-                def __init__(self, r, c):
-                    self.row = r
-                    self.col = c
-            def __init__(self, r, c):
-                self.final = self._Final(r, c)
-
-        board1.last_move = _StubMove(3, 3)  # final at d4
-        board1.last_move_turn_number = 4  # = turn_number - 1 (preceding turn)
+        board1.last_move = self._StubMove(4, 4, 4, 3)
+        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
@@ -3424,32 +3498,27 @@ class TestRepetitionRule(unittest.TestCase):
         place(board2, "e8", King('black'))
         place(board2, "d4", Rook('black'))
         board2.turn_number = 5
-        # No recent move (or older than preceding turn).
         board2.last_move = None
         board2.last_move_turn_number = None
         hash2 = board2.get_state_hash('white')
-        self.assertNotEqual(hash1, hash2)
+        self.assertEqual(hash1, hash2)
 
     def test_board_state_hash_treats_older_last_move_as_none(self):
-        """last_move from 2+ turns ago should hash identically to no last_move
-        — what matters for Restriction 2 and jump-capture is specifically
-        "on the immediately preceding turn," not "ever happened.\""""
-        class _StubMove:
-            class _Final:
-                def __init__(self, r, c):
-                    self.row = r
-                    self.col = c
-            def __init__(self, r, c):
-                self.final = self._Final(r, c)
-
+        """last_move from 2+ turns ago hashes identically to no last_move
+        — what matters is specifically "on the immediately preceding turn"
+        for all three rules (R2, jump-capture, bishop reactive)."""
+        # Enemy queen IS positioned to make last_move relevant IF preceding-turn,
+        # but the recorded last_move is older. So hash should match no-last-move.
         board1 = empty_board()
+        place(board1, "a4", Queen('white'))
         place(board1, "d4", Rook('black'))
         board1.turn_number = 10
-        board1.last_move = _StubMove(3, 3)
-        board1.last_move_turn_number = 5  # ancient, not preceding turn
+        board1.last_move = self._StubMove(4, 4, 4, 3)
+        board1.last_move_turn_number = 5  # ancient, not the preceding turn
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
+        place(board2, "a4", Queen('white'))
         place(board2, "d4", Rook('black'))
         board2.turn_number = 10
         board2.last_move = None


### PR DESCRIPTION
## Summary

User identified that the previous fix (PR #77) over-differentiated: it added \`last_move.final\` unconditionally when on the preceding turn, so two states with identical per-piece statuses but a different \`last_move.final\` that NO rule actually consults would spuriously hash differently. This biases repetition detection toward missed (false-negative) repetitions.

## Refined design

Include last-move info IF AND ONLY IF some rule consults it at this position. Three rules consult the immediately preceding move:

1. **Manipulation Restriction 2** — queen may not manipulate a piece that moved on the preceding turn. RELEVANT iff some enemy base-form queen has unblocked rank/file/diagonal LoS to \`last_move.final\`.
2. **Knight reactive jump-capture** — RELEVANT iff some enemy knight (real or queen-as-knight) is at chebyshev-1 of \`last_move.final\`.
3. **Bishop reactive capture** — RELEVANT iff some enemy bishop (real or queen-as-bishop) has unblocked diagonal LoS to \`last_move.initial\`.

If none of (1)/(2)/(3) applies — or the moved piece is the boulder, or it was captured during resolution — the hash omits last-move info entirely. Two states identical in per-piece statuses with different last_move squares that are BOTH irrelevant hash to the SAME state. Matches the principle: **same legal-move set ⇒ same hash**.

## Rulebook clarification

Per user feedback, also clarified that \`forbidden_square\` / \`forbidden_zone\` are flags from ALTERNATE manipulation-mode variants (\`original\` / \`exclusion_zone\`), NOT part of the active rule (which uses freeze mode's \`moved_by_queen\`). They're hashed in the code for variant correctness but moved out of the active rulebook's per-piece-flag list and into an implementation note.

## Training impact

Iter 10 had 0 repetition losses (per \`iter_0010.jsonl\`), so the over-differentiating hash from PR #77 didn't affect outcomes. Training can resume from \`model_iter_0010.pt\` with the refined hash. No data loss.

## Test plan

- [x] 5 new state-hash tests covering each rule's relevance check:
  - \`test_board_state_hash_includes_last_move_when_queen_los_relevant\`
  - \`test_board_state_hash_includes_last_move_when_knight_chebyshev_1\`
  - \`test_board_state_hash_includes_last_move_when_bishop_initial_los\`
  - \`test_board_state_hash_omits_last_move_when_no_rule_consults\` (THE key invariant)
  - \`test_board_state_hash_treats_older_last_move_as_none\`
- [x] 29/29 state-hash + repetition tests pass.
- [x] 40/40 tiny endgame + AI training tests pass (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)