### PR TITLE
Engine refactor: every Turn fully specified — no sub-choices; tools + easy bump

### DIFF
--- a/src/ai_controller.py
+++ b/src/ai_controller.py
@@ -113,6 +113,12 @@ class AIController:
         game.next_turn()
 
     def _apply_spatial(self, game, turn):
+        """Apply a fully-specified spatial Turn (move / boulder / manipulation).
+
+        The Turn already carries its sub-choices (jump_choice, promo_choice)
+        — engine.get_all_legal_turns enumerated each combination as a
+        separate Turn — so this method just unconditionally applies them.
+        """
         board = game.board
         mover = game.next_player
         to_r, to_c = turn.to_sq
@@ -121,11 +127,57 @@ class AIController:
 
         jump_targets = board.move(turn.piece, turn.move_obj)
 
-        if jump_targets:
-            self._resolve_jump_capture(game, turn, jump_targets)
+        # Jump-capture branch: turn.has_jump_offer is True iff the move
+        # offered a jump-capture decision. turn.jump_choice is the chosen
+        # target (capture) or None (decline). When has_jump_offer is
+        # False, no jump-capture was offered and we fall through.
+        if turn.has_jump_offer:
+            if turn.jump_choice is not None:
+                jr, jc = turn.jump_choice
+                board.execute_jump_capture(jr, jc)
+                jump_captured = True
+            else:
+                # Declined — jumped piece survives. v2 knight may gain
+                # invulnerability for one opponent turn (board helper
+                # checks the adjacent-enemy condition).
+                landing_r, landing_c = turn.to_sq
+                # jump_targets always has exactly one entry in v2 (the
+                # jumped piece) — its coords are the jumped square.
+                jumped_r, jumped_c = jump_targets[0]
+                board.set_invulnerable_after_jump_decline(
+                    turn.piece, landing_r, landing_c, jumped_r, jumped_c)
+                jump_captured = False
+            board.clear_forbidden_squares()
+            if turn.piece.color != mover:
+                turn.piece.moved_by_queen = True
+            board.update_assassin_squares(mover)
+            board.decrement_boulder_cooldown()
+            if jump_captured:
+                game.winner = board.check_winner()
+            if board.tiny_endgame_active:
+                board.update_distance_count(captured=jump_captured)
+            if not board.tiny_endgame_active and board.is_tiny_endgame():
+                board.init_tiny_endgame()
+            game.play_sound(captured=jump_captured)
+            game.next_turn()
             return
-        if turn.promotion_options:
-            self._resolve_promotion(game, turn, captured)
+
+        # Promotion branch: turn.promo_choice carries the chosen form.
+        if turn.promo_choice is not None:
+            was_manipulation = turn.piece.color != mover
+            board.promote(turn.piece, to_r, to_c, turn.promo_choice)
+            if was_manipulation:
+                new_piece = board.squares[to_r][to_c].piece
+                if new_piece is not None:
+                    new_piece.moved_by_queen = True
+            board.update_assassin_squares(mover)
+            board.decrement_boulder_cooldown()
+            if captured:
+                game.winner = board.check_winner()
+            if board.is_tiny_endgame():
+                board.init_tiny_endgame()
+            game.play_sound(captured=captured)
+            game.next_turn()
             return
 
         # Normal move completion.
@@ -145,66 +197,6 @@ class AIController:
         if not board.tiny_endgame_active and board.is_tiny_endgame():
             board.init_tiny_endgame()
         # Audio feedback for the human watching the AI's turn — mirrors the
-        # human-move path in main.py (capture vs move sound). Sound is a
-        # no-op in the headless code path used by tests / training (Game
-        # play_sound is guarded by config.sounds_loaded).
-        game.play_sound(captured=captured)
-        game.next_turn()
-
-    def _resolve_jump_capture(self, game, turn, jump_targets):
-        board = game.board
-        mover = game.next_player
-        targets = [(t[0], t[1]) for t in jump_targets]
-        choice = self.player.choose_jump_capture(targets)
-        jump_captured = choice is not None and tuple(choice) in targets
-        if jump_captured:
-            board.execute_jump_capture(choice[0], choice[1])
-        else:
-            # Declined: jumped piece survives; v2 knight may gain
-            # invulnerability for one opponent turn (board helper checks the
-            # adjacent-enemy condition). v2 jump_targets always has exactly one
-            # entry (the jumped piece).
-            landing_r, landing_c = turn.to_sq
-            jumped_r, jumped_c = jump_targets[0]
-            board.set_invulnerable_after_jump_decline(
-                turn.piece, landing_r, landing_c, jumped_r, jumped_c)
-        board.clear_forbidden_squares()
-        # If the knight was manipulated (an enemy of the mover), freeze it.
-        if turn.piece.color != mover:
-            turn.piece.moved_by_queen = True
-        board.update_assassin_squares(mover)
-        board.decrement_boulder_cooldown()
-        if jump_captured:
-            game.winner = board.check_winner()
-        if board.tiny_endgame_active:
-            board.update_distance_count(captured=jump_captured)
-        if not board.tiny_endgame_active and board.is_tiny_endgame():
-            board.init_tiny_endgame()
-        # Audio feedback — capture sound if the jump-capture was taken,
-        # move sound if declined. Mirrors human path (main.py lines 475/492).
-        game.play_sound(captured=jump_captured)
-        game.next_turn()
-
-    def _resolve_promotion(self, game, turn, captured):
-        board = game.board
-        mover = game.next_player
-        to_r, to_c = turn.to_sq
-        was_manipulation = turn.piece.color != mover
-        choice = self.player.choose_promotion(turn.promotion_options)
-        board.promote(turn.piece, to_r, to_c, choice)
-        if was_manipulation:
-            new_piece = board.squares[to_r][to_c].piece
-            if new_piece is not None:
-                new_piece.moved_by_queen = True
-        board.update_assassin_squares(mover)
-        board.decrement_boulder_cooldown()
-        if captured:
-            game.winner = board.check_winner()
-        # A pawn existed pre-move, so tiny endgame couldn't have been active;
-        # it may activate now that the last pawn promoted.
-        if board.is_tiny_endgame():
-            board.init_tiny_endgame()
-        # Audio feedback — sound reflects whether the promoting move was a
-        # capture. Mirrors human path (main.py line 599 plays at promotion).
+        # human-move path in main.py. Sound is a no-op in headless tests.
         game.play_sound(captured=captured)
         game.next_turn()

