### PR TITLE
Fix reset-confirm keys; raise Easy cap to iter 75; boulder rationale

### DIFF
--- a/docs/RULEBOOK_v2_elaborated.md
+++ b/docs/RULEBOOK_v2_elaborated.md
@@ -306,9 +306,23 @@ turn?" test, applied honestly:
   In the unreachability sense the enemy bishop cannot "reach" X this turn → 
   correctly **excluded**.
 
-The boulder is excluded for the same destination-vs-source reason: the boulder
-has no proactive capture range, so it does not threaten any destination this
-turn.
+The **boulder** is excluded for a different reason — it is treated as a
+**friendly piece for almost every rule purpose**, not as an enemy. (See the
+Boulder section for the full set of friendly-treatment cases: invuln support,
+manipulation rules, jump-capture targeting, etc.) The bishop's teleport-safety
+check considers only *enemy* reach, so the boulder is disregarded as a matter
+of consistency with that broader treatment, regardless of whether it could
+theoretically reach the destination this turn.
+
+For completeness: even if the boulder were treated as an enemy here, the
+restriction would only trigger under the "move-but-not-capture" sub-case
+(the bishop can never actually be captured by the boulder — the boulder
+captures **pawns only**). With its cooldown over, the boulder could in
+principle walk king-like onto a non-no-return-square the bishop wanted, so
+it would behave like the pawn-sideways case: a reachability block, not a
+capture block. But this hypothetical doesn't fire — the boulder's
+friendly-piece treatment removes it from the safety check entirely. The
+cooldown is incidental to this decision, not the driver.
 
 Beyond consistency, the enemy-bishop exclusion is also what makes two
 strategic mechanics possible:

