### PR TITLE
Fix: boulder no-return memory hashed conditionally on legal-move impact

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -150,7 +150,7 @@ The state includes:
   - **Invulnerability** — an invulnerable piece cannot be captured this turn.
   - **Moved-last-turn** — true for a piece IF it moved on the immediately preceding turn AND some rule consults this fact at the current position (an enemy base-form queen has queen line-of-sight to the piece, blocking manipulation under Restriction 2; OR an enemy knight is at chebyshev-1 of the piece, making jump-capture eligible).
   - **Reactive-armed** (bishops and queens-as-bishop only) — true for a bishop IF it is enemy of the piece that moved on the immediately preceding turn AND has unblocked diagonal line-of-sight to that move's INITIAL square.
-- **Boulder state:** position, cooldown counter, and no-return memory.
+- **Boulder state:** position and cooldown counter. The no-return memory (last square the boulder occupied) is included only when it actually restricts legal moves — that is, when the boulder is not on cooldown AND that square is adjacent to the boulder AND that square is empty. (A pawn there would be capturable by the boulder, overriding no-return; a non-pawn there would block the boulder for other reasons; a non-adjacent square is not in the boulder's destination set anyway.) In all other cases two states differing only in the no-return memory produce the same legal-move set and so are considered the same state.
 - **Whose turn it is.**
 
 Two positions with identical fields above produce identical legal-move sets and are considered the same state, regardless of the move history that led to them.

--- a/docs/design-notes/project_state_hash_design.md
+++ b/docs/design-notes/project_state_hash_design.md
@@ -19,7 +19,7 @@ originSessionId: 953deca3-9d3a-4d54-8ce6-5506efb26872
 - `invulnerable` — captureability filter for opposing pieces
 
 **Hashed at game-state level:**
-- boulder state (cooldown + last_square + intersection flag)
+- boulder state: position (in piece-positions), cooldown counter, intersection flag, AND a conditionally-included `last_square` (no-return memory). `last_square` is included in the hash ONLY when it actually restricts legal moves: boulder not on cooldown AND `last_square` is adjacent to current boulder position AND `last_square` is empty. Otherwise it's hashed as None — because a pawn at `last_square` lets the boulder capture-return (bypassing no-return), a non-pawn at `last_square` blocks the boulder for other reasons (no-return is moot), and a non-adjacent `last_square` is not in the destination set regardless.
 - whose turn it is
 
 **NOT hashed: literal `last_move.final` / `last_move.initial` coordinates.** Last-move relevance to legal moves is captured entirely by two DERIVED per-piece/per-bishop flags (above in per-piece section):

--- a/src/board.py
+++ b/src/board.py
@@ -800,9 +800,26 @@ class Board:
                          reactive_armed)
                 # Boulder has additional state that affects the game.
                 if isinstance(piece, Boulder):
-                    entry = entry + (piece.cooldown, piece.last_square)
+                    # `last_square` only constrains legal moves when the
+                    # no-return rule actually adds a restriction beyond
+                    # other movement rules. That requires:
+                    #   - boulder is not on cooldown (else can't move at all),
+                    #   - last_square is adjacent (chebyshev-1) to the boulder
+                    #     (else not in the destination set anyway),
+                    #   - last_square is empty (else: a pawn there allows the
+                    #     boulder to capture-return, bypassing no-return; a
+                    #     non-pawn there blocks the boulder for other reasons,
+                    #     making no-return moot).
+                    # Two states with different last_square values that all
+                    # fail one of these conditions produce the same legal-move
+                    # set and should hash identically.
+                    effective_last_sq = self._effective_boulder_last_square(
+                        piece, row, col)
+                    entry = entry + (piece.cooldown, effective_last_sq)
                 state.append(entry)
-        # Boulder on intersection (not on any square)
+        # Boulder on intersection (not on any square). When on_intersection
+        # is True the boulder has never moved, so cooldown is 0 and last_square
+        # is None; the intersection flag itself is the only meaningful bit.
         if self.boulder and self.boulder.on_intersection:
             state.append(('boulder_intersection',
                           self.boulder.cooldown, self.boulder.last_square))
@@ -847,6 +864,32 @@ class Board:
                 if isinstance(piece, Knight):
                     return True
         return False