--- a/src/engine.py
+++ b/src/engine.py
@@ -13,7 +13,15 @@ from move import Move
 
 
 class Turn:
-    """Represents a single complete turn a player can take.
+    """One complete, fully-specified legal turn.
+
+    A Turn carries ALL information needed to execute it — no secondary
+    choices are deferred. Multi-step turns (knight jump-capture decisions,
+    pawn promotion form choices) are enumerated by the engine as
+    SEPARATE Turn objects, one per possible (move + sub-choice)
+    combination. This means each distinct full turn is counted exactly
+    once everywhere (random selection, network evaluation, training
+    statistics) — no implicit branching at execution time.
 
     Turn types:
       - 'move': spatial move (piece from one square to another)
@@ -21,22 +29,33 @@ class Turn:
       - 'manipulation': queen manipulates an enemy piece
       - 'transformation': queen transforms to a different piece type
 
-    For moves that involve secondary choices (jump capture, promotion),
-    the choices are stored as lists. The AI must select from them.
+    Sub-choice fields:
+      - `jump_choice`: for a knight move that triggers reactive
+        jump-capture, this Turn either takes the capture (jump_choice =
+        (row, col) of the jumped piece) or declines (jump_choice = None).
+        For moves that don't offer jump-capture, this is None.
+      - `promo_choice`: for a pawn promotion move, the specific form
+        chosen ('queen', 'rook', 'bishop', 'knight'). None otherwise.
     """
 
     def __init__(self, turn_type, piece=None, from_sq=None, to_sq=None,
                  move_obj=None, transform_target=None,
-                 jump_capture_targets=None, promotion_options=None,
-                 is_capture=False):
+                 jump_choice=None, promo_choice=None,
+                 has_jump_offer=False, is_capture=False):
         self.turn_type = turn_type              # 'move', 'boulder', 'manipulation', 'transformation'
         self.piece = piece                      # the piece being moved/acted on
         self.from_sq = from_sq                  # (row, col) or None
         self.to_sq = to_sq                      # (row, col) or None
         self.move_obj = move_obj                # Move object for board.move()
         self.transform_target = transform_target  # 'rook', 'bishop', 'knight', 'queen' for transformations
-        self.jump_capture_targets = jump_capture_targets  # list of (row, col) or None
-        self.promotion_options = promotion_options  # list of type strings or None
+        self.jump_choice = jump_choice          # (row, col) target | None (decline OR no jump available)
+        self.promo_choice = promo_choice        # promotion form string, or None
+        # has_jump_offer distinguishes "no jump offered" (False) from
+        # "jump offered but this Turn is the decline option" (True with
+        # jump_choice=None). The engine sets this when constructing
+        # decline-Turns; execute_turn uses it to apply the
+        # invulnerability-after-decline side effects.
+        self.has_jump_offer = has_jump_offer
         self.is_capture = is_capture            # whether the move captures a piece
 
     def __repr__(self):
@@ -45,10 +64,12 @@ class Turn:
         elif self.turn_type in ('move', 'boulder', 'manipulation'):
             cap = ' capture' if self.is_capture else ''
             suffix = ''
-            if self.jump_capture_targets:
-                suffix = f' jump_targets={self.jump_capture_targets}'
-            if self.promotion_options:
-                suffix += f' promo={self.promotion_options}'
+            if self.jump_choice is not None:
+                suffix = f' jump_capture={self.jump_choice}'
+            elif self.has_jump_offer:
+                suffix = ' jump_decline'
+            if self.promo_choice is not None:
+                suffix += f' promo={self.promo_choice}'
             return f"Turn({self.turn_type}{cap} {self.piece.name}@{self.from_sq}->{self.to_sq}{suffix})"
         return f"Turn({self.turn_type})"
 
@@ -350,16 +371,29 @@ class GameEngine:
             if isinstance(piece, Pawn) and (move.final.row == 0 or move.final.row == 7):
                 promo_options = self.board.get_promotion_options(piece.color)
 
-            turns.append(Turn(
-                turn_type=turn_type,
-                piece=piece,
-                from_sq=(row, col),
-                to_sq=(move.final.row, move.final.col),
-                move_obj=move,
-                is_capture=is_cap,
-                jump_capture_targets=jump_targets,
-                promotion_options=promo_options,
-            ))
+            # Sub-choice expansion: enumerate each (jump_choice, promo_choice)
+            # combination as a separate Turn so consumers (AI evaluation,
+            # random selection, training statistics) see each fully-specified
+            # turn exactly once.
+            jump_combinations = (
+                [(t[0], t[1]) for t in jump_targets] + [None]
+                if jump_targets else [None]
+            )
+            promo_combinations = list(promo_options) if promo_options else [None]
+            has_jump_offer = jump_targets is not None and len(jump_targets) > 0
+            for jc in jump_combinations:
+                for pc in promo_combinations:
+                    turns.append(Turn(
+                        turn_type=turn_type,
+                        piece=piece,
+                        from_sq=(row, col),
+                        to_sq=(move.final.row, move.final.col),
+                        move_obj=move,
+                        is_capture=is_cap,
+                        jump_choice=jc,
+                        promo_choice=pc,
+                        has_jump_offer=has_jump_offer,
+                    ))
 
         piece.clear_moves()
 
@@ -383,19 +417,23 @@ class GameEngine:
         )
         return targets if targets else None
 
-    def execute_turn(self, turn, jump_capture_choice=None, promotion_choice=None):
-        """Execute a turn and advance the game state.
+    def execute_turn(self, turn):
+        """Execute a fully-specified turn and advance the game state.
+
+        All sub-choices (jump-capture target or decline, promotion form)
+        are read from the Turn object itself — the engine enumerates each
+        combination as a separate Turn via get_all_legal_turns, so there
+        are no implicit branches at execution time.
 
         Args:
             turn: Turn object from get_all_legal_turns()
-            jump_capture_choice: (row, col) to capture, or None to decline.
-                                 Required when turn.jump_capture_targets is not None.
-            promotion_choice: piece type string ('queen', 'rook', etc.).
-                              Required when turn.promotion_options is not None.
 
         Returns:
             TurnRecord with all data about this turn.
         """
