### PR TITLE
Reset confirmation + bishop teleport-safety rationale

### DIFF
--- a/docs/RULEBOOK_v2_elaborated.md
+++ b/docs/RULEBOOK_v2_elaborated.md
@@ -253,6 +253,76 @@ It may teleport to any square that:
 
 Capturable squares include squares that can be captured by the knight’s jump capture.
 
+### **Why teleport-safety reads "move *or* capture" (design rationale)**
+
+The two-clause restriction looks at first like a capture-safety check with an
+incidental pawn exception (pawns are the only piece that can move to a square
+they cannot capture to — sideways), but it is actually one clean principle:
+
+> **The bishop hides on squares no enemy can directly reach this turn — by
+> spatial movement OR by capture.**
+
+This framing reflects the bishop's intended **stealth / sniper** identity. The
+bishop does not travel across the board; it *redeploys* to an overwatch
+position. Reactive capture means it does not initiate attacks — it watches its
+diagonals and punishes enemies who *move* through its sightline. To stay
+consistent with that "concealed sniper" theme, the bishop must hide on ground
+the enemy cannot tread at all — not just ground the enemy cannot strike from.
+The pawn-sideways case is the rule *working as intended*, not a wart:
+sideways-adjacent to an enemy pawn is reachable, so it is not hidden ground,
+so the bishop refuses it.
+
+This deliberately contrasts the bishop with the knight. The knight is the
+overt cavalry infiltrator: it charges into contested space and earns
+temporary invulnerability for the commitment. The bishop refuses contested
+space entirely and strikes from hiding. Two infiltration philosophies, two
+distinct silhouettes — keeping the broad "move-or-capture" check is what gives
+the bishop its rear-line-controller character.
+
+The bishop only ever *exposes itself* in two cases:
+
+* it makes a reactive capture (teleport-safety is ignored on the capturing
+  teleport, so it can land exposed — the sniper reveals its position by
+  firing), or
+* it is itself pinned by an enemy bishop's line of sight and chooses to break
+  cover anyway (enemy bishops are excluded from the safety check — see below
+  — so a pinned bishop retains the choice to move, accepting the reactive
+  shot).
+
+### **Why enemy bishops (and queens-as-bishop) are excluded — destination vs. source**
+
+Excluding enemy bishops from the safety check is not arbitrary special-casing.
+It falls out of the same "can an enemy directly reach this destination this
+turn?" test, applied honestly:
+
+* **Knight jump-capture is destination-based.** A piece becomes
+  jump-capturable by *landing* at chebyshev-1 of an enemy knight. Whether
+  square X is jump-capturable is a property of X itself (plus the knight's
+  position). The threat acts on the destination directly → correctly
+  **included** in the safety check.
+* **Bishop reactive capture is source-based.** An enemy bishop can only strike
+  a piece that *began its move* on the enemy bishop's diagonal. The threat is
+  conditional on where the bishop came *from*, not on the destination square.
+  In the unreachability sense the enemy bishop cannot "reach" X this turn → 
+  correctly **excluded**.
+
+The boulder is excluded for the same destination-vs-source reason: the boulder
+has no proactive capture range, so it does not threaten any destination this
+turn.
+
+Beyond consistency, the enemy-bishop exclusion is also what makes two
+strategic mechanics possible:
+
+1. **Mutual bishop pins / standoffs.** Two bishops can sit on each other's
+   diagonals, each pinning the other (a key lockdown mechanic in the tiny
+   endgame analysis). If enemy-bishop LoS were included in the safety check,
+   any bishop whose square already sat on an enemy diagonal would have zero
+   teleport-safe destinations — frozen solid, no agency.
+2. **A pinned bishop keeps the choice to break cover.** Without the exclusion,
+   a pinned bishop would be mechanically locked out of moving. With it, the
+   pinned bishop *may* move (accepting the reactive shot) — a deliberate
+   tactical decision rather than a forced freeze.
+
 ### **Bishop Capture Mechanic**
 
 If a piece begins its move on a square within the bishop’s **diagonal line of sight**, then:

