### PR TITLE
Rulebook split: long boulder clarification → elaborated; tight rule → concise

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -150,7 +150,7 @@ The state includes:
   - **Invulnerability** — an invulnerable piece cannot be captured this turn.
   - **Moved-last-turn** — true for a piece IF it moved on the immediately preceding turn AND some rule consults this fact at the current position (an enemy base-form queen has queen line-of-sight to the piece, blocking manipulation under Restriction 2; OR an enemy knight is at chebyshev-1 of the piece, making jump-capture eligible).
   - **Reactive-armed** (bishops and queens-as-bishop only) — true for a bishop IF it is enemy of the piece that moved on the immediately preceding turn AND has unblocked diagonal line-of-sight to that move's INITIAL square.
-- **Boulder state:** position and cooldown counter. The no-return memory (last square the boulder occupied) is included only when it actually restricts legal moves — that is, when the boulder is not on cooldown AND that square is adjacent to the boulder AND that square is empty. (A pawn there would be capturable by the boulder, overriding no-return; a non-pawn there would block the boulder for other reasons; a non-adjacent square is not in the boulder's destination set anyway.) In all other cases two states differing only in the no-return memory produce the same legal-move set and so are considered the same state.
+- **Boulder state:** position, cooldown, and no-return memory. The no-return memory is part of the state ONLY when it would restrict the boulder's legal moves — i.e., the boulder is not on cooldown, the memory square is adjacent to the boulder, and that square is empty.
 - **Whose turn it is.**
 
 Two positions with identical fields above produce identical legal-move sets and are considered the same state, regardless of the move history that led to them.

--- a/docs/RULEBOOK_v2_elaborated.md
+++ b/docs/RULEBOOK_v2_elaborated.md
@@ -380,7 +380,19 @@ Concretely, a board state includes:
   * **moved-last-turn flag** (derived) — True iff this piece moved on the immediately preceding turn AND some rule actually consults this fact at this position. "Consults" means an enemy base-form queen has queen-LoS to it (Restriction 2 blocks the queen from manipulating it), OR an enemy knight is at chebyshev-1 of it (knight reactive jump-capture is eligible). False otherwise — including when the piece moved but no rule consults, since the legal-move set is then identical to that of a non-moved piece.
   * **reactive-armed flag** (derived, bishops/queen-as-bishop only) — True iff this bishop is enemy of the piece that moved on the immediately preceding turn AND has unblocked diagonal LoS to that move's INITIAL square. Bishop reactive capture is "armed" at this bishop. False for non-bishops, and for bishops not satisfying both conditions.
 
-* boulder state: its position, **cooldown**, and **no-return memory** (the last square it occupied) — a boulder on cooldown or barred from returning has different legal moves than one without those constraints
+* boulder state: its position, **cooldown**, and **conditionally-included no-return memory**.
+
+  The no-return memory (the last square the boulder occupied) is hashed only when it actually restricts the boulder's legal moves at this position. That requires ALL THREE of:
+  - the boulder is not on cooldown (else it cannot move at all this turn, and last_square is irrelevant);
+  - last_square is adjacent (chebyshev-1) to the boulder's current position (else last_square is not in the boulder's destination set regardless);
+  - last_square is empty (else the no-return restriction is moot for one of two reasons below).
+
+  Why "empty" specifically:
+  - **A pawn at last_square** allows the boulder to capture-return to that square (the no-return rule applies only to non-capturing moves, and the rulebook explicitly carves out the pawn-capture exception). So the no-return restriction does not apply; the boulder may move there.
+  - **A non-pawn at last_square** blocks the boulder for another reason: the boulder may capture pawns only, so it cannot move onto a non-pawn at all. The no-return restriction adds no further constraint.
+  - **An empty last_square** is the only case where no-return actually subtracts a destination from the boulder's legal moves.
+
+  In all other cases (cooldown blocking all moves; non-adjacent last_square; pawn or non-pawn at last_square), two states differing only in the no-return memory produce the same set of boulder legal moves and the same overall legal-move set, so they hash IDENTICALLY. Including the literal last_square in those cases would spuriously distinguish positions that are actually the same.
 
 * whose turn it is
 


### PR DESCRIPTION
## Summary

Per user feedback: the boulder's conditionally-hashed no-return memory had a verbose explanation in the concise rulebook. That level of elaboration belongs in the elaborated rulebook; the concise rulebook should state the rule precisely without enumerating every non-restricting case.

## Changes

- **\`docs/RULEBOOK_v2_elaborated.md\`** — added the full explanation: the three conjunctive conditions for inclusion, the four non-restricting cases (cooldown blocks all moves; non-adjacent square; pawn at last_square allows capture-return; non-pawn at last_square blocks for other reasons), and why each non-restricting case does NOT add a constraint.

- **\`RULEBOOK_v2.md\`** — replaced the long boulder bullet with a single tight sentence: \"The no-return memory is part of the state ONLY when it would restrict the boulder's legal moves — i.e., the boulder is not on cooldown, the memory square is adjacent to the boulder, and that square is empty.\"

No code changes. Rule semantics unchanged. State-hash tests untouched (still 37/37 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)