### PR TITLE
Trainer resume: preserve optimizer + stable epsilon; Easy AI auto-resolves checkpoint

### DIFF
--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -146,6 +146,31 @@ CLAUDE.md               # codebase + user instructions
 - #85 — All-turns-evaluated tests; easy → iter 20; long-game analyzer
 - #86 — Engine refactor: every Turn fully specified; tools; easy → iter 27 (now iter 32)
 
+## UPDATE (2026-05-27, later in session)
+
+### Training progress
+- At this update: **iter 49 complete, iter 50 in training phase.** `model_iter_0050.pt` imminent. Game lengths dropped to ~155 turns (network strengthening). Buffer near 500k cap. Loss ~0.04 (rose as buffer grew — normal).
+
+### Easy AI now AUTO-RESOLVES (no manual bump needed)
+- `Game._AI_CHECKPOINTS` (hardcoded dict) REPLACED with `Game._AI_DIFFICULTY` (target iteration + mode) and a `_resolve_ai_checkpoint(key)` classmethod.
+- **Easy = 'capped' at iter 50**: auto-picks the highest existing checkpoint ≤ 50. So it tracks the strongest available model up to iter 50, then stops. When `model_iter_0050.pt` lands, easy auto-uses it. NO manual update needed — this directly answers the user's "does easy auto-update?" (now: YES, capped at 50).
+- **Medium = 'exact' iter 75**, **Hard = 'exact' iter 100**: stay grayed-out until their exact checkpoint exists (no weak fallback).
+- To change caps: edit `Game._AI_DIFFICULTY` targets in `src/game.py`.
+
+### Pause/resume improvements (trainer.py) — NOT yet active on running process
+The user noted resume resets epsilon, optimizer, AND buffer. Implemented (applies to NEXT trainer launch/resume, NOT the currently-running PID 68135 which loaded old code):
+- **Optimizer state preserved**: saved to `<save_dir>/optimizer_state.pt` each iteration; restored on `--resume` (graceful skip if absent). Avoids Adam cold-start bump.
+- **Epsilon schedule made resume-stable**: new `--epsilon-decay-iters` arg (default 100). Epsilon now decays over a FIXED horizon (absolute iteration / decay_iters, clamped), so resuming at iteration K always gives the same epsilon regardless of `--iterations`. Previously the denominator was `start_iteration + n_iterations`, which shifted on each resume.
+- **Buffer NOT preserved** (decision): the replay buffer is up to 500k positions × 21×8×8 floats — too heavy to serialize each iteration (many GB). It rebuilds within a few iterations after resume. Documented trade-off; revisit only if buffer-reset proves to hurt.
+- **When resuming to iter 100**: use `python3 src/trainer.py ... --resume models/variant_freeze_v3/model_iter_0075.pt --iterations 25 --epsilon-decay-iters 100`. The optimizer_state.pt + epsilon-decay-iters=100 keep continuity.
+
+### Computer sleep wastes training time — SOLUTION
+- A sleeping Mac SUSPENDS all processes (you can't run during sleep — the CPU halts). The fix is to PREVENT sleep while training runs.
+- **Started `caffeinate -i -s -w 68135 &`** this session — prevents idle + system sleep until training PID 68135 exits (requires AC power for `-s`).
+- For LID-CLOSED operation (clamshell): connect power + (external display OR `sudo pmset -c disablesleep 1`, re-enable later with `... disablesleep 0`). Closing the lid otherwise sleeps regardless of caffeinate.
+- For future training launches, wrap in caffeinate directly: `caffeinate -i -s nohup python3 src/trainer.py ... &` so sleep-prevention is tied to the run automatically.
+- NOTE: the caffeinate started this session only lasts while PID 68135 lives; if the user restarts training, re-run caffeinate with the new PID.
+
 ## What the user keeps reminding you
 
 - "honest" / "honest reassessment" is a tell that you're about to be wrong. The user calls this out. Verify EVERYTHING carefully.

--- a/src/game.py
+++ b/src/game.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import re
 
 import pygame
 from pygame import gfxdraw
@@ -224,15 +225,23 @@ class Game:
         {'key': 'hard',   'label': 'AI Hard'},
     ]
 
