### PR TITLE
Mode menu: Easy / Medium / Hard AI difficulty entries; Easy available now

### DIFF
--- a/src/ai_controller.py
+++ b/src/ai_controller.py
@@ -81,7 +81,10 @@ class AIController:
         turns = self.legal_turns(game)
         if not turns:
             return False
-        turn = self.player.choose_turn(turns)
+        # Pass the engine through to choose_turn so neural-network players
+        # can simulate the resulting positions for evaluation. RandomPlayer
+        # ignores the engine argument (kept for API parity).
+        turn = self.player.choose_turn(turns, self._engine)
         if turn is None:
             return False
         self._apply_turn(game, turn)

--- a/src/game.py
+++ b/src/game.py
@@ -1,4 +1,5 @@
 import copy
+import os
 
 import pygame
 from pygame import gfxdraw
@@ -11,6 +12,10 @@ from config import Config
 from square import Square
 from piece import Queen, Boulder
 from shield_polygons import SHIELD_POLYGONS
+
+
+# Repo root used to resolve AI checkpoint paths.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
 
 # Corner positions for overlays placed on a piece's square. Each overlay
@@ -214,7 +219,21 @@ class Game:
     OPPONENT_OPTIONS = [
         {'key': 'human',  'label': 'Human (2 players)'},
         {'key': 'random', 'label': 'Random'},
+        {'key': 'easy',   'label': 'AI Easy'},
+        {'key': 'medium', 'label': 'AI Medium'},
+        {'key': 'hard',   'label': 'AI Hard'},
     ]
+
+    # AI difficulty → checkpoint path. Difficulty is realised by training
+    # depth: an under-trained network is "easy" because it still picks
+    # near-random moves; a fully-trained network is "hard". Medium and
+    # hard checkpoints become available as training progresses; the menu
+    # grays out entries whose checkpoint does not exist on disk.
+    _AI_CHECKPOINTS = {
+        'easy':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0010.pt'),
+        'medium': os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0050.pt'),
+        'hard':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0100.pt'),
+    }
 
     def __init__(self, knight_mode=Board.KNIGHT_MODE_V2):
         """Construct a Game. `knight_mode` controls which knight rules
@@ -559,14 +578,43 @@ class Game:
             self.ai_color, player=self._make_ai_player(self.opponent))
 
     def _make_ai_player(self, opponent_key):
-        """Construct the AI player for a given opponent key. Extension point:
-        add branches here for future difficulty levels (Easy / Medium / Hard
-        AI). Returning None lets AIController default to its RandomPlayer
-        baseline."""
+        """Construct the AI player for a given opponent key.
+
+        - 'random'         → returns None, letting AIController default to
+          its built-in RandomPlayer baseline.
+        - 'easy' / 'medium' / 'hard' → loads the corresponding network
+          checkpoint and wraps it in a NeuralPlayer (with the network's
+          training depth as the difficulty dial — see _AI_CHECKPOINTS).
+          The CPU device is used to keep the UI's network independent of
+          any concurrently-running training on MPS/CUDA.
+
+        Raises ValueError for unknown keys. For AI keys whose checkpoint
+        is missing, returns None and falls back to RandomPlayer so the
+        game stays playable; this should not normally happen because the
+        mode menu grays out unavailable options and skips their clicks.
+        """
         if opponent_key == 'random':
             return None  # AIController defaults to RandomPlayer
+        if opponent_key in self._AI_CHECKPOINTS:
+            ckpt = self._AI_CHECKPOINTS[opponent_key]
+            if not os.path.exists(ckpt):
+                return None  # Falls back to RandomPlayer in AIController.
+            # Lazy import: keep torch out of the import graph for the
+            # non-AI code paths.
+            from network import ValueNetwork
+            from trainer import NeuralPlayer
+            network = ValueNetwork.load(ckpt, device='cpu')
+            return NeuralPlayer(network, device='cpu', epsilon=0.0)
         raise ValueError(
             f"No player implementation for opponent {opponent_key!r}")
+
+    def _ai_checkpoint_available(self, opponent_key):
+        """True iff the opponent key is either a non-AI key or has its
+        checkpoint file on disk. Used by show_mode_menu to gray out and
+        deactivate options whose checkpoint does not yet exist."""
+        if opponent_key not in self._AI_CHECKPOINTS:
+            return True  # 'human', 'random' — always available
+        return os.path.exists(self._AI_CHECKPOINTS[opponent_key])
 
     def is_any_menu_open(self):
         """True iff a UI selection menu is currently open. main.py uses this
@@ -615,15 +663,29 @@ class Game:
                 rect = pygame.Rect(
                     row_left + i * (btn_w + gap), row_y, btn_w, btn_h)
                 active = (opt['key'] == current_key)