--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -213,3 +213,40 @@ The user noted resume resets epsilon, optimizer, AND buffer. Implemented (applie
 3. `docs/key-rule-differences.md` (cheat sheet).
 4. `docs/RULEBOOK_v2_elaborated.md` — has the new bishop rationale.
 5. `git log --oneline -20` for recent design context.
+
+## UPDATE (2026-05-29 — second update of the same calendar day)
+
+### Training progress at this update
+- **iter 58/75 complete.** Latest iter 58: W=49 B=51 avg_len=152 loss=0.0479. Training/caffeinate both alive (PID 68135 ELAPSED 2d 17h; PID 25876 caffeinate ELAPSED ~17h). Game lengths continue to shorten (172 → 152), still 0 draws / 0 repetitions.
+
+### Easy AI cap raised from 50 → 75 (`_AI_DIFFICULTY` in src/game.py)
+- User played Easy at iter 50, found it still too weak. Bumped target to 75 (still 'capped' mode — auto-tracks the strongest available checkpoint up to the cap). Once `model_iter_0075.pt` lands, Easy and Medium will resolve to the SAME checkpoint (Medium is exact-75). User accepts this and will re-tune Easy downward if it's then too strong after observing it — likely by introducing a temperature / blunder-rate knob rather than another iteration step.
+- The `_AI_DIFFICULTY` literal in game.py now carries a comment explaining the design (capped vs exact + the iter-75 overlap caveat).
+
+### Reset-confirm overlay — bugfix + scope tightening
+The first-cut reset-confirm dispatch (PR #89) lived at the BOTTOM of the KEYDOWN handler and was being shadowed:
+- **Esc** was eaten by the jump-capture / mode-menu close branch at the top (it `continue`s).
+- **Y** was eaten by the redo branch (it `continue`s and treats Y as "redo a turn").
+- **N** and **Enter** had no earlier handlers → they fell through and worked.
+
+Fix moves the entire reset-confirm intercept to the TOP of KEYDOWN. While the overlay is up only a tight whitelist passes:
+- **Y / Enter** → confirm reset.
+- **N / Esc / R** → cancel. (User asked for "press R again to cancel" — natural toggle.)
+- **T** → theme change passes through (viewing pref).
+- **F** → flip board passes through (viewing pref).
+- **All other keys** (U undo, Y-as-redo, M mode-menu, mouse drags via the implicit `is_any_menu_open`-based guarding) → suppressed.
+
+This satisfies the user's spec: "undo/redo and game mode selection should be disabled. Theme and flip board can still be enabled. Y and Esc should work. Press R again cancels."
+
+The R handler at the bottom of KEYDOWN now only OPENS the prompt — it does not handle the close path (that moved to the top intercept).
+
+### Boulder exclusion rationale corrected in elaborated rulebook
+User flagged that the previous wording ("boulder is excluded because it has no proactive capture range") was the wrong reason. Correct rationale: **the boulder is treated as a friendly piece for almost every rule purpose**, so it doesn't enter the *enemy-reach* check at all. The cooldown is incidental.
+
+For completeness: even hypothetically treating the boulder as an enemy here, the bishop can never be CAPTURED by the boulder (boulder captures pawns only). So the bishop's restriction against the boulder would reduce to a "move-but-not-capture" reachability block (analogous to the pawn-sideways case) — but this hypothetical doesn't fire because friendly-piece treatment removes the boulder entirely.
+
+This is text-only in `docs/RULEBOOK_v2_elaborated.md`; no code change.
+
+### Branch
+`claude/reset-confirm-bishop-rationale` (this branch) — open PR after committing.
+PR #89 (the earlier reset-confirm + bishop-rationale first cut) is already merged. This new commit goes on a fresh branch since #89's branch is deleted.

--- a/src/game.py
+++ b/src/game.py
@@ -239,7 +239,17 @@ class Game:
     #     Medium/Hard so they don't silently fall back to a weak model.
     _CHECKPOINT_DIR = os.path.join(_REPO_ROOT, 'models/variant_freeze_v3')
     _AI_DIFFICULTY = {
-        'easy':   {'target': 50,  'mode': 'capped'},
+        # 'capped' = use the strongest existing checkpoint with iter <= target
+        # (auto-tracks training progress up to the cap). 'exact' = must match
+        # the exact target iteration; otherwise the option is disabled in
+        # the mode menu.
+        #
+        # Easy cap raised from 50 -> 75 (2026-05-29): iter 50 still played
+        # too weakly against the user. Once iter 75 lands, Easy and Medium
+        # will resolve to the same checkpoint; if Easy is then too strong,
+        # re-tune downward (or split via a different mechanism such as
+        # higher action-selection temperature) at that point.
+        'easy':   {'target': 75,  'mode': 'capped'},
         'medium': {'target': 75,  'mode': 'exact'},
         'hard':   {'target': 100, 'mode': 'exact'},
     }

--- a/src/main.py
+++ b/src/main.py
@@ -656,6 +656,44 @@ class Main:
                 # key press
                 elif event.type == pygame.KEYDOWN:
 
+                    # Reset-confirm overlay: intercepts at the TOP of the
+                    # KEYDOWN dispatch so it can't be shadowed by other
+                    # handlers (Esc was being eaten by the jump-cancel
+                    # branch, Y by the redo branch — both used `continue`).
+                    # While the overlay is up only a tight whitelist of keys
+                    # is honoured:
+                    #   - Y / Enter: confirm reset
+                    #   - N / Esc:   cancel
+                    #   - R:         cancel (the same key that opened it
+                    #                also closes it — natural toggle)
+                    #   - T:         theme change (a viewing preference,
+                    #                doesn't interfere with the pending
+                    #                reset decision)
+                    #   - F:         flip board (same — viewing pref)
+                    # All other keys (M / U / Y-as-redo / piece dragging) are
+                    # SUPPRESSED — they could mutate state mid-decision.
+                    if game.reset_confirm_pending:
+                        if event.key in (pygame.K_y, pygame.K_RETURN):
+                            game.reset_confirm_pending = False
+                            game.reset()
+                            game = self.game
+                            board = self.game.board
+                            dragger = self.game.dragger
+                            continue
+                        if event.key in (
+                            pygame.K_n, pygame.K_ESCAPE, pygame.K_r):
+                            game.reset_confirm_pending = False
+                            continue
+                        if event.key == pygame.K_t:
+                            game.change_theme()
+                            continue
+                        if event.key == pygame.K_f:
+                            game.flip_board()
+                            continue
+                        # Suppress everything else — undo/redo, mode menu,
+                        # etc. should not run while the user is mid-decision.
+                        continue
+
                     # Esc: cancel an in-progress jump-capture second click,
                     # OR close the mode menu if it's open. (If neither is
                     # active, Esc does nothing — we don't want it to also
@@ -709,19 +747,12 @@ class Main:
 
                     # reset the game — gated behind a confirmation overlay
                     # so an accidental 'R' press doesn't wipe an in-progress
-                    # game. First 'R' opens the prompt; Y/Enter confirms, N/Esc
-                    # cancels. While the prompt is up, is_any_menu_open() is
-                    # True, so other input is gated (matches mode/promo menus).
-                    if game.reset_confirm_pending:
-                        if event.key in (pygame.K_y, pygame.K_RETURN):
-                            game.reset_confirm_pending = False
-                            game.reset()
-                            game = self.game
-                            board = self.game.board
-                            dragger = self.game.dragger
-                        elif event.key in (pygame.K_n, pygame.K_ESCAPE):
-                            game.reset_confirm_pending = False
-                    elif event.key == pygame.K_r:
+                    # game. The first 'R' press here only OPENS the prompt;
+                    # the actual reset / cancel / re-press-to-cancel logic
+                    # lives in the reset-confirm intercept at the top of
+                    # this KEYDOWN dispatch (so other handlers can't
+                    # shadow the confirmation keys).
+                    if event.key == pygame.K_r:
                         game.reset_confirm_pending = True
 
                 # quit application


### PR DESCRIPTION
## Summary
- **Reset-confirm key fix**: Y and Esc were being shadowed by earlier handlers (redo + jump-cancel) that `continue` before the confirm dispatch was reached. Moved the entire confirm intercept to the TOP of KEYDOWN. While the overlay is up: Y/Enter confirm, N/Esc/R cancel (R re-press as toggle, per user), T/F pass through (viewing prefs), everything else suppressed (undo/redo/mode-menu).
- **Easy AI cap 50 → 75**: iter 50 still played too weak. Now auto-tracks up to iter 75 (same as Medium once that lands; user accepts the overlap and will re-tune later via temperature/blunder rate).
- **Boulder rationale corrected** in elaborated rulebook: the boulder is excluded from teleport-safety because it's treated as a friendly piece for most rule purposes — NOT because it has no proactive capture range. Completeness paragraph notes that even hypothetically treating it as an enemy would only produce a move-but-not-capture reachability block (boulder captures pawns only), so the bishop is never actually capturable by it.

## Test plan
- [x] tests/test_reset_confirm.py + tests/test_mode_selection.py — 39 pass
- [ ] Manual: launch main.py, open reset confirm with R; verify Y/Enter confirm, N/Esc/R cancel, T/F still work, U/M suppressed during the prompt
- [ ] When model_iter_0075.pt lands, verify Easy auto-resolves to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)