-    # AI difficulty → checkpoint path. Difficulty is realised by training
-    # depth: an under-trained network is "easy" because it still picks
-    # near-random moves; a fully-trained network is "hard". Medium and
-    # hard checkpoints become available as training progresses; the menu
-    # grays out entries whose checkpoint does not exist on disk.
-    _AI_CHECKPOINTS = {
-        'easy':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0032.pt'),
-        'medium': os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0060.pt'),
-        'hard':   os.path.join(_REPO_ROOT, 'models/variant_freeze_v3/model_iter_0100.pt'),
+    # AI difficulty → target training iteration. Difficulty is realised by
+    # training depth: an under-trained network plays near-randomly ("easy"),
+    # a fully-trained network is "hard".
+    #
+    # Resolution modes (see _resolve_ai_checkpoint):
+    #   'capped' — use the checkpoint at `target` if it exists, else the
+    #     HIGHEST existing checkpoint at or below `target`. So Easy
+    #     automatically tracks the strongest available model up to its cap
+    #     and stops there (no manual bump needed as training progresses).
+    #   'exact'  — only use the exact `target` checkpoint; the option stays
+    #     unavailable (grayed out) until that checkpoint exists. Used for
+    #     Medium/Hard so they don't silently fall back to a weak model.
+    _CHECKPOINT_DIR = os.path.join(_REPO_ROOT, 'models/variant_freeze_v3')
+    _AI_DIFFICULTY = {
+        'easy':   {'target': 50,  'mode': 'capped'},
+        'medium': {'target': 75,  'mode': 'exact'},
+        'hard':   {'target': 100, 'mode': 'exact'},
     }
 
     def __init__(self, knight_mode=Board.KNIGHT_MODE_V2):
@@ -577,27 +586,58 @@ class Game:
         self.ai_controller = AIController(
             self.ai_color, player=self._make_ai_player(self.opponent))
 
+    @classmethod
+    def _resolve_ai_checkpoint(cls, opponent_key):
+        """Resolve an AI difficulty key to a concrete checkpoint path, or
+        None if no suitable checkpoint exists yet.
+
+        - 'capped' mode (Easy): returns the checkpoint at the target
+          iteration if it exists, else the HIGHEST existing checkpoint at
+          or below the target. So Easy auto-tracks the strongest available
+          model up to its cap (no manual bump needed) and never exceeds it.
+        - 'exact' mode (Medium/Hard): returns the exact target checkpoint
+          only if it exists, else None (stays unavailable).
+        """
+        cfg = cls._AI_DIFFICULTY.get(opponent_key)
+        if cfg is None:
+            return None
+        target = cfg['target']
+        exact = os.path.join(cls._CHECKPOINT_DIR, f'model_iter_{target:04d}.pt')
+        if os.path.exists(exact):
+            return exact
+        if cfg['mode'] == 'exact':
+            return None
+        # 'capped': pick the highest existing checkpoint with iter <= target.
+        best_path, best_iter = None, -1
+        if os.path.isdir(cls._CHECKPOINT_DIR):
+            for fname in os.listdir(cls._CHECKPOINT_DIR):
+                m = re.match(r'model_iter_(\d+)\.pt$', fname)
+                if m:
+                    it = int(m.group(1))
+                    if it <= target and it > best_iter:
+                        best_iter, best_path = it, os.path.join(
+                            cls._CHECKPOINT_DIR, fname)
+        return best_path
+
     def _make_ai_player(self, opponent_key):
         """Construct the AI player for a given opponent key.
 
-        - 'random'         → returns None, letting AIController default to
-          its built-in RandomPlayer baseline.
-        - 'easy' / 'medium' / 'hard' → loads the corresponding network
-          checkpoint and wraps it in a NeuralPlayer (with the network's
-          training depth as the difficulty dial — see _AI_CHECKPOINTS).
-          The CPU device is used to keep the UI's network independent of
-          any concurrently-running training on MPS/CUDA.
+        - 'random' → returns None, letting AIController default to its
+          built-in RandomPlayer baseline.
+        - 'easy' / 'medium' / 'hard' → resolves the difficulty to a
+          checkpoint (see _resolve_ai_checkpoint), loads the network, and
+          wraps it in a NeuralPlayer. CPU device keeps the UI network
+          independent of any concurrently-running training on MPS/CUDA.
 
-        Raises ValueError for unknown keys. For AI keys whose checkpoint
-        is missing, returns None and falls back to RandomPlayer so the
-        game stays playable; this should not normally happen because the
-        mode menu grays out unavailable options and skips their clicks.
+        Returns None (RandomPlayer fallback) for an AI key whose checkpoint
+        can't be resolved — normally unreachable because the mode menu
+        grays out and skips unavailable options.
         """
         if opponent_key == 'random':
             return None  # AIController defaults to RandomPlayer
-        if opponent_key in self._AI_CHECKPOINTS:
-            ckpt = self._AI_CHECKPOINTS[opponent_key]
-            if not os.path.exists(ckpt):
+        if opponent_key in self._AI_DIFFICULTY:
+            ckpt = self._resolve_ai_checkpoint(opponent_key)
+            if ckpt is None:
                 return None  # Falls back to RandomPlayer in AIController.
             # Lazy import: keep torch out of the import graph for the
             # non-AI code paths.
@@ -609,12 +649,12 @@ class Game:
             f"No player implementation for opponent {opponent_key!r}")
 
     def _ai_checkpoint_available(self, opponent_key):