+        # Pull sub-choices from the Turn itself.
+        jump_capture_choice = turn.jump_choice
+        promotion_choice = turn.promo_choice
         # Clear the last-manipulated tracker for this player (restriction lasts one turn)
         if self.manipulation_mode in ('freeze_invulnerable_no_repeat', 'freeze_no_repeat'):
             if turn.turn_type != 'manipulation':
@@ -508,7 +546,7 @@ class GameEngine:
                 self._apply_manipulation_effect(turn.piece, turn.from_sq)
 
         # Handle promotion
-        elif turn.promotion_options is not None and promotion_choice:
+        elif turn.promo_choice is not None and promotion_choice:
             record.promotion_choice = promotion_choice
             to_row, to_col = turn.to_sq
             self.board.promote(turn.piece, to_row, to_col, promotion_choice)

--- a/src/game.py
+++ b/src/game.py
@@ -230,7 +230,7 @@ class Game:
     # hard checkpoints become available as training progresses; the menu
     # grays out entries whose checkpoint does not exist on disk.
     _AI_CHECKPOINTS = {
-        'easy':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0020.pt'),
+        'easy':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0027.pt'),
         'medium': os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0050.pt'),
         'hard':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0100.pt'),
     }

--- a/src/players.py
+++ b/src/players.py
@@ -7,25 +7,19 @@ import random
 
 class RandomPlayer:
     """Picks uniformly at random from all legal turns.
-    For multi-step turns (jump capture, promotion), also picks randomly."""
+
+    The engine enumerates each fully-specified combination (move +
+    jump_choice + promo_choice) as a separate Turn, so this player needs
+    only one decision method: pick one Turn uniformly. Each distinct
+    full turn is therefore counted exactly once in the random sampling
+    (no implicit branching at sub-choice time)."""
 
     def choose_turn(self, turns, engine=None):
         """Select a turn from the list of legal turns.
 
