### PR TITLE
NeuralPlayer: evaluate (move + jump + promo) combinations as one decision; menu vertical

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -648,20 +648,45 @@ class Game:
             (255, 255, 255))
         surface.blit(title, title.get_rect(center=(w // 2, h // 6)))
 
-        def render_section(label, opts, group_key, current_key, section_top):
+        def render_section(label, opts, group_key, current_key, section_top,
+                           orientation='horizontal'):
+            """Render a section title and a row (or column) of buttons.
+
+            orientation='horizontal' is used for the 'Your side' row (2
+            options fit easily). orientation='vertical' stacks buttons one
+            per line — used for 'Opponent' so the menu doesn't overflow
+            the screen width as AI difficulty entries are added.
+
+            Returns the y-coordinate just below the last button (so the
+            caller can stack the next section).
+            """
             section_label = section_font.render(label, True, (220, 220, 220))
             surface.blit(section_label, section_label.get_rect(
                 center=(w // 2, section_top)))
-            btn_h = 44
-            btn_w = min(180, int(w * 0.22))
-            gap = 16
-            row_y = section_top + 38
-            n = len(opts)
-            row_w = n * btn_w + (n - 1) * gap
-            row_left = (w - row_w) // 2
+            btn_h = 40
+            gap = 10
+            top_y = section_top + 34
+
+            if orientation == 'horizontal':
+                btn_w = min(180, int(w * 0.22))
+                n = len(opts)
+                row_w = n * btn_w + (n - 1) * gap
+                row_left = (w - row_w) // 2
+                def rect_for(i):
+                    return pygame.Rect(
+                        row_left + i * (btn_w + gap), top_y, btn_w, btn_h)
+                end_y = top_y + btn_h
+            else:  # 'vertical'
+                btn_w = min(240, int(w * 0.32))
+                col_left = (w - btn_w) // 2
+                def rect_for(i):
+                    return pygame.Rect(
+                        col_left, top_y + i * (btn_h + gap), btn_w, btn_h)
+                n = len(opts)
+                end_y = top_y + n * btn_h + (n - 1) * gap
+
             for i, opt in enumerate(opts):
-                rect = pygame.Rect(
-                    row_left + i * (btn_w + gap), row_y, btn_w, btn_h)
+                rect = rect_for(i)
                 active = (opt['key'] == current_key)
                 # AI opponents whose checkpoint isn't on disk yet render
                 # dimmer and are NOT added to mode_menu_rects, so clicks
@@ -686,14 +711,17 @@ class Game:
                 if available:
                     self.mode_menu_rects.append(
                         (rect, group_key, opt['key']))
-            return row_y + btn_h
+            return end_y
 
+        # 'Your side' stays horizontal (2 options fit naturally).
+        # 'Opponent' renders vertically so the menu doesn't overflow the
+        # screen width as more difficulty entries are added.
         bottom = render_section(
             'Your side', self.mode_menu['sides'], 'side',
-            self.user_side, h // 3)
+            self.user_side, h // 4, orientation='horizontal')
         render_section(
             'Opponent', self.mode_menu['opponents'], 'opponent',
-            self.opponent, bottom + 40)
+            self.opponent, bottom + 32, orientation='vertical')
 
     def show_transform_menu(self, surface):
         """Draw the vertical strip transformation menu."""

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -61,54 +61,112 @@ class NeuralPlayer:
         self.network = network
         self.device = device
         self.epsilon = epsilon
-        # Sub-decision delegate: jump-capture decline-or-target and pawn-
-        # promotion piece choice. The trainer's self-play path doesn't
-        # consult these (it enumerates each variant as a separate Turn),
-        # but the UI's AIController calls choose_jump_capture and
-        # choose_promotion as separate steps after the main turn is chosen.
-        # Random is sufficient for the easy-mode use case; can be replaced
-        # with network-evaluated sub-decisions later for stronger AI.
-        from players import RandomPlayer
-        self._fallback = RandomPlayer()
+        # Sub-choices (jump-capture target/decline, promotion form) are
+        # decided as part of choose_turn — each combination (move +
+        # jump_choice + promo_choice) is enumerated as a distinct option
+        # and the network evaluates them all in one batch. choose_turn
+        # stores the winning sub-choices here, and choose_jump_capture /
+        # choose_promotion just return them when asked.
+        self._pending_jump_choice = None
+        self._pending_promo_choice = None
 
     def choose_turn(self, turns, engine):
-        """Select the best turn using batch network evaluation.
+        """Select the best (move + sub-choices) combination using one batch
+        network evaluation.
 
-        Simulates all legal turns, encodes the resulting positions, evaluates
-        them in a single batch GPU call, and picks the turn with the highest
-        win probability.
+        For each candidate Turn, enumerates every combination of secondary
+        choices (jump-capture target/decline; pawn-promotion form). Each
+        combination is treated as a distinct option, simulated to its
+        resulting board state, and evaluated in a single batched forward
+        pass. The combination with highest win probability is selected; its
+        sub-choices are stored on the player and returned later by
+        choose_jump_capture / choose_promotion.
+
+        This unification (vs the older multi-step approach that picked the
+        move first and only then evaluated sub-choices) ensures the network
+        sees each full combination as one option — preventing the case
+        where the best (move A, decline) loses to (move B, accept) but the
+        sub-step pipeline picks (move A, decline) anyway because it
+        evaluated "best move first" without knowing the eventual
+        sub-choice.
 
         Args:
             turns: list of Turn objects from engine.get_all_legal_turns()
             engine: GameEngine instance (needed to simulate moves)
 
         Returns:
-            chosen Turn object
+            chosen Turn object (sub-choices stored on `self`)
         """
+        # Clear sub-choices from any previous call.
+        self._pending_jump_choice = None
+        self._pending_promo_choice = None
+
         if not turns:
             return None
 
-        # Epsilon-greedy exploration
+        # Epsilon-greedy exploration: pick a random turn, then random
+        # sub-choices independently. (Picking a random combination is
+        # equivalent in distribution if sub-choice counts are equal across
+        # turns; the simpler per-step random suffices for exploration.)
         if random.random() < self.epsilon:
-            return random.choice(turns)
+            turn = random.choice(turns)
+            if turn.jump_capture_targets:
+                self._pending_jump_choice = random.choice(
+                    list(turn.jump_capture_targets) + [None])
+            if turn.promotion_options:
+                self._pending_promo_choice = random.choice(
+                    list(turn.promotion_options))
+            return turn
 
-        # Batch evaluate: simulate all turns, encode results, one forward pass
-        states = self._collect_turn_states(turns, engine)
+        # Enumerate (turn, jump_choice, promo_choice) combinations.
+        combinations = []
+        for turn in turns:
+            if turn.turn_type == 'transformation' or not turn.move_obj:
+                combinations.append((turn, None, None))
+                continue
+            jump_options = (list(turn.jump_capture_targets) + [None]
+                            if turn.jump_capture_targets else [None])
+            promo_options = (list(turn.promotion_options)
+                             if turn.promotion_options else [None])
+            for jc in jump_options:
+                for pc in promo_options:
+                    combinations.append((turn, jc, pc))
+
+        # Batch-evaluate every combination.
+        board = engine.board
+        opponent = 'black' if engine.current_player == 'white' else 'white'
+        next_turn_num = engine.turn_number + 1
+        states = []
+        for turn, jc, pc in combinations:
+            if turn.turn_type == 'transformation':
+                state = self._simulate_transformation(
+                    board, turn, opponent, next_turn_num)
+            else:
+                state = self._simulate_move(
+                    board, turn, opponent, next_turn_num,
+                    jump_choice=jc, promo_choice=pc)
+            states.append(state)
+
         opp_win_probs = self.network.predict_batch(np.array(states))
         our_win_probs = 1.0 - opp_win_probs
-
         best_idx = np.argmax(our_win_probs)
-        return turns[best_idx]
+
+        chosen_turn, chosen_jc, chosen_pc = combinations[best_idx]
+        self._pending_jump_choice = chosen_jc
+        self._pending_promo_choice = chosen_pc
+        return chosen_turn
 
     def choose_jump_capture(self, targets):
-        """Choose whether to accept the offered jump-capture. Delegates
-        to a RandomPlayer (sufficient for the UI's easy-mode use case;
-        the network is used for the main turn choice)."""
-        return self._fallback.choose_jump_capture(targets)
+        """Return the jump-capture sub-choice already decided as part of
+        choose_turn (which evaluated every (move + jump_choice +
+        promo_choice) combination in a single batch). `targets` is
+        unused — it's accepted for API parity with RandomPlayer."""
+        return self._pending_jump_choice
 
     def choose_promotion(self, options):
-        """Choose a promotion form. Delegates to a RandomPlayer."""
-        return self._fallback.choose_promotion(options)
+        """Return the promotion sub-choice already decided as part of
+        choose_turn. `options` is unused — accepted for API parity."""
+        return self._pending_promo_choice
 
     def _collect_turn_states(self, turns, engine):
         """Simulate all turns and collect encoded board states.
@@ -140,8 +198,21 @@ class NeuralPlayer:
 
         return states
 
-    def _simulate_move(self, board, turn, opponent, next_turn_num):
-        """Simulate a spatial move with lightweight save/restore."""
+    def _simulate_move(self, board, turn, opponent, next_turn_num,
+                       jump_choice=None, promo_choice=None):
+        """Simulate a spatial move (plus optional sub-choices) with
+        lightweight save/restore.
+
+        Args:
+            jump_choice: (row, col) of a jump-capture target to remove, or
+                None to decline / no jump-capture available.
+            promo_choice: piece-type string ('queen' / 'rook' / 'bishop' /
+                'knight') for pawn promotion, or None if not promoting.
+                Defaults to 'queen' (base form) when turn.promotion_options
+                is set but no explicit choice is supplied — preserving the
+                historical _simulate_move behaviour for callers that don't
+                pass promo_choice.
+        """
         from piece import Boulder
 
         move = turn.move_obj
@@ -195,11 +266,25 @@ class NeuralPlayer:
             piece.first_move = False
             piece.on_intersection = False
 
-        # Handle promotion (simulate promoting to queen)
+        # Handle jump-capture sub-choice: remove the jumped enemy piece
+        # if `jump_choice` is a (row, col) target. None = decline (or no
+        # jump-capture available).
+        saved_jump_target_piece = None
+        saved_jump_target_pos = None
+        if jump_choice is not None:
+            jr, jc = jump_choice
+            saved_jump_target_pos = (jr, jc)
+            saved_jump_target_piece = board.squares[jr][jc].piece
+            board.squares[jr][jc].piece = None
+
+        # Handle promotion. Use the supplied promo_choice if any; fall back
+        # to 'queen' (base form) for backward compatibility with callers
+        # that don't pass promo_choice.
         saved_promoted_piece = None
         if turn.promotion_options:
             saved_promoted_piece = piece  # save the pawn
-            board.promote(piece, turn.to_sq[0], turn.to_sq[1], 'queen')
+            promo_target = promo_choice if promo_choice is not None else 'queen'
+            board.promote(piece, turn.to_sq[0], turn.to_sq[1], promo_target)
 
         # --- Encode ---
         state = encode_board_for_player(board, opponent, next_turn_num)
@@ -208,6 +293,11 @@ class NeuralPlayer:
         # Undo promotion (restore pawn)
         if saved_promoted_piece is not None:
             board.squares[turn.to_sq[0]][turn.to_sq[1]].piece = saved_promoted_piece
+
+        # Undo jump-capture (restore the jumped piece)
+        if saved_jump_target_pos is not None:
+            jr, jc = saved_jump_target_pos
+            board.squares[jr][jc].piece = saved_jump_target_piece
 
         # Undo move
         board.squares[final.row][final.col].piece = saved_final_piece
@@ -253,114 +343,12 @@ class NeuralPlayer:
 
         return state
 
-    def choose_jump_capture(self, targets, turn, engine):
-        """Choose whether to jump-capture an adjacent enemy piece.
-
-        The knight move has been chosen but NOT executed. Simulates the knight
-        landing, then evaluates each capture target (plus declining) by encoding
-        the resulting position.
-
-        Args:
-            targets: list of (row, col) of capturable enemy pieces
-            turn: the chosen Turn object (needed for from_sq/to_sq)
-            engine: GameEngine instance
-
-        Returns:
-            (row, col) to capture, or None to decline
-        """
-        options = list(targets) + [None]
-        if random.random() < self.epsilon:
-            return random.choice(options)
-
-        from piece import Boulder
-
-        board = engine.board
-        opponent = 'black' if engine.current_player == 'white' else 'white'
-        next_turn_num = engine.turn_number + 1
-        piece = turn.piece
-        move = turn.move_obj
-        initial = move.initial
-        final = move.final
-
-        # Simulate the knight move first
-        saved_initial = board.squares[initial.row][initial.col].piece
-        saved_final = board.squares[final.row][final.col].piece
-        board.squares[initial.row][initial.col].piece = None
-        board.squares[final.row][final.col].piece = piece
-
-        # Evaluate each option
-        states = []
-        for target in options:
-            if target is not None:
-                row, col = target
-                saved_target = board.squares[row][col].piece
-                board.squares[row][col].piece = None
-                state = encode_board_for_player(board, opponent, next_turn_num)
-                states.append(state)
-                board.squares[row][col].piece = saved_target
-            else:
-                state = encode_board_for_player(board, opponent, next_turn_num)
-                states.append(state)
-
-        # Restore the knight move
-        board.squares[final.row][final.col].piece = saved_final
-        board.squares[initial.row][initial.col].piece = saved_initial
-
-        opp_win_probs = self.network.predict_batch(np.array(states))
-        our_win_probs = 1.0 - opp_win_probs
-        best_idx = np.argmax(our_win_probs)
-        return options[best_idx]
-
-    def choose_promotion(self, options, turn, engine):
-        """Choose which piece type to promote a pawn to.
-
-        The pawn move has been chosen but NOT executed. Simulates the pawn
-        moving to the last rank, then evaluates each promotion type.
-
-        Args:
-            options: list of piece type strings ('queen', 'rook', 'bishop', 'knight')
-            turn: the chosen Turn object (needed for from_sq/to_sq)
-            engine: GameEngine instance
-
-        Returns:
-            piece type string
-        """
-        if random.random() < self.epsilon:
-            return random.choice(options)
-        if len(options) == 1:
-            return options[0]
-
-        board = engine.board
-        opponent = 'black' if engine.current_player == 'white' else 'white'
-        next_turn_num = engine.turn_number + 1
-        piece = turn.piece
-        move = turn.move_obj
-        initial = move.initial
-        to_row, to_col = turn.to_sq
-
-        # Simulate the pawn move
-        saved_initial = board.squares[initial.row][initial.col].piece
-        saved_final = board.squares[to_row][to_col].piece
-        board.squares[initial.row][initial.col].piece = None
-        board.squares[to_row][to_col].piece = piece
-
-        # Evaluate each promotion type
-        states = []
-        for promo_type in options:
-            board.promote(piece, to_row, to_col, promo_type)
-            state = encode_board_for_player(board, opponent, next_turn_num)
-            states.append(state)
-            # Restore the pawn (promote replaces it)
-            board.squares[to_row][to_col].piece = piece
-
-        # Restore the pawn move
-        board.squares[to_row][to_col].piece = saved_final
-        board.squares[initial.row][initial.col].piece = saved_initial
-
-        opp_win_probs = self.network.predict_batch(np.array(states))
-        our_win_probs = 1.0 - opp_win_probs
-        best_idx = np.argmax(our_win_probs)
-        return options[best_idx]
+    # Note: the old 3-arg `choose_jump_capture(targets, turn, engine)` and
+    # `choose_promotion(options, turn, engine)` methods were removed when
+    # sub-choice evaluation was unified into `choose_turn` (which now
+    # enumerates every (move + jump_choice + promo_choice) combination as
+    # a distinct option). The 2-arg methods above (line ~155-170) replace
+    # them — they just return the sub-choices decided as part of choose_turn.
 
 
 def play_training_game(network, device, max_turns=1000, epsilon=0.1,
@@ -398,16 +386,19 @@ def play_training_game(network, device, max_turns=1000, epsilon=0.1,
         states.append(state)
         players_at_state.append(engine.current_player)
 
-        # Choose and execute turn
+        # Choose and execute turn. choose_turn evaluates every
+        # (move + jump_choice + promo_choice) combination in one batch
+        # and stores the winning sub-choices on the player; the 2-arg
+        # choose_jump_capture/choose_promotion methods just retrieve them.
         turn = player.choose_turn(turns, engine)
 
         jump_choice = None
         if turn.jump_capture_targets:
-            jump_choice = player.choose_jump_capture(turn.jump_capture_targets, turn, engine)
+            jump_choice = player.choose_jump_capture(turn.jump_capture_targets)
 
         promo_choice = None
         if turn.promotion_options:
-            promo_choice = player.choose_promotion(turn.promotion_options, turn, engine)
+            promo_choice = player.choose_promotion(turn.promotion_options)
 
         engine.execute_turn(turn, jump_choice, promo_choice)
 


### PR DESCRIPTION
## Summary

Two changes per user feedback:

### 1. Unified combination evaluation for NeuralPlayer

Per user: \"Each combination of 2 steps should count as a single distinct legal turn option for all AI evaluation and training purposes. Don't randomly pick these, even for the easy AI.\"

**Before:** NeuralPlayer used a 3-step evaluation pipeline — choose the move first (with promotion forced to 'queen', jump-capture ignored), then separately pick a jump-capture target/decline, then separately pick a promotion piece-type. Inconsistent: the network could pick (move A, decline) based on step 1 evaluation, when (move B, accept) might actually have higher win probability — but the pipeline never tried that combination.

**After:** \`choose_turn\` enumerates EVERY (move + jump_choice + promo_choice) combination as a distinct option, simulates each to its resulting state, batch-evaluates them all in one forward pass, and picks the combination with highest win probability. Sub-choices are stored on the player; \`choose_jump_capture(targets)\` and \`choose_promotion(options)\` are now 2-arg methods that just return the stored values.

**Latent bug fixed:** my prior commit added 2-arg fallback versions of \`choose_jump_capture\` / \`choose_promotion\` to NeuralPlayer, but they were shadowed by the existing 3-arg versions later in the class body. AIController calls the 1-arg signature; that path would have crashed on jump-capture/promotion situations. With the unified approach the 2-arg methods are the only ones defined.

### 2. Mode menu — vertical Opponent layout

The 5-entry Opponent row (Human / Random / AI Easy / AI Medium / AI Hard) overflowed the screen width. \`render_section\` now accepts an orientation:
- **\`Your side\`** stays horizontal (2 options).
- **\`Opponent\`** renders vertically (one button per row).

Grayed-out unavailable styling and \`mode_menu_rects\` hit-detection unchanged.

## Test plan

- [x] 43/43 tests pass (test_ai TestTrainingData + test_ai_controller + test_mode_selection).
- [x] E2E smoke: \`g.ai_controller.take_turn(g)\` with AI Easy succeeds, returns a Turn with stored sub-choices.

## Training impact

The running training process (started before this PR) continues with the old 3-step evaluation in-memory. The refactored logic takes effect on the next trainer launch. The network weights are unchanged and continue to learn from whichever evaluation strategy generates the self-play data; the new logic is a strict superset of the old (it considers more option combinations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)