### PR TITLE
Fix: state hash uses derived per-piece/per-bishop flags, not literal last_move coords

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -372,14 +372,20 @@ Concretely, a board state includes:
   * **royal flag** (`is_royal`) and **transformed flag** (`is_transformed`) — together, the "queen markers" (form + identity)
   * **manipulation freeze** (`moved_by_queen`, Restriction 1) — a frozen piece cannot make a spatial move on its next turn
   * **invulnerability** — a piece marked invulnerable cannot be captured this turn; this filters opposing captures and so materially changes the legal-move set
+  * **moved-last-turn flag** (derived) — True iff this piece moved on the immediately preceding turn AND some rule actually consults this fact at this position. "Consults" means an enemy base-form queen has queen-LoS to it (Restriction 2 blocks the queen from manipulating it), OR an enemy knight is at chebyshev-1 of it (knight reactive jump-capture is eligible). False otherwise — including when the piece moved but no rule consults, since the legal-move set is then identical to that of a non-moved piece.
+  * **reactive-armed flag** (derived, bishops/queen-as-bishop only) — True iff this bishop is enemy of the piece that moved on the immediately preceding turn AND has unblocked diagonal LoS to that move's INITIAL square. Bishop reactive capture is "armed" at this bishop. False for non-bishops, and for bishops not satisfying both conditions.
 
 * boulder state: its position, **cooldown**, and **no-return memory** (the last square it occupied) — a boulder on cooldown or barred from returning has different legal moves than one without those constraints
 
 * whose turn it is
 
-* **last-move information IF AND ONLY IF it affects some rule's eligibility at this position.** Three rules consult the immediately preceding move: (a) manipulation Restriction 2 (queen may not manipulate a piece that moved on the immediately preceding turn) — consults `last_move.final`; (b) knight reactive jump-capture (jumped piece must have moved on the immediately preceding turn) — also consults `last_move.final`; (c) bishop reactive capture (eligible only if the captured piece began its move on the bishop's diagonal LoS) — consults `last_move.initial`. The state hash includes the relevant square(s) IF some enemy queen/knight/bishop is positioned to actually consult them, and OMITS them otherwise. So two positions identical in all per-piece statuses but differing only in `last_move.final` (or `.initial`) hash to the SAME state when no rule actually consults the change. This avoids over-differentiation: same legal-move set ⇒ same state.
+What is NOT part of the board state for repetition purposes:
 