-        `engine` is accepted for API parity with NeuralPlayer (which needs
+        `engine` is accepted for API parity with NeuralPlayer (which uses
         the engine to simulate turns). RandomPlayer ignores it.
         """
         if not turns:
             return None
         return random.choice(turns)
-
-    def choose_jump_capture(self, targets):
-        """Choose whether to jump-capture and which target.
-        Returns (row, col) to capture, or None to decline."""
-        # Randomly capture or decline (equal probability for each option)
-        options = list(targets) + [None]
-        return random.choice(options)
-
-    def choose_promotion(self, options):
-        """Choose which piece type to promote to."""
-        return random.choice(options)

--- a/src/selfplay.py
+++ b/src/selfplay.py
@@ -37,20 +37,13 @@ def play_one_game(args):
             break
 
         player = white if engine.current_player == 'white' else black
+        # The engine enumerates each fully-specified combination as a
+        # separate Turn (no sub-choices remain after this call).
         turn = player.choose_turn(turns)
-
-        # Handle secondary choices
-        jump_choice = None
-        if turn.jump_capture_targets:
-            jump_choice = player.choose_jump_capture(turn.jump_capture_targets)
-
-        promo_choice = None
-        if turn.promotion_options:
-            promo_choice = player.choose_promotion(turn.promotion_options)
 
         # Record branching factor before executing
         n_turns = len(turns)
-        record = engine.execute_turn(turn, jump_choice, promo_choice)
+        record = engine.execute_turn(turn)
         record.legal_turn_count = n_turns
         # Update the stored dict in game_record (last entry)
         engine.game_record.turns[-1]['legal_turn_count'] = n_turns

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -61,112 +61,54 @@ class NeuralPlayer:
         self.network = network
         self.device = device
         self.epsilon = epsilon
-        # Sub-choices (jump-capture target/decline, promotion form) are
-        # decided as part of choose_turn — each combination (move +
-        # jump_choice + promo_choice) is enumerated as a distinct option
-        # and the network evaluates them all in one batch. choose_turn
-        # stores the winning sub-choices here, and choose_jump_capture /
-        # choose_promotion just return them when asked.
-        self._pending_jump_choice = None
-        self._pending_promo_choice = None
 
     def choose_turn(self, turns, engine):
-        """Select the best (move + sub-choices) combination using one batch
+        """Select the best Turn from the legal-turns list using one batched
         network evaluation.
 
-        For each candidate Turn, enumerates every combination of secondary
-        choices (jump-capture target/decline; pawn-promotion form). Each
-        combination is treated as a distinct option, simulated to its
-        resulting board state, and evaluated in a single batched forward
-        pass. The combination with highest win probability is selected; its
-        sub-choices are stored on the player and returned later by
-        choose_jump_capture / choose_promotion.
-
-        This unification (vs the older multi-step approach that picked the
-        move first and only then evaluated sub-choices) ensures the network
-        sees each full combination as one option — preventing the case
-        where the best (move A, decline) loses to (move B, accept) but the
-        sub-step pipeline picks (move A, decline) anyway because it
-        evaluated "best move first" without knowing the eventual
-        sub-choice.
+        The engine enumerates each fully-specified combination (move +
+        jump_choice + promo_choice) as a separate Turn, so this method
+        just evaluates every Turn in the list and picks the highest-
+        win-probability option. No sub-choices remain after this call —
+        the returned Turn is complete.
 
         Args:
-            turns: list of Turn objects from engine.get_all_legal_turns()
-            engine: GameEngine instance (needed to simulate moves)
+            turns: list of fully-specified Turn objects from
+                engine.get_all_legal_turns()
+            engine: GameEngine instance (used to simulate each Turn for
+                state encoding)
 
         Returns:
-            chosen Turn object (sub-choices stored on `self`)
+            chosen Turn object (already includes its jump_choice and
+            promo_choice, ready for execute_turn).
         """
-        # Clear sub-choices from any previous call.
-        self._pending_jump_choice = None
-        self._pending_promo_choice = None
-
         if not turns:
             return None
 
-        # Epsilon-greedy exploration: pick a random turn, then random
-        # sub-choices independently. (Picking a random combination is
-        # equivalent in distribution if sub-choice counts are equal across
-        # turns; the simpler per-step random suffices for exploration.)
+        # Epsilon-greedy exploration.
         if random.random() < self.epsilon:
-            turn = random.choice(turns)
-            if turn.jump_capture_targets:
-                self._pending_jump_choice = random.choice(
-                    list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                self._pending_promo_choice = random.choice(
-                    list(turn.promotion_options))
-            return turn
+            return random.choice(turns)
 
-        # Enumerate (turn, jump_choice, promo_choice) combinations.
-        combinations = []
-        for turn in turns:
-            if turn.turn_type == 'transformation' or not turn.move_obj:
-                combinations.append((turn, None, None))
-                continue
-            jump_options = (list(turn.jump_capture_targets) + [None]
-                            if turn.jump_capture_targets else [None])
-            promo_options = (list(turn.promotion_options)
-                             if turn.promotion_options else [None])
-            for jc in jump_options:
-                for pc in promo_options:
-                    combinations.append((turn, jc, pc))
-
-        # Batch-evaluate every combination.
+        # Batch-evaluate every Turn.
         board = engine.board
         opponent = 'black' if engine.current_player == 'white' else 'white'
         next_turn_num = engine.turn_number + 1
         states = []
-        for turn, jc, pc in combinations:
+        for turn in turns:
             if turn.turn_type == 'transformation':
                 state = self._simulate_transformation(
                     board, turn, opponent, next_turn_num)
             else:
                 state = self._simulate_move(
                     board, turn, opponent, next_turn_num,
-                    jump_choice=jc, promo_choice=pc)
+                    jump_choice=turn.jump_choice,
+                    promo_choice=turn.promo_choice)
             states.append(state)
 
         opp_win_probs = self.network.predict_batch(np.array(states))
         our_win_probs = 1.0 - opp_win_probs
         best_idx = np.argmax(our_win_probs)
-
-        chosen_turn, chosen_jc, chosen_pc = combinations[best_idx]
-        self._pending_jump_choice = chosen_jc
-        self._pending_promo_choice = chosen_pc
-        return chosen_turn
-
-    def choose_jump_capture(self, targets):
-        """Return the jump-capture sub-choice already decided as part of
-        choose_turn (which evaluated every (move + jump_choice +
-        promo_choice) combination in a single batch). `targets` is
-        unused — it's accepted for API parity with RandomPlayer."""
-        return self._pending_jump_choice
-
-    def choose_promotion(self, options):
-        """Return the promotion sub-choice already decided as part of
-        choose_turn. `options` is unused — accepted for API parity."""
-        return self._pending_promo_choice
+        return turns[best_idx]
 
     def _collect_turn_states(self, turns, engine):
         """Simulate all turns and collect encoded board states.
@@ -208,10 +150,7 @@ class NeuralPlayer:
                 None to decline / no jump-capture available.
             promo_choice: piece-type string ('queen' / 'rook' / 'bishop' /
                 'knight') for pawn promotion, or None if not promoting.
-                Defaults to 'queen' (base form) when turn.promotion_options
-                is set but no explicit choice is supplied — preserving the
-                historical _simulate_move behaviour for callers that don't
-                pass promo_choice.
+                None when the move is not a promotion.
         """
         from piece import Boulder
 
@@ -277,14 +216,14 @@ class NeuralPlayer:
             saved_jump_target_piece = board.squares[jr][jc].piece
             board.squares[jr][jc].piece = None
 
-        # Handle promotion. Use the supplied promo_choice if any; fall back
-        # to 'queen' (base form) for backward compatibility with callers
-        # that don't pass promo_choice.
+        # Handle promotion. promo_choice (either from the parameter or
+        # from turn.promo_choice) carries the chosen form. If the move is
+        # to a promotion rank, board.promote replaces the pawn with the
+        # chosen piece type.
         saved_promoted_piece = None
-        if turn.promotion_options:
+        if promo_choice is not None:
             saved_promoted_piece = piece  # save the pawn
-            promo_target = promo_choice if promo_choice is not None else 'queen'
-            board.promote(piece, turn.to_sq[0], turn.to_sq[1], promo_target)
+            board.promote(piece, turn.to_sq[0], turn.to_sq[1], promo_choice)
 
         # --- Encode ---
         state = encode_board_for_player(board, opponent, next_turn_num)
@@ -343,14 +282,6 @@ class NeuralPlayer:
 
         return state
 
-    # Note: the old 3-arg `choose_jump_capture(targets, turn, engine)` and
-    # `choose_promotion(options, turn, engine)` methods were removed when
-    # sub-choice evaluation was unified into `choose_turn` (which now
-    # enumerates every (move + jump_choice + promo_choice) combination as
-    # a distinct option). The 2-arg methods above (line ~155-170) replace
-    # them — they just return the sub-choices decided as part of choose_turn.
-
-
 def play_training_game(network, device, max_turns=1000, epsilon=0.1,
                        manipulation_mode='freeze'):
     """Play a single self-play game and collect training data.
@@ -386,21 +317,11 @@ def play_training_game(network, device, max_turns=1000, epsilon=0.1,
         states.append(state)
         players_at_state.append(engine.current_player)
 
-        # Choose and execute turn. choose_turn evaluates every
-        # (move + jump_choice + promo_choice) combination in one batch
-        # and stores the winning sub-choices on the player; the 2-arg
-        # choose_jump_capture/choose_promotion methods just retrieve them.
+        # The engine enumerates each combination as a fully-specified
+        # Turn; player picks one and we execute it directly. No sub-choice
+        # method calls are needed.
         turn = player.choose_turn(turns, engine)
-
-        jump_choice = None
-        if turn.jump_capture_targets:
-            jump_choice = player.choose_jump_capture(turn.jump_capture_targets)
-
-        promo_choice = None
-        if turn.promotion_options:
-            promo_choice = player.choose_promotion(turn.promotion_options)
-
-        engine.execute_turn(turn, jump_choice, promo_choice)
+        engine.execute_turn(turn)
 
     # Finalize and determine outcomes
     game_record = engine.get_game_record()

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -279,32 +279,28 @@ class TestMakeUnmake:
 # =====================================================================
 
 class TestCombinationEvaluation:
-    """NeuralPlayer must evaluate EVERY turn type and EVERY sub-choice
-    combination as a distinct option — no random fallback for sub-choices
-    or special turn types (transformations, manipulations, reactive
-    captures, king self-captures, jump-captures, promotions)."""
+    """Every fully-specified Turn is counted exactly once and evaluated
+    by the network — no sub-choices remain after engine.get_all_legal_turns
+    returns. Multi-step moves (knight jump-capture, pawn promotion) are
+    enumerated as separate Turns, one per (move + jump_choice + promo_choice)
+    combination."""
 
     def _make_player(self, epsilon=0.0):
         network = ValueNetwork(conv_channels=32, num_res_blocks=2, fc_size=64)
         network.eval()
         return NeuralPlayer(network, device='cpu', epsilon=epsilon)
 
-    def test_combination_eval_handles_transformation_turns(self):
-        """Transformation turns must be evaluated by the network (not just
-        skipped or randomly chosen). With epsilon=0, choose_turn should
-        run _simulate_transformation for any 'transformation' turn in the
-        legal-turns list."""
+    def test_engine_enumerates_transformation_turns_with_no_subchoices(self):
+        """Transformations are one Turn each (one per available form);
+        no separate sub-choice handling needed. NeuralPlayer evaluates
+        each via _simulate_transformation."""
         from piece import Queen, Rook, King
         from square import Square
 
         board = Board()
-        # Clear the default starting setup so we can place pieces directly.
         for r in range(8):
             for c in range(8):
                 board.squares[r][c] = Square(r, c)
-        # Place a white queen and king + a black king. The queen has
-        # transformation actions available if a friendly piece was
-        # captured earlier — simulate this by appending to captured_pieces.
         board.squares[4][3].piece = Queen('white')
         board.squares[7][4].piece = King('white')
         board.squares[0][4].piece = King('black')
@@ -316,32 +312,27 @@ class TestCombinationEvaluation:
         engine.current_player = 'white'
         engine.turn_number = board.turn_number
         turns = engine.get_all_legal_turns()
-        # Verify at least one transformation turn is in the list.
-        transformation_turns = [t for t in turns if t.turn_type == 'transformation']
-        assert len(transformation_turns) >= 1, \
-            f"Expected at least one transformation turn; got types: " \
-            f"{[t.turn_type for t in turns]}"
+        # Verify transformation turn(s) are present and have no
+        # sub-choice attributes set (transformations don't take sub-choices).
+        ts = [t for t in turns if t.turn_type == 'transformation']
+        assert len(ts) >= 1
+        for t in ts:
+            assert t.jump_choice is None
+            assert t.promo_choice is None
+            assert t.has_jump_offer is False
 
-        # choose_turn must process all turn types without exception.
+        # Determinism check: same input ⇒ same output (no random fallback).
         player = self._make_player(epsilon=0.0)
-        chosen = player.choose_turn(turns, engine)
-        assert chosen is not None
-        # Either a 'move' or 'transformation' could be the best — verify
-        # the network was actually consulted (not random) by checking
-        # determinism: same input ⇒ same output.
-        chosen_again = player.choose_turn(turns, engine)
-        assert chosen.turn_type == chosen_again.turn_type
-        if chosen.turn_type == 'transformation':
-            assert chosen.transform_target == chosen_again.transform_target
+        c1 = player.choose_turn(turns, engine)
+        c2 = player.choose_turn(turns, engine)
+        assert c1 is c2 or (c1.turn_type == c2.turn_type
+                            and c1.transform_target == c2.transform_target
+                            and c1.from_sq == c2.from_sq)
 
-    def test_combination_eval_enumerates_jump_capture_subchoices(self):
-        """When a turn has jump_capture_targets, choose_turn must
-        enumerate each (target | decline) as a distinct combination and
-        evaluate them all in one batch. The chosen sub-choice is stored
-        in _pending_jump_choice for choose_jump_capture to return."""
-        # Build a minimal jump-capture-eligible position: white knight at
-        # c3, white king at h1, black king at h8, black queen at d4 that
-        # JUST MOVED there on the preceding turn.
+    def test_engine_enumerates_jump_capture_as_separate_turns(self):
+        """Knight moves that trigger reactive jump-capture get enumerated
+        as one Turn per (target, decline) option. Each Turn is fully
+        specified — its jump_choice field tells execute_turn what to do."""
         from piece import King, Queen, Knight
         from square import Square
         from move import Move
@@ -356,8 +347,6 @@ class TestCombinationEvaluation:
         board.squares[5][2].piece = knight   # c3
         bq = Queen('black')
         board.squares[4][3].piece = bq       # d4
-        # Make d4 a piece-that-moved-on-preceding-turn so jump-capture
-        # eligibility applies on white's next turn.
         prev = Move(Square(4, 4), Square(4, 3))  # came from e4
         board.last_move = prev
         board.last_move_turn_number = 4
@@ -369,63 +358,91 @@ class TestCombinationEvaluation:
         engine.current_player = 'white'
         engine.turn_number = board.turn_number
         turns = engine.get_all_legal_turns()
-        # At least one knight move should have jump_capture_targets set.
-        jc_turns = [t for t in turns if t.jump_capture_targets]
-        assert len(jc_turns) >= 1, \
-            "Expected at least one knight move with jump_capture_targets"
+        # Find Turns from the knight's c3→a1 leap (jumps over d4 enemy).
+        # Each enumerated Turn with has_jump_offer=True represents one
+        # of {take, decline}.
+        jumps = [t for t in turns if t.has_jump_offer]
+        # There must be at least 2 such Turns (take + decline) per leap.
+        assert len(jumps) >= 2, \
+            f"Expected jump-capture Turns enumerated as separate options; got {len(jumps)}"
+        takes = [t for t in jumps if t.jump_choice is not None]
+        declines = [t for t in jumps if t.jump_choice is None]
+        assert len(takes) >= 1 and len(declines) >= 1, \
+            "Expected at least one take and one decline Turn for the jump-capture"
 
+        # Determinism + no sub-choice methods needed: choose_turn returns
+        # a fully-specified Turn whose jump_choice is already set.
         player = self._make_player(epsilon=0.0)
         chosen = player.choose_turn(turns, engine)
         assert chosen is not None
-        # If the chosen turn has jump targets, the player must have
-        # decided whether to take the capture (not None unless decline
-        # was the best option).
-        if chosen.jump_capture_targets:
-            # _pending_jump_choice was set by choose_turn — either a
-            # target tuple or None (decline). Both are legitimate
-            # network-evaluated decisions (NOT a random pick).
-            assert hasattr(player, '_pending_jump_choice')
-            # The decision must be deterministic from the same inputs.
-            player2 = self._make_player(epsilon=0.0)
-            player2.network.load_state_dict(player.network.state_dict())
-            chosen2 = player2.choose_turn(turns, engine)
-            assert (chosen2.from_sq, chosen2.to_sq) == (chosen.from_sq, chosen.to_sq)
+        if chosen.has_jump_offer:
+            assert chosen.jump_choice is None or isinstance(chosen.jump_choice, tuple)
 
-    def test_choose_jump_capture_returns_pending_choice_not_random(self):
-        """choose_jump_capture (2-arg) returns the sub-choice already
-        decided by choose_turn — never a fresh random pick."""
-        player = self._make_player(epsilon=0.0)
-        # Manually plant a decision.
-        player._pending_jump_choice = (4, 3)
-        assert player.choose_jump_capture([(4, 3), (5, 4)]) == (4, 3)
-        player._pending_jump_choice = None  # "decline" decision
-        assert player.choose_jump_capture([(4, 3)]) is None
+    def test_engine_enumerates_promotion_as_separate_turns(self):
+        """Pawn moves that promote get enumerated as one Turn per
+        promotion form. Each Turn's promo_choice is set; no sub-choice
+        method call is needed at execution time."""
+        from piece import Pawn, King
+        from square import Square
 
-    def test_choose_promotion_returns_pending_choice_not_random(self):
-        """choose_promotion (2-arg) returns the sub-choice already
-        decided by choose_turn — never a fresh random pick."""
-        player = self._make_player(epsilon=0.0)
-        player._pending_promo_choice = 'knight'
-        assert player.choose_promotion(['queen', 'rook', 'bishop', 'knight']) == 'knight'
+        board = Board()
+        for r in range(8):
+            for c in range(8):
+                board.squares[r][c] = Square(r, c)
+        board.squares[7][4].piece = King('white')
+        board.squares[0][4].piece = King('black')
+        # White pawn ready to promote at row 1 → row 0.
+        pawn = Pawn('white')
+        board.squares[1][2].piece = pawn   # c7
+        board.turn_number = 8
 
-    def test_combination_eval_evaluates_manipulation_and_king_self_capture(self):
-        """All standard turn-types ('move', 'manipulation', 'boulder',
-        'transformation') flow through choose_turn's combination loop and
-        produce a network-evaluated state — verified by deterministic
-        re-evaluation."""
-        # Use the starting position which has all the basic 'move' types.
+        engine = GameEngine(manipulation_mode='freeze')
+        engine.board = board
+        engine.current_player = 'white'
+        engine.turn_number = board.turn_number
+        turns = engine.get_all_legal_turns()
+        promo_turns = [t for t in turns if t.promo_choice is not None]
+        # At least the base-form promotion option should be present;
+        # other forms require prior captures (none here), so we expect
+        # exactly 'queen' as the single promo option.
+        assert len(promo_turns) >= 1, "Expected pawn promotion Turn(s)"
+        for t in promo_turns:
+            assert t.promo_choice in ('queen', 'rook', 'bishop', 'knight')
+
+    def test_neural_player_has_no_subchoice_methods(self):
+        """The refactored API exposes only choose_turn — sub-choice
+        decisions are baked into the Turn by the engine."""
+        player = self._make_player()
+        assert hasattr(player, 'choose_turn')
+        assert not hasattr(player, 'choose_jump_capture'), \
+            "choose_jump_capture should be removed (Turns are now fully specified)"
+        assert not hasattr(player, 'choose_promotion'), \
+            "choose_promotion should be removed (Turns are now fully specified)"
+
+    def test_random_player_has_no_subchoice_methods(self):
+        """RandomPlayer also exposes only choose_turn — each fully-
+        specified Turn is one option in the random sample."""
+        from players import RandomPlayer
+        rp = RandomPlayer()
+        assert hasattr(rp, 'choose_turn')
+        assert not hasattr(rp, 'choose_jump_capture')
+        assert not hasattr(rp, 'choose_promotion')
+
+    def test_each_combination_counted_once_in_legal_turns(self):
+        """The legal-turns list contains each fully-specified combination
+        exactly once. For positions with N base moves of which k offer
+        jump-capture (with 1 target each) and m offer promotion (with p
+        forms each), the total is `(N - k - m) + 2*k + p*m`. We don't
+        check this exact count here; we just verify no duplicates."""
+        # Use the starting position: only basic moves, no sub-choices.
         engine = GameEngine(manipulation_mode='freeze')
         turns = engine.get_all_legal_turns()
-        # The default opening has only 'move' turns (no transformation
-        # options yet, no enemies to manipulate at adjacent diagonals,
-        # nothing to jump-capture). But choose_turn must still evaluate
-        # every one — verify count and determinism.
-        player = self._make_player(epsilon=0.0)
-        chosen1 = player.choose_turn(turns, engine)
-        chosen2 = player.choose_turn(turns, engine)
-        assert chosen1 is not None
-        assert (chosen1.from_sq, chosen1.to_sq) == (chosen2.from_sq, chosen2.to_sq), \
-            "Same input ⇒ same output expected (deterministic network eval)"
+        seen = set()
+        for t in turns:
+            key = (t.turn_type, t.from_sq, t.to_sq, t.transform_target,
+                   t.jump_choice, t.promo_choice)
+            assert key not in seen, f"Duplicate Turn in legal-turns: {t!r}"
+            seen.add(key)
 
 
 class TestTrainingData:

--- a/tools/benchmark_checkpoint.py
+++ b/tools/benchmark_checkpoint.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Benchmark a checkpoint by pitting it against RandomPlayer in N games.
+
+Measures absolute strength: how often does this checkpoint beat a
+purely-random opponent? Useful for confirming that a checkpoint is
+actually better than random play (a stronger floor than relative
+checkpoint-vs-checkpoint matchups).
+
+Alternates colors 50/50 across games to factor out first-mover effects.
+
+Example:
+    python3 tools/benchmark_checkpoint.py \\
+        --checkpoint models/variant_freeze_v3/model_iter_0025.pt \\
+        --num-games 30 --max-turns 1500
+"""
+
+import argparse
+import os
+import sys
+import time
+import random
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+class _Stub:
+    def __getattr__(self, n): return self
+    def __call__(self, *a, **k): return self
+sys.modules.setdefault('pygame', _Stub())
+sys.modules.setdefault('pygame.gfxdraw', _Stub())
+
+from engine import GameEngine
+from network import ValueNetwork
+from trainer import NeuralPlayer
+from players import RandomPlayer
+
+
+def play_match(player_white, player_black, max_turns, manipulation_mode='freeze'):
+    engine = GameEngine(max_turns=max_turns, manipulation_mode=manipulation_mode)
+    while engine.winner is None and engine.turn_number < max_turns:
+        turns = engine.get_all_legal_turns()
+        if not turns:
+            break
+        player = player_white if engine.current_player == 'white' else player_black
+        turn = player.choose_turn(turns, engine)
+        engine.execute_turn(turn)
+    return engine.winner, engine.turn_number, engine.loss_reason
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--checkpoint', required=True)
+    parser.add_argument('--num-games', type=int, default=20)
+    parser.add_argument('--max-turns', type=int, default=1500)
+    parser.add_argument('--epsilon', type=float, default=0.0)
+    parser.add_argument('--manipulation-mode', default='freeze')
+    parser.add_argument('--seed', type=int, default=None)
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    if not os.path.exists(args.checkpoint):
+        print(f'Checkpoint not found: {args.checkpoint}', file=sys.stderr)
+        return 1
+
+    print(f'Checkpoint: {args.checkpoint}')
+    network = ValueNetwork.load(args.checkpoint, device='cpu')
+    net_player = NeuralPlayer(network, device='cpu', epsilon=args.epsilon)
+    rand_player = RandomPlayer()
+
+    print(f'Playing {args.num_games} games vs RandomPlayer '
+          f'(max_turns={args.max_turns}, epsilon={args.epsilon})...')
+    print(f"  {'Game':>5}  {'Net as':>7}  {'Winner':>7}  {'Turns':>5}  Elapsed")
+
+    net_wins = rand_wins = draws = 0
+    net_white_wins = net_black_wins = 0
+    lengths = []
+    end_reasons = {}
+    t_start = time.time()
+
+    for i in range(args.num_games):
+        net_is_white = (i % 2 == 0)
+        if net_is_white:
+            pw, pb = net_player, rand_player
+            net_as = 'white'
+        else:
+            pw, pb = rand_player, net_player
+            net_as = 'black'
+
+        t = time.time()
+        winner, turns, reason = play_match(
+            pw, pb, args.max_turns, manipulation_mode=args.manipulation_mode)
+        elapsed = time.time() - t
+
+        if winner is None:
+            draws += 1
+            who = 'draw'
+        elif (net_is_white and winner == 'white') or (not net_is_white and winner == 'black'):
+            net_wins += 1
+            if net_is_white: net_white_wins += 1
+            else: net_black_wins += 1
+            who = 'Net'
+        else:
+            rand_wins += 1
+            who = 'Random'
+
+        lengths.append(turns)
+        reason = reason or 'unfinished'
+        end_reasons[reason] = end_reasons.get(reason, 0) + 1
+
+        print(f"  {i+1:>5}  {net_as:>7}  {who:>7}  {turns:>5}  {elapsed:.1f}s")
+
+    total = time.time() - t_start
+    print()
+    print(f'=== Benchmark Results ({args.num_games} games, {total:.0f}s total) ===')
+    print(f'  Network wins:  {net_wins}/{args.num_games} ({100*net_wins/args.num_games:.1f}%)')
+    print(f'    as white: {net_white_wins}, as black: {net_black_wins}')
+    print(f'  Random wins:   {rand_wins}/{args.num_games} ({100*rand_wins/args.num_games:.1f}%)')
+    print(f'  Draws:         {draws}/{args.num_games} ({100*draws/args.num_games:.1f}%)')
+    print(f'  Game length:   min={min(lengths)}, max={max(lengths)}, '
+          f'mean={sum(lengths)/len(lengths):.0f}')
+    print(f'  End reasons:   {end_reasons}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/compare_models.py
+++ b/tools/compare_models.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Pit two network checkpoints against each other in N self-play games.
+
+Useful for measuring relative strength as training progresses (e.g.,
+"is iter 50 actually stronger than iter 25?"). Also useful for picking
+a sensible Easy/Medium/Hard difficulty mapping by quantifying
+checkpoint-to-checkpoint win rates.
+
+Each game alternates which checkpoint plays white (50/50) to factor out
+any first-mover advantage. Results report win rates per checkpoint along
+with average game length, distribution, and end-reason breakdown.
+
+Example:
+    python3 tools/compare_models.py \\
+        --model-a models/variant_freeze_v3/model_iter_0010.pt \\
+        --model-b models/variant_freeze_v3/model_iter_0025.pt \\
+        --num-games 30 --max-turns 1500
+"""
+
+import argparse
+import os
+import sys
+import time
+import random
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Stub pygame so this script runs in any environment.
+class _Stub:
+    def __getattr__(self, n): return self
+    def __call__(self, *a, **k): return self
+sys.modules.setdefault('pygame', _Stub())
+sys.modules.setdefault('pygame.gfxdraw', _Stub())
+
+from engine import GameEngine
+from network import ValueNetwork
+from trainer import NeuralPlayer
+
+
+def play_match(player_white, player_black, max_turns, manipulation_mode='freeze'):
+    """Play one game with given white/black players. Returns
+    (winner, total_turns, loss_reason).
+    """
+    engine = GameEngine(max_turns=max_turns, manipulation_mode=manipulation_mode)
+    while engine.winner is None and engine.turn_number < max_turns:
+        turns = engine.get_all_legal_turns()
+        if not turns:
+            break
+        player = player_white if engine.current_player == 'white' else player_black
+        turn = player.choose_turn(turns, engine)
+        engine.execute_turn(turn)
+    return engine.winner, engine.turn_number, engine.loss_reason
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--model-a', required=True, help='Checkpoint A')
+    parser.add_argument('--model-b', required=True, help='Checkpoint B')
+    parser.add_argument('--num-games', type=int, default=20)
+    parser.add_argument('--max-turns', type=int, default=1500)
+    parser.add_argument('--epsilon', type=float, default=0.0,
+                        help='Exploration rate (0 = deterministic; >0 lets the '
+                             'network mix in random moves for diversity).')
+    parser.add_argument('--manipulation-mode', default='freeze')
+    parser.add_argument('--seed', type=int, default=None)
+    args = parser.parse_args()
+
+    if args.seed is not None:
+        random.seed(args.seed)
+
+    if not os.path.exists(args.model_a):
+        print(f'Model A not found: {args.model_a}', file=sys.stderr)
+        return 1
+    if not os.path.exists(args.model_b):
+        print(f'Model B not found: {args.model_b}', file=sys.stderr)
+        return 1
+
+    print(f'Model A: {args.model_a}')
+    print(f'Model B: {args.model_b}')
+    net_a = ValueNetwork.load(args.model_a, device='cpu')
+    net_b = ValueNetwork.load(args.model_b, device='cpu')
+    player_a = NeuralPlayer(net_a, device='cpu', epsilon=args.epsilon)
+    player_b = NeuralPlayer(net_b, device='cpu', epsilon=args.epsilon)
+
+    print(f'Playing {args.num_games} games (max_turns={args.max_turns}, '
+          f'epsilon={args.epsilon})...')
+    print(f"  {'Game':>5}  {'A as':>6}  {'Winner':>7}  {'Turns':>5}  {'Reason':>20}  Elapsed")
+
+    a_wins = b_wins = draws = 0
+    a_white_wins = a_black_wins = 0
+    lengths = []
+    end_reasons = {}
+    t_start = time.time()
+
+    for i in range(args.num_games):
+        # Alternate which model plays white.
+        a_is_white = (i % 2 == 0)
+        if a_is_white:
+            pw, pb = player_a, player_b
+            a_as = 'white'
+        else:
+            pw, pb = player_b, player_a
+            a_as = 'black'
+
+        t = time.time()
+        winner, turns, reason = play_match(
+            pw, pb, args.max_turns, manipulation_mode=args.manipulation_mode)
+        elapsed = time.time() - t
+
+        # Map winner color → which model won.
+        if winner is None:
+            draws += 1
+            who = 'draw'
+        elif (a_is_white and winner == 'white') or (not a_is_white and winner == 'black'):
+            a_wins += 1
+            if a_is_white: a_white_wins += 1
+            else: a_black_wins += 1
+            who = 'A'
+        else:
+            b_wins += 1
+            who = 'B'
+
+        lengths.append(turns)
+        reason = reason or 'unfinished'
+        end_reasons[reason] = end_reasons.get(reason, 0) + 1
+
+        print(f"  {i+1:>5}  {a_as:>6}  {who:>7}  {turns:>5}  {reason:>20}  {elapsed:.1f}s")
+
+    total = time.time() - t_start
+    print()
+    print(f'=== Results ({args.num_games} games, {total:.0f}s total) ===')
+    print(f'  Model A wins: {a_wins}/{args.num_games} ({100*a_wins/args.num_games:.1f}%)')
+    print(f'    as white: {a_white_wins}, as black: {a_black_wins}')
+    print(f'  Model B wins: {b_wins}/{args.num_games} ({100*b_wins/args.num_games:.1f}%)')
+    print(f'  Draws:        {draws}/{args.num_games} ({100*draws/args.num_games:.1f}%)')
+    print(f'  Game length:  min={min(lengths)}, max={max(lengths)}, '
+          f'mean={sum(lengths)/len(lengths):.0f}')
+    print(f'  End reasons:  {end_reasons}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three coordinated changes per user feedback:

### 1. No sub-choices anywhere

Per user: \"Any multi-step turn still needs to count as 1 single legal turn possibility for all AI evaluation and training purposes. Even random player should treat it as a single legal turn possibility with no sub-choices, so that each distinct possible full legal turn is only counted once.\"

The engine now enumerates each (move + jump_choice + promo_choice) combination as a separate, fully-specified Turn. Players just pick one — no second method call:

- **Turn class**: replaced \`jump_capture_targets\` / \`promotion_options\` (lists of options) with \`jump_choice\` / \`promo_choice\` (the SINGLE decision baked into this Turn). New \`has_jump_offer\` field distinguishes "no jump-capture offered" from "jump offered, this Turn is the decline option".
- **\`engine.get_all_legal_turns()\`**: now loops over each (jump_choice, promo_choice) combination per move, creating a Turn per combination.
- **\`engine.execute_turn(turn)\`**: signature simplified — no separate \`jump_capture_choice\` / \`promotion_choice\` args. Reads from the Turn directly.
- **NeuralPlayer**: \`choose_jump_capture\` and \`choose_promotion\` REMOVED. \`choose_turn\` just batch-evaluates each Turn.
- **RandomPlayer**: same simplification. Each fully-specified combination is one option in the random sample.
- **AIController._apply_spatial**: branches on Turn's stored choices, no sub-method calls. Latent next_turn double-call fixed.
- **\`src/selfplay.py\`** and **\`src/trainer.py\`** updated to use the new \`execute_turn(turn)\` signature.

### 2. Two new analysis tools

- **\`tools/compare_models.py\`** — head-to-head between two checkpoints, alternating colors, reports win rates / game lengths / end-reason distribution. Useful for "is iter 50 stronger than iter 25" + Easy/Medium/Hard mapping decisions.
- **\`tools/benchmark_checkpoint.py\`** — pits one checkpoint against RandomPlayer across N games. Measures absolute strength.

(\`tools/analyze_long_games.py\` complements these for investigating long-tail game dynamics.)

### 3. Easy AI bumped to iter 27

Latest available checkpoint. Will re-map to iter 50 / 100 once those exist.

## Test plan

- [x] 44/44 mode_selection + ai_controller pass.
- [x] 5/5 TestTrainingData pass.
- [x] 6/6 TestCombinationEvaluation pass — including new tests asserting NeuralPlayer/RandomPlayer have NO sub-choice methods and the engine enumerates each fully-specified Turn exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)