+
+    def _effective_boulder_last_square(self, boulder, boulder_r, boulder_c):
+        """Return the boulder's last_square IFF it actually restricts legal
+        moves at the current position, else None.
+
+        The no-return rule applies only to non-capturing moves; a pawn at
+        last_square allows a capture-return (which bypasses no-return). A
+        non-pawn at last_square blocks the boulder for other reasons (the
+        boulder captures pawns only). So last_square restricts legal moves
+        only when:
+
+          - boulder.cooldown == 0 (boulder can move at all this turn), AND
+          - last_square is adjacent (chebyshev-1) to boulder, AND
+          - last_square is empty.
+
+        Otherwise, two states differing only in last_square produce the
+        same legal-move set and should hash identically.
+        """
+        if boulder.last_square is None or boulder.cooldown > 0:
+            return None
+        last_r, last_c = boulder.last_square
+        if max(abs(last_r - boulder_r), abs(last_c - boulder_c)) != 1:
+            return None
+        if self.squares[last_r][last_c].piece is not None:
+            return None
+        return boulder.last_square
 
     def _has_unblocked_diagonal_los(self, from_r, from_c, to_r, to_c):
         """True iff (from) and (to) are on the same diagonal AND all

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -3627,6 +3627,144 @@ class TestRepetitionRule(unittest.TestCase):
         # Different armed sets ({B} vs {}) → different hash.
         self.assertNotEqual(hash1, hash2)
 
+    # 2026-05-26 boulder no-return-memory refinement: last_square only
+    # restricts legal moves when (cooldown==0 AND last_square is adjacent
+    # AND last_square is empty). A pawn there allows capture-return; a
+    # non-pawn there blocks the boulder for other reasons; a non-adjacent
+    # square is not in the destination set. In all those non-restricting
+    # cases, different last_squares should hash IDENTICALLY.
+
+    def test_boulder_last_square_pawn_at_last_square_no_distinguishment(self):
+        """Two states differing only in boulder.last_square, where BOTH
+        last_squares are occupied by pawns (boulder can capture-return),
+        produce the same legal-move set and MUST hash identically."""
+        # Use rotational-pair last_squares so the other state has the
+        # same pawn distribution.
+        board1 = empty_board()
+        b = Boulder()
+        place(board1, "d4", b)
+        place(board1, "d5", Pawn('white'))  # adjacent to d4
+        place(board1, "e4", Pawn('white'))  # adjacent to d4
+        b.cooldown = 0
+        b.on_intersection = False
+        b.last_square = (4, 4)  # e4 — pawn there
+        board1.boulder = b
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        b2 = Boulder()
+        place(board2, "d4", b2)
+        place(board2, "d5", Pawn('white'))
+        place(board2, "e4", Pawn('white'))
+        b2.cooldown = 0
+        b2.on_intersection = False
+        b2.last_square = (3, 3)  # d5 — pawn there (row=rank-1's complement: d5=(3,3))
+        board2.boulder = b2
+        hash2 = board2.get_state_hash('white')
+        # Both boulders can capture-return to either pawn; same legal moves.
+        self.assertEqual(hash1, hash2)
+
+    def test_boulder_last_square_empty_adjacent_distinguished(self):
+        """Two states differing only in boulder.last_square, where the two
+        last_squares are EMPTY and adjacent, produce DIFFERENT legal-move
+        sets (different no-return excluded squares) and MUST hash differently."""
+        board1 = empty_board()
+        b = Boulder()
+        place(board1, "d4", b)
+        b.cooldown = 0
+        b.on_intersection = False
+        b.last_square = (4, 4)  # e4 empty — no-return blocks e4
+        board1.boulder = b
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        b2 = Boulder()
+        place(board2, "d4", b2)
+        b2.cooldown = 0
+        b2.on_intersection = False
+        b2.last_square = (3, 3)  # d5 empty — no-return blocks d5
+        board2.boulder = b2
+        hash2 = board2.get_state_hash('white')
+        self.assertNotEqual(hash1, hash2)
+
+    def test_boulder_last_square_non_adjacent_no_distinguishment(self):
+        """Two states differing only in boulder.last_square, where the
+        last_squares are non-adjacent to the boulder, hash identically.
+        A non-adjacent last_square is not in the boulder's destination set
+        regardless of no-return."""
+        board1 = empty_board()
+        b = Boulder()
+        place(board1, "d4", b)
+        b.cooldown = 0
+        b.on_intersection = False
+        b.last_square = (0, 0)  # a8 — non-adjacent
+        board1.boulder = b
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        b2 = Boulder()
+        place(board2, "d4", b2)
+        b2.cooldown = 0
+        b2.on_intersection = False
+        b2.last_square = (7, 7)  # h1 — non-adjacent
+        board2.boulder = b2
+        hash2 = board2.get_state_hash('white')
+        self.assertEqual(hash1, hash2)
+
+    def test_boulder_last_square_on_cooldown_no_distinguishment(self):
+        """When the boulder is on cooldown, it cannot move at all this
+        turn; last_square is irrelevant. Two states with different
+        last_squares but the same positive cooldown should hash identically
+        (assuming all other state matches)."""
+        board1 = empty_board()
+        b = Boulder()
+        place(board1, "d4", b)
+        b.cooldown = 2  # blocked
+        b.on_intersection = False
+        b.last_square = (4, 4)  # e4 empty
+        board1.boulder = b
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        b2 = Boulder()
+        place(board2, "d4", b2)
+        b2.cooldown = 2  # also blocked
+        b2.on_intersection = False
+        b2.last_square = (3, 3)  # d5 empty (different from board1)
+        board2.boulder = b2
+        hash2 = board2.get_state_hash('white')
+        self.assertEqual(hash1, hash2)
+
+    def test_boulder_last_square_non_pawn_no_distinguishment(self):
+        """Two states differing only in boulder.last_square, where each
+        last_square holds a non-pawn piece (boulder can't capture non-pawns,
+        so can't move there regardless of no-return), hash identically."""
+        # Place a non-pawn (rook) at each last_square. The OTHER configuration
+        # must match for this to isolate the last_square question — so we
+        # use the same non-pawn pair in both boards, just vary last_square.
+        board1 = empty_board()
+        b = Boulder()
+        place(board1, "d4", b)
+        place(board1, "d5", Rook('white'))
+        place(board1, "e4", Rook('white'))
+        b.cooldown = 0
+        b.on_intersection = False
+        b.last_square = (3, 3)  # d5 — rook there
+        board1.boulder = b
+        hash1 = board1.get_state_hash('white')
+
+        board2 = empty_board()
+        b2 = Boulder()
+        place(board2, "d4", b2)
+        place(board2, "d5", Rook('white'))
+        place(board2, "e4", Rook('white'))
+        b2.cooldown = 0
+        b2.on_intersection = False
+        b2.last_square = (4, 4)  # e4 — rook there
+        board2.boulder = b2
+        hash2 = board2.get_state_hash('white')
+        self.assertEqual(hash1, hash2)
+
     # ---- State history tracking ----
 
     def test_state_history_records_positions(self):


### PR DESCRIPTION
## Summary

User identified the final over-differentiation case in the state hash: the boulder's \`last_square\` (no-return memory) was always hashed directly, but two states with different \`last_square\` values can produce identical legal-move sets.

## The four non-restricting cases

The no-return rule only restricts legal moves when ALL three hold:
- Boulder is not on cooldown.
- \`last_square\` is adjacent (chebyshev-1) to the boulder.
- \`last_square\` is empty.

Otherwise the rule does NOT restrict legal moves:

| Case | Why no-return is moot |
|---|---|
| Pawn at \`last_square\` | Boulder can capture-return there (no-return exception for captures). |
| Non-pawn at \`last_square\` | Boulder can't move there anyway (captures pawns only). |
| Non-adjacent \`last_square\` | Not in boulder's destination set regardless. |
| Boulder on cooldown | Boulder can't move at all this turn. |

In all four cases, two states differing only in \`last_square\` produce the same legal-move set and so should hash IDENTICALLY.

## Test plan

5 new tests in \`tests/test_piece_movement.py::TestRepetitionRule\`:
- \`test_boulder_last_square_pawn_at_last_square_no_distinguishment\` — pawn at last_square ⇒ same hash regardless.
- \`test_boulder_last_square_empty_adjacent_distinguished\` — empty adjacent ⇒ different hash (genuinely different legal moves).
- \`test_boulder_last_square_non_adjacent_no_distinguishment\` — non-adjacent ⇒ same hash.
- \`test_boulder_last_square_on_cooldown_no_distinguishment\` — cooldown blocks ⇒ same hash.
- \`test_boulder_last_square_non_pawn_no_distinguishment\` — non-pawn at last_square ⇒ same hash.

All 37 state-hash + repetition tests pass.

## Training impact

0 repetition events across all 25 iterations of the training run so far (per the per-game JSONL data), so the bug never fired in practice. Training resumes from \`model_iter_0025.pt\` with the corrected hash. No data loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)