+                # AI opponents whose checkpoint isn't on disk yet render
+                # dimmer and are NOT added to mode_menu_rects, so clicks
+                # on them are ignored.
+                available = (group_key != 'opponent'
+                             or self._ai_checkpoint_available(opt['key']))
+                if available:
+                    bg = (80, 140, 200) if active else (60, 60, 60)
+                    border = (200, 200, 200)
+                    text_color = (255, 255, 255)
+                else:
+                    # Unavailable AI options: dim background + dim text.
+                    bg = (40, 40, 40)
+                    border = (100, 100, 100)
+                    text_color = (130, 130, 130)
+                pygame.draw.rect(surface, bg, rect, border_radius=6)
                 pygame.draw.rect(
-                    surface, (80, 140, 200) if active else (60, 60, 60),
-                    rect, border_radius=6)
-                pygame.draw.rect(
-                    surface, (200, 200, 200), rect, width=2, border_radius=6)
+                    surface, border, rect, width=2, border_radius=6)
                 label_surf = option_font.render(
-                    opt['label'], True, (255, 255, 255))
+                    opt['label'], True, text_color)
                 surface.blit(label_surf, label_surf.get_rect(center=rect.center))
-                self.mode_menu_rects.append((rect, group_key, opt['key']))
+                if available:
+                    self.mode_menu_rects.append(
+                        (rect, group_key, opt['key']))
             return row_y + btn_h
 
         bottom = render_section(

--- a/src/players.py
+++ b/src/players.py
@@ -9,8 +9,12 @@ class RandomPlayer:
     """Picks uniformly at random from all legal turns.
     For multi-step turns (jump capture, promotion), also picks randomly."""
 
-    def choose_turn(self, turns):
-        """Select a turn from the list of legal turns."""
+    def choose_turn(self, turns, engine=None):
+        """Select a turn from the list of legal turns.
+
+        `engine` is accepted for API parity with NeuralPlayer (which needs
+        the engine to simulate turns). RandomPlayer ignores it.
+        """
         if not turns:
             return None
         return random.choice(turns)

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -61,6 +61,15 @@ class NeuralPlayer:
         self.network = network
         self.device = device
         self.epsilon = epsilon
+        # Sub-decision delegate: jump-capture decline-or-target and pawn-
+        # promotion piece choice. The trainer's self-play path doesn't
+        # consult these (it enumerates each variant as a separate Turn),
+        # but the UI's AIController calls choose_jump_capture and
+        # choose_promotion as separate steps after the main turn is chosen.
+        # Random is sufficient for the easy-mode use case; can be replaced
+        # with network-evaluated sub-decisions later for stronger AI.
+        from players import RandomPlayer
+        self._fallback = RandomPlayer()
 
     def choose_turn(self, turns, engine):
         """Select the best turn using batch network evaluation.
@@ -90,6 +99,16 @@ class NeuralPlayer:
 
         best_idx = np.argmax(our_win_probs)
         return turns[best_idx]
+
+    def choose_jump_capture(self, targets):
+        """Choose whether to accept the offered jump-capture. Delegates
+        to a RandomPlayer (sufficient for the UI's easy-mode use case;
+        the network is used for the main turn choice)."""
+        return self._fallback.choose_jump_capture(targets)
+
+    def choose_promotion(self, options):
+        """Choose a promotion form. Delegates to a RandomPlayer."""
+        return self._fallback.choose_promotion(options)
 
     def _collect_turn_states(self, turns, engine):
         """Simulate all turns and collect encoded board states.

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -80,6 +80,56 @@ def test_opponent_options_catalog_has_human_and_random():
         assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
 
 
+def test_opponent_options_includes_ai_difficulties():
+    """Easy / Medium / Hard difficulty entries exist for the AI modes."""
+    keys = [opt['key'] for opt in Game.OPPONENT_OPTIONS]
+    assert 'easy' in keys
+    assert 'medium' in keys
+    assert 'hard' in keys
+
+
+def test_ai_checkpoint_paths_configured():
+    """The class-level _AI_CHECKPOINTS dict maps each AI difficulty key to a
+    concrete checkpoint path (resolvable to a string; may or may not exist
+    on disk depending on training progress)."""
+    g = Game()
+    assert 'easy' in Game._AI_CHECKPOINTS
+    assert 'medium' in Game._AI_CHECKPOINTS
+    assert 'hard' in Game._AI_CHECKPOINTS
+    for key in ('easy', 'medium', 'hard'):
+        path = Game._AI_CHECKPOINTS[key]
+        assert isinstance(path, str)
+        assert path.endswith('.pt')
+
+
+def test_ai_checkpoint_available_for_non_ai_keys():
+    """`human` and `random` are always 'available' (not gated by a
+    checkpoint)."""
+    g = Game()
+    assert g._ai_checkpoint_available('human') is True
+    assert g._ai_checkpoint_available('random') is True
+
+
+def test_make_ai_player_random_returns_none():
+    """`random` opponent key returns None (AIController falls back to its
+    built-in RandomPlayer)."""
+    g = Game()
+    assert g._make_ai_player('random') is None
+
+
+def test_make_ai_player_easy_when_checkpoint_missing_falls_back():
+    """If the easy checkpoint isn't on disk, _make_ai_player returns None
+    so the AIController falls back to RandomPlayer rather than crashing."""
+    g = Game()
+    # Temporarily point easy to a non-existent path.
+    saved = Game._AI_CHECKPOINTS['easy']
+    Game._AI_CHECKPOINTS['easy'] = '/nonexistent/never/here.pt'
+    try:
+        assert g._make_ai_player('easy') is None
+    finally:
+        Game._AI_CHECKPOINTS['easy'] = saved
+
+
 # --- open / close menu ------------------------------------------------------
 
 def test_open_close_mode_menu():
@@ -228,7 +278,15 @@ def test_show_mode_menu_populates_rects_for_both_groups_when_open():
     n_sides = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'side')
     n_opps = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'opponent')
     assert n_sides == len(Game.SIDE_OPTIONS)