--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -177,3 +177,39 @@ The user noted resume resets epsilon, optimizer, AND buffer. Implemented (applie
 - Don't randomly pick any sub-choices — every full Turn must be a single distinct option, evaluated as such. (PR #86 nailed this; do NOT regress.)
 - Work directly on the main repo at `/Users/ag/Code/python-chess-ai-yt/`. Feature branches OK; do NOT use worktrees.
 - Mirror memory files to `docs/design-notes/` whenever you change them, and commit.
+
+## UPDATE (2026-05-29 — reset confirmation + bishop rationale)
+
+### Training progress at this update
+- **iter 57/75 complete** (process still PID 68135, started 2026-05-25). `model_iter_0050.pt` landed → Easy AI auto-resolved to it (per the auto-resolve mechanic from PR #88). Latest iter 57: W=44 B=56, avg_len ~172 turns, loss ~0.048 (loss is in normal "buffer-full + harder positions" range). 0 draws/0 repetitions still hold across all 5700+ games. caffeinate (separate PID, this session's) still holding off sleep.
+- After current run completes at iter 75, plan resume to iter 100: `python3 src/trainer.py ... --resume models/variant_freeze_v3/model_iter_0075.pt --iterations 25 --epsilon-decay-iters 100` (resume-stable optimizer + epsilon kick in here).
+
+### Reset-game confirmation (PR pending — this branch)
+- Branch: `claude/reset-confirm-bishop-rationale`. PR not yet opened at the time of this writing — open at end of session.
+- Problem: pressing 'R' immediately reset the in-progress game — user lost games to accidental keystrokes.
+- Fix: 'R' now opens a confirmation overlay. Y/Enter confirms the reset; N/Esc cancels. While the overlay is up, `Game.is_any_menu_open()` is True, so the main loop gates other interactions exactly like the mode/promo menus.
+- New `Game.reset_confirm_pending: bool` flag (default False) + `Game.show_reset_confirm(surface)` render method. Hooked into the main render order between `show_winner` and the next frame.
+- Tests in `tests/test_reset_confirm.py` (5 tests, all pass): flag default, gating via `is_any_menu_open`, `reset()` clears the flag, overlay no-op when not pending, overlay visibly draws when pending. Pygame headless via SDL dummy drivers.
+- Files touched: `src/game.py`, `src/main.py`, `tests/test_reset_confirm.py`.
+
+### Bishop teleport-safety rationale added to elaborated rulebook
+- Added to `docs/RULEBOOK_v2_elaborated.md` two new subsections under "Bishop":
+  1. **"Why teleport-safety reads move *or* capture (design rationale)"** — frames the broad rule as a single principle ("the bishop hides on squares no enemy can directly reach this turn") rather than capture-safety + pawn exception. The pawn-sideways block is the rule working as intended — sideways-adjacent to a pawn is reachable, so it's not hidden ground. Reinforces the bishop's **rear-line sniper / overwatch** identity in deliberate contrast with the knight's overt cavalry infiltration. The bishop only exposes itself when (a) it captures (safety-check ignored on the capturing teleport — the sniper reveals position by firing) or (b) it's pinned by an enemy bishop and chooses to break cover.
+  2. **"Why enemy bishops (and queens-as-bishop) are excluded — destination vs. source"** — distinguishes destination-based threats (knight jump-capture; depends on the square X itself, so INCLUDED in safety check) from source-based threats (enemy bishop reactive capture; depends on where the bishop came from, not on X, so EXCLUDED). Boulder excluded for the same reason (no proactive capture range). Plus: the exclusion is what makes mutual bishop pins / standoffs possible and what keeps a pinned bishop's agency (it may still choose to move and accept the reactive shot, rather than being mechanically locked).
+- This is a **clarification / "keep and articulate"** change — the implemented behavior already matches. No code change. The concise `RULEBOOK_v2.md` is intentionally unchanged (the "why" lives in the elaborated copy by design — split established in PR #80).
+- This decision came out of a long side-chat where the user weighed broad ("move + capture") vs narrow ("capture only") teleport-safety. **Final user lean: REAR-LINE SNIPER (broad rule, keep current).** Direct quote from the user that grounds it: *"The bishop essentially 'hides' itself from enemies - it doesn't want to be easily seen or exposed, like an assassin. It hides out of enemy sight and strikes when they least expect it, punishing their movement when they are least attentive."*
+
+### Bishop strategic-strength notes (from same side-chat — read before any tiny-endgame work)
+- This variant's R / N / B are MUCH closer in value than standard chess (consistent with 1-unit-each tiny-endgame valuation):
+  - Rook: nerfed vs standard (1-step + 90° + sweep, not unlimited single-axis). Proactive captures, forking, more blockable.
+  - Knight: buffed vs standard (24 squares of influence = 16 movement + 8 jump-capture, plus reactive jump-capture + supported invulnerability).
+  - Bishop: midgame situationally weaker (reactive-only capture — depends on opponent cooperating), endgame strong (global teleport + the key piece for leashing an enemy queen-as-bishop; 0-bishop endgames like 2R+N / 2N+R were exactly the hardest tiny-endgame compositions).
+- Rough parity in aggregate (R ≈ N ≈ B) but DIFFERENT shapes: rook = direct firepower, knight = area control + dual capture, bishop = positional control + endgame mobility.
+- Future work flagged for after training matures: build an endgame-matchup harness (K+R vs K+B, K+N vs K+B, etc.) using the trained checkpoints + `tools/compare_models.py` style code to get empirical relative-value numbers.
+
+### Roadmap-aware reading order for next session
+1. This handoff file (top to bottom).
+2. `RULEBOOK_v2.md` (concise, current rules).
+3. `docs/key-rule-differences.md` (cheat sheet).
+4. `docs/RULEBOOK_v2_elaborated.md` — has the new bishop rationale.
+5. `git log --oneline -20` for recent design context.

--- a/src/game.py
+++ b/src/game.py
@@ -278,6 +278,11 @@ class Game:
         # (live-settings model) so the user can also change the other.
         self.mode_menu = None             # dict with 'sides' + 'opponents', or None
         self.mode_menu_rects = []         # [(rect, 'side'|'opponent', key), ...]
+        # Reset-game confirmation. True iff the user pressed 'R' and we are
+        # waiting for them to confirm (Y / Enter) or cancel (N / Esc). The
+        # overlay is rendered by show_reset_confirm; main.py treats it like
+        # any other open menu (no interactions while up).
+        self.reset_confirm_pending = False
         # User choices — the two dimensions the menu exposes.
         self.user_side = 'white'          # the colour the human plays
         self.opponent = 'human'           # 'human' or an AI key (e.g. 'random')
@@ -663,7 +668,25 @@ class Game:
             self.transform_menu is not None
             or self.promotion_menu is not None
             or self.mode_menu is not None
+            or self.reset_confirm_pending
         )
+
+    def show_reset_confirm(self, surface):
+        """Render the reset-game confirmation overlay if pending."""
+        if not self.reset_confirm_pending:
+            return
+        w, h = surface.get_size()
+        backdrop = pygame.Surface((w, h), pygame.SRCALPHA)
+        backdrop.fill((0, 0, 0, 170))
+        surface.blit(backdrop, (0, 0))
+        title_font = pygame.font.SysFont('arial', 28, bold=True)
+        body_font = pygame.font.SysFont('arial', 20)
+        title = title_font.render('Reset the game?', True, (255, 255, 255))
+        body = body_font.render(
+            'Press Y or Enter to reset.   Press N or Esc to cancel.',
+            True, (220, 220, 220))
+        surface.blit(title, title.get_rect(center=(w // 2, h // 2 - 30)))
+        surface.blit(body, body.get_rect(center=(w // 2, h // 2 + 20)))
 
     def show_mode_menu(self, surface):
         """Render the mode-selection menu, if open, and populate

--- a/src/main.py
+++ b/src/main.py
@@ -125,6 +125,7 @@ class Main:
             game.show_promotion_menu(screen)
             game.show_mode_menu(screen)
             game.show_winner(screen)
+            game.show_reset_confirm(screen)
             board.update_lines_of_sight()
             board.update_threat_squares()
 
@@ -706,12 +707,22 @@ class Main:
                     if event.key == pygame.K_t:
                         game.change_theme()
 
-                     # reset the game
-                    if event.key == pygame.K_r:
-                        game.reset()
-                        game = self.game
-                        board = self.game.board
-                        dragger = self.game.dragger
+                    # reset the game — gated behind a confirmation overlay
+                    # so an accidental 'R' press doesn't wipe an in-progress
+                    # game. First 'R' opens the prompt; Y/Enter confirms, N/Esc
+                    # cancels. While the prompt is up, is_any_menu_open() is
+                    # True, so other input is gated (matches mode/promo menus).
+                    if game.reset_confirm_pending:
+                        if event.key in (pygame.K_y, pygame.K_RETURN):
+                            game.reset_confirm_pending = False
+                            game.reset()
+                            game = self.game
+                            board = self.game.board
+                            dragger = self.game.dragger
+                        elif event.key in (pygame.K_n, pygame.K_ESCAPE):
+                            game.reset_confirm_pending = False
+                    elif event.key == pygame.K_r:
+                        game.reset_confirm_pending = True
 
                 # quit application
                 elif event.type == pygame.QUIT:

--- a/tests/test_reset_confirm.py
+++ b/tests/test_reset_confirm.py
@@ -1,0 +1,79 @@
+"""Tests for the 'R' reset-game confirmation overlay.
+
+Pressing 'R' should NOT immediately wipe an in-progress game — it should
+open a confirmation prompt so an accidental keystroke doesn't destroy state.
+
+We test the Game-side state machine (the flag + how it interacts with
+is_any_menu_open and reset()), not the pygame key dispatch in main.py,
+because main.py is a long-running event loop and isn't unit-test-friendly.
+The dispatch itself is a thin 5-line branch over the flag — covered by
+manual smoke testing.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+from game import Game
+
+
+def test_reset_confirm_pending_defaults_false():
+    """A fresh game has no pending reset prompt."""
+    g = Game()
+    assert g.reset_confirm_pending is False
+
+
+def test_pending_flag_blocks_other_input_via_is_any_menu_open():
+    """While the confirm prompt is up, is_any_menu_open() is True so the
+    main loop gates other interactions (matching how the mode/promo menus
+    behave). Without this, the user could still click pieces underneath
+    the overlay."""
+    g = Game()
+    assert g.is_any_menu_open() is False
+    g.reset_confirm_pending = True
+    assert g.is_any_menu_open() is True
+    g.reset_confirm_pending = False
+    assert g.is_any_menu_open() is False
+
+
+def test_reset_clears_pending_flag():
+    """If the prompt is somehow up when reset() runs (defensive), it should
+    be cleared post-reset — reset() calls __init__() which re-initializes
+    every flag back to default."""
+    g = Game()
+    g.reset_confirm_pending = True
+    g.reset()
+    assert g.reset_confirm_pending is False
+
+
+def test_show_reset_confirm_noop_when_not_pending():
+    """No overlay when no prompt is up — surface must be untouched."""
+    surface = pygame.Surface((400, 400))
+    surface.fill((10, 20, 30))
+    g = Game()
+    g.show_reset_confirm(surface)
+    # Pixel at center should be unchanged.
+    assert surface.get_at((200, 200))[:3] == (10, 20, 30)
+
+
+def test_show_reset_confirm_draws_overlay_when_pending():
+    """Overlay must visibly change the surface when pending."""
+    surface = pygame.Surface((400, 400))
+    surface.fill((10, 20, 30))
+    g = Game()
+    g.reset_confirm_pending = True
+    g.show_reset_confirm(surface)
+    # After the dark backdrop + text blit, the center pixel differs from
+    # the original bg color.
+    assert surface.get_at((200, 200))[:3] != (10, 20, 30)


### PR DESCRIPTION
## Summary
- 'R' key now opens a confirmation overlay (Y/Enter confirms, N/Esc cancels) instead of resetting immediately — fixes accidental-keystroke game wipes
- Adds two rationale subsections to docs/RULEBOOK_v2_elaborated.md under Bishop: (1) why teleport-safety reads "move OR capture" as a single hidden-ground principle, framing the bishop's rear-line-sniper identity vs the knight's overt infiltrator; (2) why enemy bishops / queens-as-bishop / boulder are excluded — destination-vs-source threat distinction. No code change for the rulebook part — keep-and-articulate.
- Mirrors handoff memory into docs/design-notes/ per the project's standing rule.

## Test plan
- [x] tests/test_reset_confirm.py — 5 tests covering the flag default, gating via is_any_menu_open, reset() clearing the flag, and overlay visibility (all pass)
- [x] tests/test_mode_selection.py — unchanged, still passes (39 total in the merged run)
- [ ] Manual: launch main.py, press R, confirm overlay appears; press Esc/N to cancel; press R then Y/Enter to confirm reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)