-What is NOT part of the board state for repetition purposes: the state-history counts of the repetition rule itself, and the distance counts of the tiny endgame rule. These are game-level tracking that the rules use to determine when their respective limits fire; they accumulate across the game but are not properties of the current position.
+* **The literal coordinates of `last_move.final` or `last_move.initial`.** The relevance of last_move to legal moves is captured entirely by the derived per-piece "moved-last-turn" and per-bishop "reactive-armed" flags above. Two positions identical in all per-piece statuses but with different last_move squares hash to the SAME state when no rule actually consults the change. (Example: two states with the same bishop positions and the same set of armed bishops, but different `last_move.initial` squares that happen to lie on the same bishops' diagonal LoS — same legal moves, same hash.)
+* The state-history counts of the repetition rule itself.
+* The distance counts of the tiny endgame rule.
+
+The last two are game-level rule-tracking accumulating across turns, not properties of the current position.
 
 (Implementation note: the code's `get_state_hash` also includes two per-piece flags — `forbidden_square` and `forbidden_zone` — that belong to ALTERNATE manipulation-mode variants (not part of the active rule, which uses `moved_by_queen` freeze). They're hashed for variant correctness but are always `None` under the active rule and so have no effect here.)
 

--- a/docs/design-notes/project_state_hash_design.md
+++ b/docs/design-notes/project_state_hash_design.md
@@ -21,12 +21,18 @@ originSessionId: 953deca3-9d3a-4d54-8ce6-5506efb26872
 **Hashed at game-state level:**
 - boulder state (cooldown + last_square + intersection flag)
 - whose turn it is
-- **last-move info IF AND ONLY IF some rule consults it at this position.** Three rules consult the immediately preceding move:
-  1. Manipulation Restriction 2 — current player's base-form queen may not manipulate a piece that moved on the preceding turn. Consults `last_move.final`. RELEVANT iff an enemy-of-moved-piece base-form queen has unblocked rank/file/diagonal LoS to `last_move.final`.
-  2. Knight reactive jump-capture — a piece that moved on the preceding turn can be jump-captured by an enemy knight positioned at chebyshev-1. Consults `last_move.final`. RELEVANT iff an enemy-of-moved-piece knight (real or queen-as-knight) is at chebyshev-1 of `last_move.final`.
-  3. Bishop reactive capture — captured piece must have begun its move on the bishop's diagonal LoS. Consults `last_move.initial`. RELEVANT iff an enemy-of-moved-piece bishop (real or queen-as-bishop) has unblocked diagonal LoS to `last_move.initial`.
-- The state hash includes the relevant square(s) IF any of (1)/(2)/(3) applies, and OMITS them otherwise. Two states with identical per-piece statuses but differing only in `last_move.final` / `.initial` (where no rule consults the difference) hash to the SAME state — no spurious over-differentiation.
-- Note: boulder moves never trigger any of the three rules (queens can't manipulate boulder; knight/bishop can't capture boulder). If the moved piece is the boulder, no last-move info is hashed.
+
+**NOT hashed: literal `last_move.final` / `last_move.initial` coordinates.** Last-move relevance to legal moves is captured entirely by two DERIVED per-piece/per-bishop flags (above in per-piece section):
+
+1. **`moved_last_turn` flag (per-piece):** True iff this piece moved on the immediately preceding turn AND some enemy base-form queen has queen-LoS (R2 relevance) OR some enemy knight is at chebyshev-1 (jump-capture relevance). Captures both R2 and knight-jump-capture eligibility consequences in one flag.
+2. **`reactive_armed` flag (per-bishop):** True iff this bishop is enemy-of-moved-piece AND has unblocked diagonal LoS to `last_move.initial`. Captures bishop reactive eligibility per bishop.
+
+Why these flags suffice (and the literal coords don't): the legal-move set depends only on whether each rule is "armed" at each relevant piece, not on the literal squares the last move involved. Two states with the same per-piece flags have the same legal-move set, hence the same hash. Two states with different `last_move.initial` that produce the same set of armed bishops (e.g., both initials on the same bishops' diagonals) hash IDENTICALLY — this was the over-differentiation the user caught in the prior design.
+
+Edge cases handled:
+- Boulder moves: boulder color is 'none', so `enemy_of_moved` is undefined → both flags are False for all pieces → hashed as if no last_move.
+- Moved piece captured during resolution: `mp is None` at last_move.final → both flags False everywhere → hashed as if no last_move.
+- Older-than-preceding-turn `last_move`: `last_move_turn_number != turn_number - 1` → flags False everywhere → hashed as if no last_move.
 
 **Deliberately NOT hashed:**
 - The repetition rule's own state-history counts.
@@ -43,15 +49,21 @@ The previous "positional only" design (2026-05-13) included only `is_royal`/`is_
 
 Two positions identical in piece arrangement but differing in any of these flags can have DIFFERENT legal-move sets. The old hash collided them, biasing repetition detection toward false positives. The new hash separates them — but ONLY when the difference actually changes the legal-move set, to avoid the opposite bias (over-differentiation that causes spurious misses). The new framing matches the user's principle exactly: same legal-move set ⇒ same state.
 
-### Conditional inclusion of last-move info
+### Conditional inclusion of last-move info → derived per-piece flags
 
-An initial fix (committed earlier on 2026-05-26) included `last_move.final` unconditionally whenever it pointed to a piece that moved on the immediately preceding turn. User identified this over-differentiated: two states where `last_move.final` differs but neither difference affects ANY rule's eligibility would still hash differently. The refined design includes last-move info ONLY when one of the three rules (manipulation Restriction 2, knight reactive jump-capture, bishop reactive capture) has an enemy piece positioned to consult it. See `Board._last_move_relevance_for_hash` in `src/board.py`.
+An initial fix (PR #77, committed earlier on 2026-05-26) included `last_move.final` unconditionally whenever it pointed to a piece that moved on the immediately preceding turn. User identified this over-differentiated: two states where `last_move.final` differs but neither difference affects ANY rule's eligibility would still hash differently.
+
+A second fix (PR #78, same day) made inclusion of `last_move.final` and `last_move.initial` CONDITIONAL on whether some enemy queen/knight/bishop was positioned to consult them. But this STILL over-differentiated by including the LITERAL coordinates when the relevance check passed: two states with different initial squares that both happened to be on the same bishops' diagonals (producing the same armed-bishop set) would still hash differently.
+
+The final fix (PR #79, same day) eliminates literal coordinates from the hash entirely. Last-move relevance is captured by two derived flags on the per-piece entry: `moved_last_turn` (per-piece, True iff some rule consults this piece's recent move) and `reactive_armed` (per-bishop, True iff this bishop has LoS to last_move.initial). Now two states with the same derived flags hash identically — matching the user's principle exactly.
 
 ## Impact on training (Goal 3)
 
 Prior to the original "positional only" → "all legal-move-affecting state" fix on 2026-05-26, the training (`models/variant_freeze_v3/`) had completed 9 iterations with 0 repetition losses across 900 games (verified in per-game JSONL). The original bug never fired, so the network weights at `model_iter_0009.pt` are valid. Training was paused, the hash fix applied, training resumed from `model_iter_0009.pt`.
 
-After the over-differentiation refinement (conditional inclusion of last-move info), iter 10 had been completed with the over-differentiating hash. Iter 10 also produced 0 repetitions (per `iter_0010.jsonl`), so its data is fine — the over-differentiation doesn't matter when no repetitions actually fire. Training was paused again, the refinement applied, and training resumed from `model_iter_0010.pt`. No data loss across both fixes.
+After PR #78's conditional-inclusion refinement, iter 10 had been completed. Iter 10 also produced 0 repetitions (per `iter_0010.jsonl`), so its data is fine. Training resumed from `model_iter_0010.pt`.
+
+After PR #79's literal-coords → derived-flags refinement, iter 11 had completed (0 repetitions per `iter_0011.jsonl`). Training resumed from `model_iter_0011.pt` with the final correct hash. No data loss across all three fixes.
 
 ## Implementation
 

--- a/src/board.py
+++ b/src/board.py
@@ -680,72 +680,128 @@ class Board:
     def get_state_hash(self, next_player):
         """Compute a hashable representation of the current board state.
 
-        Principle (2026-05-26 update): the hash captures everything that
-        determines the set of legal moves at this position, EXCEPT for
-        the restrictions enforced by the repetition rule itself (the
-        state-history count) and the tiny endgame rule (distance-count
-        history). Those are tracked at the game-state level over time,
-        not as per-position properties. Two positions that look identical
-        in all hashed fields produce identical legal-move sets and so are
-        treated as the same state for repetition purposes.
+        Principle: the hash captures the legal-move set at this position.
+        Two positions with the same hash have the same legal moves; two
+        positions with different hashes have (in principle) different
+        legal moves. Information not affecting the legal-move set is
+        EXCLUDED — including the literal coordinates of `last_move.final`
+        and `last_move.initial`, which we capture via derived per-piece
+        and per-bishop flags instead.
 
-        Hashed per piece:
+        Hashed per piece (every piece on the board contributes an entry):
           - position (row, col)
           - piece type (name) + color + royal flag + transformed flag
           - `moved_by_queen` (Restriction 1 freeze under the active
-            "freeze" manipulation rule): if true, the piece may not make
+            "freeze" manipulation rule): if true, the piece cannot make
             a spatial move on its next turn
-          - `forbidden_square` and `forbidden_zone`: per-piece flags used
-            by alternate manipulation-mode variants (not the active rule
-            set in RULEBOOK_v2.md, but kept in the hash so variant runs
-            under `--manipulation-mode original` / `exclusion_zone`
-            also have correct repetition detection)
+          - `forbidden_square` and `forbidden_zone`: per-piece flags from
+            ALTERNATE manipulation-mode variants (not the active rule;
+            always None under freeze mode but kept here so variant runs
+            under `--manipulation-mode original` / `exclusion_zone` also
+            have correct repetition detection)
           - `invulnerable`: piece cannot be captured (filters opposing
             captures); a transient per-piece status that materially
             changes the legal-move set this turn
+          - `moved_last_turn` (DERIVED): True iff this piece moved on the
+            immediately preceding turn AND some rule consults it at this
+            position. "Consults" means an enemy base-form queen has
+            queen-LoS to this piece (Restriction 2 blocks manipulation)
+            OR an enemy knight is at chebyshev-1 of this piece (knight
+            reactive jump-capture eligible). The flag is False otherwise
+            (including when the piece moved but no rule consults — same
+            legal-move set as a non-moved piece in that situation).
+          - `reactive_armed` (DERIVED, bishops/queen-as-bishop only): True
+            iff this bishop is enemy of the piece that moved on the
+            immediately preceding turn AND has unblocked diagonal LoS to
+            that move's INITIAL square. Bishop reactive eligibility is
+            armed at this bishop. The flag is False for non-bishops and
+            for bishops not enemy of moved piece or not on initial's
+            diagonal LoS.
 
         Hashed at game-state level:
           - boulder state (cooldown + last_square + intersection flag)
           - whose turn it is (`next_player`)
-          - `last_move`-relevance: conditionally included info about the
-            move on the immediately preceding turn (if any) — but only
-            when it actually affects a rule's eligibility at this
-            position. Three rules consult last_move:
-              * Manipulation Restriction 2 — queen may not manipulate a
-                piece that moved on the immediately preceding turn
-              * Knight reactive jump-capture — eligible only if jumped
-                piece moved on the immediately preceding turn
-              * Bishop reactive capture — eligible only if the captured
-                piece began its move on the bishop's diagonal LoS
-            If NO enemy queen / knight / bishop is positioned to consult
-            last_move at this state, the last_move info is omitted from
-            the hash — otherwise two states with identical per-piece
-            statuses but different last_move would spuriously
-            differentiate. See _last_move_relevance_for_hash.
+          - sorted list of invulnerable-piece squares
 
         NOT hashed:
+          - the literal coordinates of `last_move.final` or
+            `last_move.initial` — captured via derived per-piece flags
+            above. Two states with the same per-piece flags but different
+            last_move squares produce the same legal moves and thus the
+            same hash.
           - the prior history of states (the repetition rule's own
             counting machinery)
           - the tiny endgame distance counts (the tiny endgame rule's
             own counting machinery)
-          These are game-state restrictions over time, not properties
-          of the current position; including them would conflate the
-          rule mechanisms with the position they apply to.
+          The last two are game-state restrictions accumulating across
+          turns, not properties of the current position.
         """
+        # Step 1: derive context for last-move flags (if last move was on
+        # the immediately preceding turn AND the moved piece is still on
+        # the board AND is not the boulder).
+        is_preceding = (
+            self.last_move is not None
+            and self.last_move_turn_number is not None
+            and self.last_move_turn_number == self.turn_number - 1
+        )
+        moved_final_r = moved_final_c = -1
+        moved_initial_r = moved_initial_c = -1
+        enemy_of_moved = None  # color whose pieces could consult last_move
+        if is_preceding:
+            moved_final_r = self.last_move.final.row
+            moved_final_c = self.last_move.final.col
+            moved_initial_r = self.last_move.initial.row
+            moved_initial_c = self.last_move.initial.col
+            mp = self.squares[moved_final_r][moved_final_c].piece
+            if mp is None or mp.color == 'none':
+                # Moved piece was captured during resolution, or boulder
+                # moved (boulder doesn't trigger any of the three rules).
+                is_preceding = False
+            else:
+                enemy_of_moved = 'black' if mp.color == 'white' else 'white'
+
         state = []
         for row in range(ROWS):
             for col in range(COLS):
                 piece = self.squares[row][col].piece
-                if piece:
-                    entry = (row, col, piece.name, piece.color,
-                             piece.is_royal, piece.is_transformed,
-                             piece.moved_by_queen,
-                             piece.forbidden_square,
-                             tuple(piece.forbidden_zone) if piece.forbidden_zone else None)
-                    # Boulder has additional state that affects the game
-                    if isinstance(piece, Boulder):
-                        entry = entry + (piece.cooldown, piece.last_square)
-                    state.append(entry)
+                if piece is None:
+                    continue
+                # `moved_last_turn` flag: True iff this piece moved on
+                # the immediately preceding turn AND some enemy queen has
+                # LoS (R2) or some enemy knight is at chebyshev-1
+                # (jump-capture). Captures R2 + knight-jump-capture
+                # eligibility consequences for this piece.
+                moved_last_turn = False
+                if (is_preceding and row == moved_final_r
+                        and col == moved_final_c):
+                    if (self._enemy_base_queen_has_los_to(
+                                enemy_of_moved, row, col)
+                            or self._enemy_knight_at_chebyshev_1(
+                                enemy_of_moved, row, col)):
+                        moved_last_turn = True
+                # `reactive_armed` flag (bishop only): True iff this
+                # bishop is enemy of moved piece AND has unblocked
+                # diagonal LoS to last_move.initial. Captures bishop
+                # reactive eligibility being armed at this bishop.
+                reactive_armed = False
+                if (is_preceding and isinstance(piece, Bishop)
+                        and piece.color == enemy_of_moved):
+                    if self._has_unblocked_diagonal_los(
+                            row, col,
+                            moved_initial_r, moved_initial_c):
+                        reactive_armed = True
+                entry = (row, col, piece.name, piece.color,
+                         piece.is_royal, piece.is_transformed,
+                         piece.moved_by_queen,
+                         piece.forbidden_square,
+                         (tuple(piece.forbidden_zone)
+                          if piece.forbidden_zone else None),
+                         moved_last_turn,
+                         reactive_armed)
+                # Boulder has additional state that affects the game.
+                if isinstance(piece, Boulder):
+                    entry = entry + (piece.cooldown, piece.last_square)
+                state.append(entry)
         # Boulder on intersection (not on any square)
         if self.boulder and self.boulder.on_intersection:
             state.append(('boulder_intersection',
@@ -760,76 +816,7 @@ class Board:
                 if piece and piece.invulnerable:
                     invulnerable_squares.append((row, col))
         state.append(('invulnerable', tuple(sorted(invulnerable_squares))))
-        # Last-move-affecting-legal-moves info. Only included if last_move
-        # actually affects a rule's eligibility at this position — see
-        # _last_move_relevance_for_hash. Two states with identical per-piece
-        # statuses but different last_move final squares should NOT
-        # differentiate unless one of the three relevant rules (manipulation
-        # Restriction 2, knight reactive jump-capture, bishop reactive
-        # capture) actually consults that information here.
-        last_move_relevance = self._last_move_relevance_for_hash()
-        if last_move_relevance is not None:
-            state.append(('last_move_relevant', last_move_relevance))
         return tuple(state)
-
-    def _last_move_relevance_for_hash(self):
-        """Summary of last_move's relevance to legal moves at this position,
-        or None if last_move doesn't affect any rule's eligibility.
-
-        The three rules that consult last_move:
-          1. Manipulation Restriction 2 — current player's queen cannot
-             manipulate a piece that moved on the immediately preceding turn.
-             RELEVANT iff some enemy-of-moved-piece base-form queen has
-             unblocked rank/file/diagonal LoS to last_move.final.
-          2. Knight reactive jump-capture — knight (real or queen-as-knight)
-             jump-captures a piece that moved on the immediately preceding turn.
-             RELEVANT iff some enemy-of-moved-piece knight is at chebyshev-1
-             distance from last_move.final.
-          3. Bishop reactive capture — bishop (real or queen-as-bishop)
-             captures a piece that began its move on the bishop's diagonal LoS.
-             RELEVANT iff some enemy-of-moved-piece bishop has unblocked
-             diagonal LoS to last_move.initial.
-
-        Returns None if (a) last_move was not on the immediately preceding
-        turn, (b) the moved piece is the boulder (none of the three rules
-        apply to boulder), (c) the moved piece was captured mid-resolution
-        and is no longer present, or (d) none of the three rules has any
-        eligibility-consulting enemy piece in position.
-
-        Otherwise returns (final_or_none, initial_or_none) where:
-          - final_or_none = (r, c) of last_move.final if rule 1 or 2 applies,
-            else None
-          - initial_or_none = (r, c) of last_move.initial if rule 3 applies,
-            else None
-        """
-        if (self.last_move is None or self.last_move_turn_number is None
-                or self.last_move_turn_number != self.turn_number - 1):
-            return None
-        final_r = self.last_move.final.row
-        final_c = self.last_move.final.col
-        initial_r = self.last_move.initial.row
-        initial_c = self.last_move.initial.col
-        moved_piece = self.squares[final_r][final_c].piece
-        if moved_piece is None:
-            # Moved piece was captured during resolution; no rule can consult it now.
-            return None
-        if moved_piece.color == 'none':
-            # Boulder: queens cannot manipulate it, knight cannot jump-capture
-            # it, bishop cannot reactive-capture it (only kings capture boulder).
-            return None
-        enemy_color = 'black' if moved_piece.color == 'white' else 'white'
-        final_relevant = (
-            self._enemy_base_queen_has_los_to(enemy_color, final_r, final_c)
-            or self._enemy_knight_at_chebyshev_1(enemy_color, final_r, final_c)
-        )
-        initial_relevant = self._enemy_bishop_has_los_to(
-            enemy_color, initial_r, initial_c)
-        if not final_relevant and not initial_relevant:
-            return None
-        return (
-            (final_r, final_c) if final_relevant else None,
-            (initial_r, initial_c) if initial_relevant else None,
-        )
 
     def _enemy_base_queen_has_los_to(self, enemy_color, target_r, target_c):
         """True iff some base-form queen of `enemy_color` has unblocked
@@ -861,34 +848,26 @@ class Board:
                     return True
         return False
 
-    def _enemy_bishop_has_los_to(self, enemy_color, target_r, target_c):
-        """True iff some bishop (Bishop instance covers real bishops AND
-        queen-as-bishop, since transformation produces a Bishop instance) of
-        `enemy_color` has unblocked diagonal LoS to (target_r, target_c)."""
-        for r in range(ROWS):
-            for c in range(COLS):
-                piece = self.squares[r][c].piece
-                if piece is None or piece.color != enemy_color:
-                    continue
-                if not isinstance(piece, Bishop):
-                    continue
-                dr = target_r - r
-                dc = target_c - c
-                if abs(dr) != abs(dc) or dr == 0:
-                    continue
-                step_r = 1 if dr > 0 else -1
-                step_c = 1 if dc > 0 else -1
-                rr, cc = r + step_r, c + step_c
-                blocked = False
-                while (rr, cc) != (target_r, target_c):
-                    if self.squares[rr][cc].has_piece():
-                        blocked = True
-                        break
-                    rr += step_r
-                    cc += step_c
-                if not blocked:
-                    return True
-        return False
+    def _has_unblocked_diagonal_los(self, from_r, from_c, to_r, to_c):
+        """True iff (from) and (to) are on the same diagonal AND all
+        squares strictly between them are empty. Used to check whether
+        a specific bishop is "armed" for reactive capture, given the
+        moved piece's initial square."""
+        if from_r == to_r and from_c == to_c:
+            return False
+        dr = to_r - from_r
+        dc = to_c - from_c
+        if abs(dr) != abs(dc) or dr == 0:
+            return False
+        step_r = 1 if dr > 0 else -1
+        step_c = 1 if dc > 0 else -1
+        r, c = from_r + step_r, from_c + step_c
+        while (r, c) != (to_r, to_c):
+            if self.squares[r][c].has_piece():
+                return False
+            r += step_r
+            c += step_c
+        return True
 
     def _has_unblocked_queen_los(self, from_r, from_c, to_r, to_c):
         """True iff (from) and (to) are on the same rank/file/diagonal AND

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -3526,6 +3526,107 @@ class TestRepetitionRule(unittest.TestCase):
         hash2 = board2.get_state_hash('white')
         self.assertEqual(hash1, hash2)
 
+    # 2026-05-26 second refinement: literal last_move squares are NOT
+    # hashed directly — only derived per-piece/per-bishop eligibility
+    # flags. So two states with different last_move.initial that produce
+    # the same set of armed bishops hash to the SAME state. Same for
+    # last_move.final via the moved_last_turn flag on the moved piece.
+
+    def test_board_state_hash_same_armed_bishop_set_same_hash_different_initials(self):
+        """Two states with the same set of armed bishops (same per-bishop
+        reactive_armed flags) but DIFFERENT last_move.initial squares
+        hash IDENTICALLY. The armed status is what determines legal moves,
+        not the literal initial coordinate."""
+        # h1=(7,7). Both e4=(4,4) and c6=(2,2) are on h1's a8-h1 diagonal.
+        # So h1 is armed in both states.
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        place(board1, "h1", Bishop('white'))
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4 → final d4
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        place(board2, "h1", Bishop('white'))
+        board2.turn_number = 5
+        # initial c6=(2,2) is also on h1's diagonal. h1 is still armed.
+        board2.last_move = self._StubMove(2, 2, 4, 3)
+        board2.last_move_turn_number = 4
+        hash2 = board2.get_state_hash('white')
+        self.assertEqual(hash1, hash2)
+
+    def test_board_state_hash_different_armed_bishop_set_different_hash(self):
+        """Two states with DIFFERENT sets of armed bishops hash DIFFERENTLY.
+        State1: bishop at h1 armed. State2: bishop at h1 NOT armed."""
+        # state1: initial e4 on h1 diagonal → h1 armed.
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        place(board1, "h1", Bishop('white'))
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        # state2: initial b3=(5,1). h1=(7,7) to b3=(5,1) diff (-2,-6).
+        # NOT diagonal (|Δr|≠|Δc|). h1 NOT armed.
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        place(board2, "h1", Bishop('white'))
+        board2.turn_number = 5
+        board2.last_move = self._StubMove(5, 1, 4, 3)
+        board2.last_move_turn_number = 4
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_board_state_hash_armed_set_subset_difference_distinguished(self):
+        """Two states with the same bishops but different SUBSETS of armed
+        bishops hash differently. Both bishops on the board; only one armed
+        in state1, only the other in state2."""
+        # State1: initial = b2=(6,1).
+        #   Bishop A at h8=(0,7): diff (-6, -6). Diagonal. A ARMED.
+        #   Bishop B at a1=(7,0): diff (1, -1). |1|==|-1|. Diagonal. B ARMED.
+        # Hmm both armed in state1. Let me pick different squares.
+
+        # State1: initial = b7=(1,1). Bishop at h1=(7,7) diff (6, 6). Diagonal. ARMED.
+        # Bishop at a8=(0,0): diff (-1, -1). Diagonal. ARMED. Hmm both armed too.
+        # The geometry of two diagonals through a common point — they cross at a point.
+
+        # Use one bishop on a diagonal and one off.
+        # Bishop A at h1=(7,7). Bishop B at a1=(7,0) (corner, on rank 1).
+        # last_move.initial = b2=(6,1). A: h1 to b2 diff (-1,-6). NOT diag.
+        # B at a1: a1 to b2 diff (-1, 1). Diagonal. B ARMED.
+        # So state1: A NOT armed, B armed.
+
+        # last_move.initial = c3=(5,2). A: h1 to c3 diff (-2,-5). NOT diag.
+        # B at a1: a1 to c3 diff (-2, 2). Diagonal. B ARMED.
+        # Same armed set. Hash same. Not what we want for this test.
+
+        # Let me try harder. State 2: initial = a3=(5,0).
+        # A at h1=(7,7): diff (-2, -7). NOT diag.
+        # B at a1=(7,0): diff (-2, 0). Same file but Δr=2, Δc=0. NOT diag.
+        # Both NOT armed. Different from state1 (B armed in state1, no one in state2).
+        board1 = empty_board()
+        place(board1, "d4", Rook('black'))
+        place(board1, "h1", Bishop('white'))
+        place(board1, "a1", Bishop('white'))
+        board1.turn_number = 5
+        board1.last_move = self._StubMove(6, 1, 4, 3)  # initial b2 — B (a1) armed
+        board1.last_move_turn_number = 4
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        place(board2, "d4", Rook('black'))
+        place(board2, "h1", Bishop('white'))
+        place(board2, "a1", Bishop('white'))
+        board2.turn_number = 5
+        board2.last_move = self._StubMove(5, 0, 4, 3)  # initial a3 — no bishop armed
+        board2.last_move_turn_number = 4
+        hash2 = board2.get_state_hash('white')
+        # Different armed sets ({B} vs {}) → different hash.
+        self.assertNotEqual(hash1, hash2)
+
     # ---- State history tracking ----
 
     def test_state_history_records_positions(self):


### PR DESCRIPTION
## Summary

User caught that PR #78 STILL over-differentiated: it conditionally included the **literal** \`last_move.final\` and \`last_move.initial\` coordinates whenever some rule could consult them. But two states with different \`last_move.initial\` that both lie on the same set of bishops' diagonals produce the **same set of armed bishops** and the **same legal moves** — they should hash IDENTICALLY, not differently.

This PR replaces the literal-coordinate inclusion with two derived per-piece flags:

| Flag | Where | True iff |
|---|---|---|
| \`moved_last_turn\` | every piece | THIS piece moved on the immediately preceding turn AND some enemy base-form queen has queen-LoS to it (R2) OR some enemy knight is at chebyshev-1 of it (jump-capture) |
| \`reactive_armed\` | bishops/queen-as-bishop only | THIS bishop is enemy-of-moved-piece AND has unblocked diagonal LoS to \`last_move.initial\` |

## Effect

- Same set of armed bishops + same moved-last-turn flag on the moved piece ⇒ **same hash** (regardless of literal \`last_move\` coords).
- Different armed-bishop sets or different moved-last-turn flag ⇒ different hash.
- Matches the user's principle: **same legal-move set ⇒ same hash, full stop**.

## Test plan

- [x] 3 new tests for the new invariant:
  - \`test_board_state_hash_same_armed_bishop_set_same_hash_different_initials\` — two states with same armed bishop set but different \`last_move.initial\` hash IDENTICALLY.
  - \`test_board_state_hash_different_armed_bishop_set_different_hash\` — different armed sets ⇒ different hash.
  - \`test_board_state_hash_armed_set_subset_difference_distinguished\` — subset differences distinguished correctly.
- [x] 29 prior state-hash + repetition tests still pass (32/32 total).
- [x] 40/40 tiny endgame + AI training tests pass (no regressions).

## Training impact

Iter 11 had 0 repetition losses (per \`iter_0011.jsonl\`), so PR #78's over-differentiating hash didn't affect outcomes. Training can resume from \`model_iter_0011.pt\` with the final correct hash. No data loss across all three state-hash refinements (PR #77 → #78 → #79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)