-    assert n_opps == len(Game.OPPONENT_OPTIONS)
+    # Opponent options whose AI checkpoint is missing are deliberately
+    # excluded from mode_menu_rects (rendered dim, not clickable). So the
+    # rect count equals the number of opponents whose checkpoint exists
+    # (or which aren't AI keys at all).
+    expected_opps = sum(
+        1 for opt in Game.OPPONENT_OPTIONS
+        if g._ai_checkpoint_available(opt['key']))
+    assert n_opps == expected_opps
+    assert n_opps >= 2  # 'human' and 'random' are always available
     for rect, group, key in g.mode_menu_rects:
         assert isinstance(rect, pygame.Rect)
         assert group in ('side', 'opponent')


### PR DESCRIPTION
## Summary

Surface Easy/Medium/Hard difficulty options in the in-UI mode-selection menu. Easy is functional now using an early training checkpoint (\`model_iter_0010.pt\`). Medium and Hard render dim and ignore clicks until their checkpoints exist on disk.

**Difficulty as training-depth.** An under-trained network picks near-random moves and is \"easy\"; a fully-trained network is \"hard\". Specifically:

| Difficulty | Checkpoint | Status |
|---|---|---|
| Easy | \`models/variant_freeze_v3/model_iter_0010.pt\` | Available (training has passed iter 10) |
| Medium | \`models/variant_freeze_v3/model_iter_0050.pt\` | Will become available when training reaches iter 50 |
| Hard | \`models/variant_freeze_v3/model_iter_0100.pt\` | Will become available when training reaches iter 100 |

Update \`Game._AI_CHECKPOINTS\` to repoint after future training runs.

## Changes

- **\`src/players.py\`** — \`RandomPlayer.choose_turn\` accepts an optional \`engine\` arg for API parity with NeuralPlayer.
- **\`src/trainer.py\`** — \`NeuralPlayer\` gains \`choose_jump_capture\` and \`choose_promotion\` methods (random delegate via an internal RandomPlayer), satisfying AIController's 3-method player contract.
- **\`src/ai_controller.py\`** — \`take_turn\` passes \`self._engine\` to \`player.choose_turn\` for network-based players.
- **\`src/game.py\`** —
  - OPPONENT_OPTIONS extended with \`easy\`/\`medium\`/\`hard\`.
  - New class attr \`_AI_CHECKPOINTS\` maps each difficulty to its checkpoint path (resolved relative to repo root).
  - \`_make_ai_player\` loads ValueNetwork from the checkpoint (CPU device — independent of concurrent training on MPS) and wraps it in NeuralPlayer with epsilon=0.
  - \`_ai_checkpoint_available\` helper.
  - \`show_mode_menu\` renders unavailable AI options dim and excludes them from \`mode_menu_rects\` so their clicks pass through.

## Test plan

- [x] 38/38 mode selection + AI controller tests pass.
- [x] Updated rect-count test to expect only available opponents.
- [x] 5 new tests: OPPONENT_OPTIONS catalog, _AI_CHECKPOINTS structure, non-AI keys always-available, random returns None, missing-checkpoint fallback.
- [x] End-to-end smoke test (script):
  - \`g._make_ai_player('easy')\` returns a NeuralPlayer with all 3 decision methods.
  - \`g.ai_controller.take_turn(g)\` picks and applies a turn in ~400 ms on CPU.

## Concurrent training

Easy NeuralPlayer uses CPU device. The running training process uses MPS. They don't compete for the same accelerator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)