-        """True iff the opponent key is either a non-AI key or has its
-        checkpoint file on disk. Used by show_mode_menu to gray out and
-        deactivate options whose checkpoint does not yet exist."""
-        if opponent_key not in self._AI_CHECKPOINTS:
+        """True iff the opponent key is a non-AI key, or its difficulty
+        resolves to an existing checkpoint. Used by show_mode_menu to gray
+        out and deactivate options that can't yet be played."""
+        if opponent_key not in self._AI_DIFFICULTY:
             return True  # 'human', 'random' — always available
-        return os.path.exists(self._AI_CHECKPOINTS[opponent_key])
+        return self._resolve_ai_checkpoint(opponent_key) is not None
 
     def is_any_menu_open(self):
         """True iff a UI selection menu is currently open. main.py uses this

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -383,6 +383,7 @@ def training_loop(
     max_turns=1000,
     epsilon_start=1.0,
     epsilon_end=0.1,
+    epsilon_decay_iters=100,
     epochs_per_iteration=10,
     batch_size=256,
     learning_rate=0.001,
@@ -445,8 +446,11 @@ def training_loop(
     all_states = []
     all_outcomes = []
 
-    # Load existing history if resuming
+    # Resume-state file paths.
     history_path = os.path.join(save_dir, 'training_history.json')
+    optimizer_path = os.path.join(save_dir, 'optimizer_state.pt')
+
+    # Load existing history if resuming
     start_iteration = 0
     if resume_from and os.path.exists(history_path):
         with open(history_path) as f:
@@ -454,15 +458,36 @@ def training_loop(
         start_iteration = len(history)
         print(f"Resuming from iteration {start_iteration + 1}")
 
+        # Restore optimizer state (Adam momentum/variance estimates) if a
+        # saved optimizer file exists. Without this, resuming resets the
+        # optimizer to a cold start, discarding accumulated moments and
+        # causing a brief training-instability bump after each resume.
+        # Gracefully skip if absent (older runs) or incompatible.
+        if os.path.exists(optimizer_path):
+            try:
+                opt_state = torch.load(optimizer_path, map_location=device)
+                optimizer.load_state_dict(opt_state)
+                print(f"Restored optimizer state from {optimizer_path}")
+            except Exception as exc:  # noqa: BLE001 - defensive: never block resume
+                print(f"WARNING: could not restore optimizer state "
+                      f"({exc}); continuing with a fresh optimizer.")
+
     # Buffer size: keep last N positions for training (sliding window)
     max_buffer_size = 500000
 
     for iteration in range(start_iteration, start_iteration + n_iterations):
         iter_start = time.time()
 
-        # Decay epsilon linearly over total planned iterations
+        # Decay epsilon linearly over a FIXED horizon (epsilon_decay_iters),
+        # NOT over (start_iteration + n_iterations). Using the absolute
+        # iteration against a fixed denominator makes the epsilon schedule
+        # CONTINUOUS across pause/resume — resuming at iteration K always
+        # yields the same epsilon regardless of how many iterations this
+        # particular run was configured for. Clamped so epsilon never
+        # overshoots epsilon_end once past the decay horizon.
         total_iters = start_iteration + n_iterations
-        epsilon = epsilon_start + (epsilon_end - epsilon_start) * (iteration / max(total_iters - 1, 1))
+        decay_frac = min(iteration / max(epsilon_decay_iters - 1, 1), 1.0)
+        epsilon = epsilon_start + (epsilon_end - epsilon_start) * decay_frac
 
         print(f"\n{'='*60}")
         print(f"Iteration {iteration + 1}/{total_iters} | epsilon={epsilon:.3f}")
@@ -583,6 +608,11 @@ def training_loop(
         checkpoint_path = os.path.join(save_dir, f'model_iter_{iteration + 1:04d}.pt')
         network.save(checkpoint_path)
 
+        # Save optimizer state alongside, so a later --resume can restore
+        # the Adam moments and continue without a cold-start bump. This is
+        # a single small file overwritten each iteration (not per-iter).
+        torch.save(optimizer.state_dict(), optimizer_path)
+
         # Record history (incl. per-iteration loss-reason breakdown for
         # post-hoc analysis without re-reading per-game JSONL).
         iter_info = {
@@ -632,6 +662,11 @@ if __name__ == '__main__':
                         help='Initial exploration rate')
     parser.add_argument('--epsilon-end', type=float, default=0.1,
                         help='Final exploration rate')
+    parser.add_argument('--epsilon-decay-iters', type=int, default=100,
+                        help='Fixed horizon (in absolute iterations) over '
+                             'which epsilon decays from start to end. Using a '
+                             'fixed horizon keeps the schedule continuous '
+                             'across pause/resume. Default 100.')
     parser.add_argument('--epochs', type=int, default=10,
                         help='Training epochs per iteration')
     parser.add_argument('--batch-size', type=int, default=256,
@@ -662,6 +697,7 @@ if __name__ == '__main__':
         max_turns=args.max_turns,
         epsilon_start=args.epsilon_start,
         epsilon_end=args.epsilon_end,
+        epsilon_decay_iters=args.epsilon_decay_iters,
         epochs_per_iteration=args.epochs,
         batch_size=args.batch_size,
         learning_rate=args.lr,

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -88,18 +88,21 @@ def test_opponent_options_includes_ai_difficulties():
     assert 'hard' in keys
 
 
-def test_ai_checkpoint_paths_configured():
-    """The class-level _AI_CHECKPOINTS dict maps each AI difficulty key to a
-    concrete checkpoint path (resolvable to a string; may or may not exist
-    on disk depending on training progress)."""
-    g = Game()
-    assert 'easy' in Game._AI_CHECKPOINTS
-    assert 'medium' in Game._AI_CHECKPOINTS
-    assert 'hard' in Game._AI_CHECKPOINTS
+def test_ai_difficulty_targets_configured():
+    """The class-level _AI_DIFFICULTY dict maps each AI difficulty key to a
+    target iteration and a resolution mode ('capped' or 'exact')."""
+    assert 'easy' in Game._AI_DIFFICULTY
+    assert 'medium' in Game._AI_DIFFICULTY
+    assert 'hard' in Game._AI_DIFFICULTY
     for key in ('easy', 'medium', 'hard'):
-        path = Game._AI_CHECKPOINTS[key]
-        assert isinstance(path, str)
-        assert path.endswith('.pt')
+        cfg = Game._AI_DIFFICULTY[key]
+        assert isinstance(cfg['target'], int)
+        assert cfg['mode'] in ('capped', 'exact')
+    # Easy is 'capped' (auto-tracks latest up to its cap); Medium/Hard are
+    # 'exact' (gated until their exact checkpoint exists).
+    assert Game._AI_DIFFICULTY['easy']['mode'] == 'capped'
+    assert Game._AI_DIFFICULTY['medium']['mode'] == 'exact'
+    assert Game._AI_DIFFICULTY['hard']['mode'] == 'exact'
 
 
 def test_ai_checkpoint_available_for_non_ai_keys():
@@ -117,17 +120,46 @@ def test_make_ai_player_random_returns_none():
     assert g._make_ai_player('random') is None
 
 
-def test_make_ai_player_easy_when_checkpoint_missing_falls_back():
-    """If the easy checkpoint isn't on disk, _make_ai_player returns None
-    so the AIController falls back to RandomPlayer rather than crashing."""
-    g = Game()
-    # Temporarily point easy to a non-existent path.
-    saved = Game._AI_CHECKPOINTS['easy']
-    Game._AI_CHECKPOINTS['easy'] = '/nonexistent/never/here.pt'
+def test_resolve_easy_capped_picks_highest_below_target(tmp_path):
+    """Easy ('capped') resolves to the highest existing checkpoint at or
+    below its target. With checkpoints 10, 20, 32 present and target 50,
+    it picks 32. When 50 exists, it picks 50. Never exceeds 50."""
+    saved_dir = Game._CHECKPOINT_DIR
+    saved_easy = dict(Game._AI_DIFFICULTY['easy'])
+    Game._CHECKPOINT_DIR = str(tmp_path)
+    Game._AI_DIFFICULTY['easy'] = {'target': 50, 'mode': 'capped'}
     try:
-        assert g._make_ai_player('easy') is None
+        for it in (10, 20, 32):
+            (tmp_path / f'model_iter_{it:04d}.pt').write_text('x')
+        resolved = Game._resolve_ai_checkpoint('easy')
+        assert resolved.endswith('model_iter_0032.pt')
+        # Now iter 50 lands → easy should pick it exactly.
+        (tmp_path / 'model_iter_0050.pt').write_text('x')
+        assert Game._resolve_ai_checkpoint('easy').endswith('model_iter_0050.pt')
+        # A later iter (60) must NOT be picked (cap is 50).
+        (tmp_path / 'model_iter_0060.pt').write_text('x')
+        assert Game._resolve_ai_checkpoint('easy').endswith('model_iter_0050.pt')
     finally:
-        Game._AI_CHECKPOINTS['easy'] = saved
+        Game._CHECKPOINT_DIR = saved_dir
+        Game._AI_DIFFICULTY['easy'] = saved_easy
+
+
+def test_resolve_medium_exact_unavailable_until_checkpoint_exists(tmp_path):
+    """Medium ('exact') resolves to None until its exact checkpoint exists,
+    even when lower checkpoints are present."""
+    saved_dir = Game._CHECKPOINT_DIR
+    saved_med = dict(Game._AI_DIFFICULTY['medium'])
+    Game._CHECKPOINT_DIR = str(tmp_path)
+    Game._AI_DIFFICULTY['medium'] = {'target': 75, 'mode': 'exact'}
+    try:
+        for it in (10, 32, 50):
+            (tmp_path / f'model_iter_{it:04d}.pt').write_text('x')
+        assert Game._resolve_ai_checkpoint('medium') is None  # 75 not present
+        (tmp_path / 'model_iter_0075.pt').write_text('x')
+        assert Game._resolve_ai_checkpoint('medium').endswith('model_iter_0075.pt')
+    finally:
+        Game._CHECKPOINT_DIR = saved_dir
+        Game._AI_DIFFICULTY['medium'] = saved_med
 
 
 # --- open / close menu ------------------------------------------------------


### PR DESCRIPTION
## Summary

Three improvements per user feedback.

### 1. Easy AI auto-resolves its checkpoint (no manual bump)

Replaced the hardcoded \`_AI_CHECKPOINTS\` dict with \`_AI_DIFFICULTY\` (target iteration + resolution mode) + a \`_resolve_ai_checkpoint\` classmethod:
- **Easy** ('capped' at iter 50): auto-picks the highest existing checkpoint ≤ 50. When \`model_iter_0050.pt\` lands (imminent), Easy auto-uses it. **No manual update needed.**
- **Medium** ('exact' iter 75) / **Hard** ('exact' iter 100): grayed out until their exact checkpoint exists.

Answers the user's "does easy auto-update?" — now YES (capped). Also satisfies "update easy to iter 50 when iter 50 completes" automatically.

### 2. Trainer resume preserves optimizer state + stable epsilon

- **Optimizer**: saved to \`optimizer_state.pt\` each iteration; restored on \`--resume\` (graceful skip if absent). Avoids Adam cold-start bump.
- **Epsilon**: new \`--epsilon-decay-iters\` arg (default 100). Decays over a FIXED horizon so resuming at iteration K always yields the same epsilon. Previously the denominator shifted on each resume.
- **Buffer**: NOT preserved (too heavy — up to 500k × 21×8×8 floats; rebuilds in a few iters). Documented.

Applies to the NEXT launch/resume — the running process (PID 68135) is unaffected, **no pause needed**.

### 3. Computer-sleep handling (ops)

A sleeping Mac suspends all processes — you can only prevent sleep, not run during it. Started \`caffeinate -i -s -w <pid>\` this session. Future launches: \`caffeinate -i -s nohup python3 src/trainer.py ...\`. Lid-closed needs clamshell or \`pmset -c disablesleep 1\`.

## Test plan

- [x] 39/39 mode_selection + ai_controller tests pass.
- [x] New tests for capped/exact checkpoint resolution.
- [x] trainer imports cleanly; \`--epsilon-decay-iters\` wired through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)