### PR TITLE
CvC mode + Easy iter 100 + Goal 4 kickoff doc

### DIFF
--- a/docs/design-notes/project_roadmap.md
+++ b/docs/design-notes/project_roadmap.md
@@ -73,11 +73,12 @@ Rationale for the args:
 4. Run the training command above (consider `tmux` or `nohup` for long-running session).
 5. Monitor progress; expect iteration 1 to be the slowest.
 
-### Goal 4 (ambitious, research) — GDL + GGP
+### Goal 4 (ambitious, research) — GDL + GGP — KICKOFF 2026-05-30
 - **GDL (Game Description Language):** formalize the written game rules into a logical/declarative GDL representation. Converts RULEBOOK_v2.md prose into machine-readable formal logic.
 - **GGP (General Game Player):** build/use a general game player that takes the GDL as input. A GGP can adapt to rule modifications WITHOUT full re-training each time — a huge advantage given how often this variant's rules change.
 - This variant could serve as a **benchmark for GGPs** (it's a novel, non-trivial game with unusual mechanics: reactive captures, manipulation, transformation, boulder, tiny-endgame rule).
 - This is the heavy-research direction, aligned with ISEF / ROBO ambitions.
+- **Status (2026-05-30): KICKOFF DOC LANDED** at `docs/goal4_gdl_ggp_planning.md`. The doc lays out the GDL landscape (GDL-I vs Ludii), why this variant is a good benchmark, the hardest formalization parts (bishop reactive capture = source-based predicate; repetition state hashing; tiny-endgame valuation; knight invuln condition; etc.), an 11-step incremental rollout plan starting with kings+base-queens only, and 5 open questions for the user to decide before any GDL writing begins (dialect choice, GGP strength target, ISEF scope, timeline, engine-as-ground-truth treatment). NOTHING ELSE STARTED YET — waiting on user answers to the open questions in §6 of that doc.
 
 ## Sequencing note
 Goals 1 → (finalize rules) → 3 (train) is the dependency chain: don't train (Goal 3) until rules are finalized (which Goal 1 + a rules-finalization pass support). Goal 2 (human-vs-AI mode) can proceed in parallel since it doesn't depend on rule finalization (it uses whatever rules + whatever trained/untrained AI exists). Goal 4 (GDL/GGP) is the long-horizon research payoff.

--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -250,3 +250,42 @@ This is text-only in `docs/RULEBOOK_v2_elaborated.md`; no code change.
 ### Branch
 `claude/reset-confirm-bishop-rationale` (this branch) — open PR after committing.
 PR #89 (the earlier reset-confirm + bishop-rationale first cut) is already merged. This new commit goes on a fresh branch since #89's branch is deleted.
+
+## UPDATE (2026-05-30 — CvC mode + Easy iter 100 cap + Goal 4 kickoff)
+
+### Training progress at this update
+- **iter 64/75 complete.** Latest iter 64: W=50 B=50 (perfect balance), avg_len=168 turns, loss=0.0486. Training process PID 68135 ELAPSED 3d 5h+; caffeinate PID 25876 ELAPSED 1d 5h+. Both still alive. Still 0 draws / 0 repetitions across all 6400+ games.
+- User feedback: at iter 64 the network is still blundering — possibly worse than random. They opted to push Easy cap all the way to iter 100 (see below) since iter 75 is unlikely to be much stronger.
+
+### Easy AI cap: 50 -> 75 -> 100 (`_AI_DIFFICULTY` in src/game.py)
+- Iter 50 was too weak; iter 75 expected to still be too weak; bumped to 100 so Easy auto-tracks the strongest checkpoint up to the end of the planned training. Once iter 100 lands, ALL three difficulties resolve to the same checkpoint — re-tune via a different mechanism (action-selection temperature, explicit blunder rate) rather than another iteration step, because iteration depth alone is too coarse a difficulty knob given how late blundering persists.
+
+### Computer-vs-Computer mode (NEW — fully landed)
+The mode menu was previously a two-slot design: one 'side' (which colour the human plays) + one 'opponent' (the other side). This couldn't express AI-vs-AI. Refactored to a per-side design:
+- **`Game.PLAYER_OPTIONS`** catalog: 'human' | 'random' | 'easy' | 'medium' | 'hard'. Same catalog is shown twice in the menu — one column per side.
+- **`Game.white_player`, `Game.black_player`** are the primary state. Each independently picks from PLAYER_OPTIONS.
+- **`Game.ai_controllers`** is a dict `{'white': ctrl or None, 'black': ctrl or None}` (the per-side AIController objects).
+- **`Game.current_ai_controller()`** returns the AIController for whichever colour is to move RIGHT NOW (or None if that side is human / game over). Drives main.py's AI-turn dispatch uniformly across HvAI and CvC.
+- **`Game.mode`** strings: `'human_vs_human'` | `'human_vs_<aikey>'` (e.g. `'human_vs_random'`) | `'computer_vs_computer'`.
+
+Backward compat — preserved via @property:
+- `Game.user_side` -> human's colour in HvAI; `_perspective_side` (default 'white') in HvH; None in CvC.
+- `Game.opponent` -> AI key in HvAI; 'human' in HvH; None in CvC.
+- `Game.ai_color` -> AI's colour in HvAI; None in HvH/CvC.
+- `Game.ai_controller` (singular) -> the one controller in HvAI; None in HvH/CvC.
+- `apply_mode_selection(side=..., opponent=...)` still works (translates via `_perspective_side` so HvH retains a stable human-side perspective).
+
+Menu rendering: two side-by-side vertical columns ("White player" / "Black player"), each showing the full PLAYER_OPTIONS catalog. AI options whose checkpoint isn't on disk render dim and are excluded from `mode_menu_rects` (not clickable), same gating as before. Click rects are now `(rect, side, player_key)` where side ∈ {'white', 'black'}.
+
+Undo/redo in CvC: single-step (HvH-style). The skip-AI-turn behaviour is HvAI-only; the test_cvc_mode tests assert single-step explicitly.
+
+**Tests** (TDD red-then-green): 37 new tests in `tests/test_cvc_mode.py` covering the new catalog, the per-side API, mode derivation, the per-side ai_controllers dict, all four back-compat @property accessors, the legacy `side=` + `opponent=` kwargs translation, the new menu shape, current_ai_controller dispatch in HvH/HvAI/CvC, multi-turn CvC autoplay, and single-step CvC undo/redo. `tests/test_mode_selection.py` updated for the menu's new group keys (3 obsolete catalog tests merged into one new check; one menu-shape test rewritten for `'white'/'black'` instead of `'side'/'opponent'`). All 79 mode-related tests pass; 2 pre-existing failures in `test_v2_freeze` and `test_v2_knight` are NOT caused by this work (verified on main before commit).
+
+### Goal 4 (GDL + GGP) — KICKOFF
+- New doc: `docs/goal4_gdl_ggp_planning.md`. Lays out the GDL landscape (GDL-I vs Ludii vs adjacent options), why this variant is a good GGP benchmark, the hardest formalization parts (ranked: bishop reactive capture = source-based predicate; repetition state hashing; tiny-endgame cancel-queens + 1-to-2 valuation; knight invuln with adjacent-enemy-other-than-jumped; rook 2-segment enumeration; manipulation R1/R2; multi-form queen), an 11-step incremental rollout starting with "kings + base queens only" as the toolchain bootstrap, and 5 open questions to resolve before writing GDL.
+- The 5 open questions: (1) dialect (GDL-I vs Ludii); (2) GGP strength target (legal-play baseline vs head-to-head vs NN); (3) ISEF scope (spec vs comparison vs rule-churn experiment); (4) timeline; (5) treat existing Python engine as ground truth or expect divergences.
+- Lean documented: GDL-I for ISEF positioning ("GGP" is the recognized framing in that world), evaluate Ludii in parallel as a fallback / cross-check.
+- NOTHING ELSE STARTED — waiting on user answers to §6 of the planning doc before drafting any GDL.
+
+### PR
+`claude/cvc-mode-easy-iter100-goal4` (this branch) — open PR after committing.

--- a/docs/goal4_gdl_ggp_planning.md
+++ b/docs/goal4_gdl_ggp_planning.md
@@ -1,0 +1,252 @@
+# Goal 4 — GDL + GGP Planning (kickoff)
+
+**Status:** kickoff, 2026-05-30.  
+**Owner:** ag.  
+**Prereqs:** Goals 1–3 (rules finalized; HvH/HvAI/CvC playable; AI training in
+progress, currently at iter 64/75).
+
+This document scopes Goal 4 of the project roadmap: formalizing the variant's
+rules in a **Game Description Language (GDL)** and using/building a **General
+Game Player (GGP)** to play them, aimed at an **ISEF submission in the ROBO
+(Robotics and Intelligent Machines) category**.
+
+The document is intentionally a *kickoff*, not a plan-of-record. It lays out
+the landscape, names the hard parts, and proposes a small concrete first step
+that can be executed without committing to a full GDL dialect or a specific
+player implementation yet.
+
+---
+
+## 1. What we want
+
+Two outcomes, in priority order:
+
+1. **A correct, complete formal specification of the variant's rules in
+   GDL** (or a GDL-adjacent formalism). The current rulebook
+   (`RULEBOOK_v2.md`) is precise English prose. A GDL spec turns it into
+   declarative logic that a general game player can ingest as input.
+
+2. **A working General Game Player playing the variant from that spec.**
+   "Working" here is graded:
+   - **Baseline:** any existing GGP framework reads our GDL and produces
+     legal play (no strength target yet).
+   - **Comparison:** the GGP plays head-to-head against the Goal 3 trained
+     network to give relative-strength data.
+   - **Stretch:** the GGP's algorithmic approach scales, *unchanged*, to a
+     proposed rule modification — demonstrating the "no retraining required"
+     advantage that motivates Goal 4 in the first place.
+
+The deeper research point — the one worth showing at ISEF — is that
+**under rule churn, a GGP-style approach has a fundamentally different cost
+curve from a trained NN**: rule changes are O(spec edit) for the GGP and
+O(re-train) for the NN. This variant has churned rules many times during
+design and is a faithful stress-test of that claim.
+
+---
+
+## 2. GDL landscape (background)
+
+Two main dialects in the literature:
+
+- **GDL-I (Stanford GDL, ~2005):** first-order Datalog/Prolog-flavored.
+  Perfect-information, deterministic, synchronous turns. Used at the
+  Stanford GGP competitions (2005 onward). Best-known engines: Cadia
+  Player, FluxPlayer, TurboTurtle, Sancho. Reasoner toolkits: GGP-Base
+  (Java), [Stanford GGP server](http://ggp.stanford.edu/), Palamedes.
+- **GDL-II (~2010):** adds imperfect information (random events, hidden
+  state). Strictly more expressive; tooling thinner.
+
+Our variant is **perfect-information + deterministic** (boulder cooldown
+and no-return are public state; no dice; no fog). Therefore **GDL-I is
+sufficient** — start there.
+
+Adjacent formalisms worth knowing about:
+- **Toss / RBG (Regular Boardgames):** more concise than GDL for board
+  games. Less mature ecosystem but more readable specs.
+- **Zillions of Games (ZRF):** commercial, retired engine. Mentioned only
+  because some prior chess-variant work used it; not a serious option for
+  research.
+- **Ludii:** the modern academic successor — a board-game–specific DSL
+  with a strong solver and AI baseline. **Worth serious consideration** as
+  an alternative target.
+
+---
+
+## 3. Why this variant is a good GGP benchmark
+
+Most published GDL chess specs cover standard chess (with various holes
+around castling/en-passant). This variant offers genuinely novel
+mechanics that exercise corners of GDL most descriptions don't reach:
+
+- **Per-piece state across turns:** manipulation freeze, knight
+  invulnerability, bishop reactive-armed flag. GDL handles this naturally
+  via per-piece facts in the next state, but few existing specs do it at
+  this density. Good test of expressiveness.
+- **Source-vs-destination reactive captures:** the knight's jump-capture
+  (destination-based, triggered by an enemy landing at chebyshev-1)
+  and the bishop's reactive capture (source-based, triggered by an enemy
+  *leaving* the bishop's diagonal LoS). Both depend on
+  *immediately-preceding-turn* facts — exactly the kind of cross-turn
+  predicate that distinguishes a serious GDL from a state-only one.
+- **Multi-step composite moves:** the rook moves two segments in one turn
+  (1-step + 90° sweep); the knight may take a jump-capture sub-decision
+  after the spatial leap. In GDL these are typically modeled as a single
+  composite legal move enumerated up-front (the design we took in our
+  Python `Turn` object), but the per-side enumeration is non-trivial.
+- **Neutral piece with memory:** the boulder is owned by neither side,
+  carries cooldown + no-return state, and has asymmetric capture rules
+  (captures pawns only; only king captures it). Most GDL chess specs have
+  no neutral piece at all.
+- **Three loss conditions:** royal capture (both), no-legal-moves, and
+  repetition-3, plus the tiny endgame's distance-3 limit. The repetition
+  rule requires tracking *position counts* across the entire game —
+  expressible in GDL but verbose, and our state-hash design (positional +
+  flag-derived, see `project_state_hash_design.md`) is a non-trivial
+  predicate to specify.
+- **Conditional state inclusion:** the no-return-memory square and the
+  moved-last-turn / reactive-armed flags only enter the state when they'd
+  actually affect legality (see RULEBOOK_v2.md "Repetition Rule"). This
+  is a subtle but real source of correctness work — the GDL must match
+  the Python engine's hashing decisions exactly, or repetition counts
+  diverge.
+
+If we can get a complete, *correct* GDL spec for this variant, it's a
+genuinely novel benchmark contribution.
+
+---
+
+## 4. The hard parts (formalization-grade)
+
+Ranked by expected difficulty in GDL-I:
+
+1. **Bishop reactive capture (source-based).** The "legal move" predicate
+   must consult the *previous* turn's *source square* of the moving
+   enemy. GDL handles this via a `did(?player, ?move)` literal in the
+   prior state, but the predicate becomes textually heavy.
+2. **Repetition rule state hashing.** The state-hash specification
+   (positional + conditional per-piece flags + conditional boulder
+   no-return) is precise in our Python code. Translating exactly is
+   labor-intensive.
+3. **Tiny endgame rule (cancel-queens + 1-to-2 valuation).** Modular
+   arithmetic, min, balance condition. GDL-I can do this but it's verbose.
+4. **Knight invulnerability with the "adjacent-enemy-other-than-jumped"
+   condition.** Multi-condition predicate; easy to get wrong.
+5. **Rook 2-segment move enumeration.** Direct in GDL — enumerate all
+   (segment-1, segment-2) tuples; just lots of legal-move clauses.
+6. **Manipulation Restriction 1 & 2.** Restriction 2 is the trickier one
+   (must look back to the target's last *spatial* move, not just last
+   turn).
+7. **Multi-form queen (base / rook / bishop / knight).** State that
+   carries the current form; transformation as a state-only action.
+
+None of these are *impossible* in GDL-I — they're textually substantial
+but mechanically straightforward.
+
+---
+
+## 5. Proposed first concrete step
+
+Don't try to write the whole GDL spec on day one. Instead, **build a
+small, isolated GDL fragment for a stripped-down variant**, verify it
+end-to-end against an existing GGP reasoner, and iterate.
+
+Proposed first-fragment scope:
+
+- **8×8 board, kings + base-form queens only.** No pawns, no
+  rook/bishop/knight/boulder, no manipulation, no transformation.
+- **Only the win condition:** capture both royals.
+- **No tiny endgame rule, no repetition rule** (yet).
+- One side to move at a time, standard alternation.
+
+This fragment lets us:
+- Pick a GDL toolchain (GGP-Base / Palamedes / Ludii) and verify our
+  install with a *known-trivial* spec.
+- Get fluent with the syntax + reasoner before adding any of the hard
+  parts (§4).
+- Set up the comparison harness (GGP-side play, parsing legal moves,
+  driving full games) that will be reused for every later fragment.
+
+Then layer one mechanic at a time, in increasing-difficulty order:
+
+| step | adds                                          | notes                              |
+|------|-----------------------------------------------|------------------------------------|
+| 1    | kings + base queens only                      | toolchain bootstrap                |
+| 2    | + pawns (incl. capture asymmetry)             | first cross-piece interaction      |
+| 3    | + rook (2-segment)                            | first multi-step move              |
+| 4    | + knight (radius-2, no jump-capture yet)      | move enumeration                   |
+| 5    | + bishop (teleport, no reactive yet)          | teleport-safety predicate          |
+| 6    | + boulder (with cooldown + no-return)         | first neutral-piece state          |
+| 7    | + queen actions (manipulation, transformation)| introduces cross-turn restrictions |
+| 8    | + knight jump-capture & invuln                | first reactive capture             |
+| 9    | + bishop reactive capture                     | source-based predicate (hardest)   |
+| 10   | + repetition rule                             | game-level position counting       |
+| 11   | + tiny endgame rule                           | distance counting + balance check  |
+
+Each step ends with the same checkpoint: parse the spec in a GGP
+reasoner, generate legal moves for a small handcrafted position, **compare
+the set against the Python engine's `get_all_legal_turns()` output for
+the same position.** Equality on a curated set of test positions is the
+quality gate for moving to the next step.
+
+---
+
+## 6. Open questions for the user
+
+These should be decided before any GDL writing begins:
+
+1. **Dialect / toolchain.** GDL-I (Stanford, classic) vs Ludii (modern
+   academic, board-game–specific DSL with a stronger solver baseline).
+   GDL-I is the more recognizable ISEF "GGP" framing; Ludii is the more
+   productive engineering choice. **Lean: GDL-I for the ISEF positioning,
+   but evaluate Ludii in parallel as a fallback / cross-check.**
+2. **Strength target for the GGP.** Baseline-legal-play (the easiest
+   goal) vs head-to-head competitive vs the trained Goal-3 network.
+3. **Scope of the ISEF submission.** Is the contribution (a) the GDL spec
+   itself, (b) the GGP-vs-NN comparison, or (c) the rule-churn cost-curve
+   experiment? Probably (a) + (c); (b) is supporting evidence.
+4. **Timeline.** When is the ISEF deadline? Drives whether we go for the
+   full 11-step rollout or stop at step 6 (a respectable subset).
+5. **Reuse of the existing Python engine as ground truth.** Do we treat
+   `src/engine.py` + `src/board.py` as the spec of last resort, or do we
+   discover places where the rulebook and the engine disagree (a
+   plausible side-effect)? The latter is real research value: a complete
+   GDL spec will be a *formal verification* of the engine.
+
+---
+
+## 7. What's NOT in scope for Goal 4 (yet)
+
+- **GDL-II** (imperfect information). Not needed.
+- **Real-time / continuous-time rules.** This is a discrete turn-based
+  game.
+- **Learning inside the GGP.** Starting with classical reasoners
+  (Monte-Carlo Tree Search, propositional networks). NN-augmented GGP is
+  a stretch follow-on.
+- **Rebuilding the existing engine.** GDL is *additive* — the Python
+  engine remains the canonical game runtime for the human-vs-AI UI and
+  for training.
+
+---
+
+## 8. Where this fits in the broader project
+
+- **Goal 1 (rules finalized):** prerequisite met. We can formalize
+  without fearing mid-stream rule changes.
+- **Goal 2 (HvH / HvAI / CvC modes):** independent. The GGP will
+  eventually plug into the CvC mode as another "player type" alongside
+  random / easy / medium / hard.
+- **Goal 3 (trained NN, in progress):** the GGP-vs-NN comparison is the
+  capstone experiment. We can't start it until both the GDL is correct
+  enough to play AND the network is trained enough to be a meaningful
+  opponent (iter ~100 is the working target).
+- **Goal 4 (this doc):** the long-horizon research direction. The
+  rule-churn cost-curve story is the part that's hardest to find anywhere
+  else and the part most likely to land at ISEF.
+
+---
+
+## 9. Immediate next action
+
+When the user picks a dialect (§6 Q1), step 1 of §5 ("kings + base
+queens only") can be drafted in a few hundred lines of GDL. Until then,
+this doc is the kickoff record and the rulebook stays the source of truth.

--- a/src/game.py
+++ b/src/game.py
@@ -207,18 +207,22 @@ def _overlay_pixel_origin(row, col, position):
 
 class Game:
 
-    # Mode selector — two INDEPENDENT dimensions, rendered as two button
-    # rows in the in-UI menu. SIDE_OPTIONS is which colour the human plays;
-    # OPPONENT_OPTIONS is what plays the other colour. Selecting one updates
-    # only that dimension, leaving the other in place. Extensible: append
-    # entries to OPPONENT_OPTIONS to plug in future difficulty levels
-    # (Easy / Medium / Hard AI) and add a matching branch in `_make_ai_player`.
-    SIDE_OPTIONS = [
-        {'key': 'white', 'label': 'White'},
-        {'key': 'black', 'label': 'Black'},
-    ]
-    OPPONENT_OPTIONS = [
-        {'key': 'human',  'label': 'Human (2 players)'},
+    # Mode selector — per-side player choice. The in-UI menu renders the
+    # SAME catalog twice (one column per side), and EACH side can
+    # independently be set to any player type:
+    #
+    #     human  | random | easy | medium | hard
+    #
+    # Modes (derived):
+    #     both 'human'              -> HvH (human_vs_human)
+    #     exactly one 'human'       -> HvAI (human_vs_ai)
+    #     neither 'human'           -> CvC (computer_vs_computer)
+    #
+    # Adding new player types: append here and add a matching branch in
+    # _make_ai_player. Adding a new SIDE is not a meaningful operation in
+    # 2-colour chess — the catalog is per-side, not per-slot.
+    PLAYER_OPTIONS = [
+        {'key': 'human',  'label': 'Human'},
         {'key': 'random', 'label': 'Random'},
         {'key': 'easy',   'label': 'AI Easy'},
         {'key': 'medium', 'label': 'AI Medium'},
@@ -244,12 +248,15 @@ class Game:
         # the exact target iteration; otherwise the option is disabled in
         # the mode menu.
         #
-        # Easy cap raised from 50 -> 75 (2026-05-29): iter 50 still played
-        # too weakly against the user. Once iter 75 lands, Easy and Medium
-        # will resolve to the same checkpoint; if Easy is then too strong,
-        # re-tune downward (or split via a different mechanism such as
-        # higher action-selection temperature) at that point.
-        'easy':   {'target': 75,  'mode': 'capped'},
+        # Easy cap raised 50 -> 75 -> 100 (2026-05-30): at iter 64 the
+        # network was still blundering more than random in user testing.
+        # Cap pushed all the way to 100 so Easy auto-tracks whatever the
+        # strongest available checkpoint is — once iter 100 lands, all
+        # three difficulties resolve to the same checkpoint. Re-tune via
+        # a different mechanism (temperature / explicit blunder rate)
+        # once the network is genuinely strong; iteration depth alone
+        # isn't a fine enough difficulty knob.
+        'easy':   {'target': 100, 'mode': 'capped'},
         'medium': {'target': 75,  'mode': 'exact'},
         'hard':   {'target': 100, 'mode': 'exact'},
     }
@@ -282,24 +289,35 @@ class Game:
         # Promotion menu state
         self.promotion_menu = None        # dict with 'pawn', 'row', 'col' or None
         self.promotion_menu_rects = []    # list of (rect, option_name) for click detection
-        # Mode-selector menu state (Goal 2). Opened via M in main.py. The
-        # menu lets the user pick their side AND their opponent independently;
-        # each click applies that one dimension and leaves the menu open
-        # (live-settings model) so the user can also change the other.
-        self.mode_menu = None             # dict with 'sides' + 'opponents', or None
-        self.mode_menu_rects = []         # [(rect, 'side'|'opponent', key), ...]
+        # Mode-selector menu state (Goal 2 + CvC extension). Opened via M
+        # in main.py. The menu lets the user pick the player type for EACH
+        # side independently; each click applies that one side and leaves
+        # the menu open (live-settings model) so the user can also change
+        # the other side. The dict shape is {'white': [opts], 'black':
+        # [opts]} — render-friendly. Rect tags are (rect, 'white'|'black',
+        # player_key).
+        self.mode_menu = None
+        self.mode_menu_rects = []
         # Reset-game confirmation. True iff the user pressed 'R' and we are
         # waiting for them to confirm (Y / Enter) or cancel (N / Esc). The
         # overlay is rendered by show_reset_confirm; main.py treats it like
         # any other open menu (no interactions while up).
         self.reset_confirm_pending = False
-        # User choices — the two dimensions the menu exposes.
-        self.user_side = 'white'          # the colour the human plays
-        self.opponent = 'human'           # 'human' or an AI key (e.g. 'random')
-        # Derived from (user_side, opponent); kept in sync by `_refresh_ai`.
+        # Per-side player choice — the primary mode state. Both default to
+        # 'human' (HvH). `user_side`, `opponent`, `ai_color`,
+        # `ai_controller` are derived @property values kept for back-compat
+        # with the pre-CvC API.
+        self.white_player = 'human'
+        self.black_player = 'human'
+        # Legacy perspective. The original two-slot menu had an explicit
+        # `user_side` that was kept even in HvH (where there's no unique
+        # human side); some callers/tests still set `side=` via
+        # apply_mode_selection. Stored here so the `user_side` property
+        # can return a stable value across HvH calls. Defaults to 'white'.
+        self._perspective_side = 'white'
+        # Derived from (white_player, black_player) by `_refresh_ai`.
         self.mode = 'human_vs_human'      # string for display/logging
-        self.ai_color = None              # opposite of user_side when AI is active
-        self.ai_controller = None
+        self.ai_controllers = {'white': None, 'black': None}
         self.winner = None                # 'white', 'black', or None
         # Record initial board state for repetition rule
         self.board.record_state(self.next_player)
@@ -555,10 +573,14 @@ class Game:
     # ---- Mode selector (in-UI human-vs-AI menu) ---------------------------
 
     def open_mode_menu(self):
-        """Open the mode-selection menu. Pure state change — no rendering."""
+        """Open the mode-selection menu. Pure state change — no rendering.
+
+        Menu shape is {'white': [PLAYER_OPTIONS], 'black': [PLAYER_OPTIONS]}.
+        Each side renders the same catalog; selecting a button on one side
+        only updates that side."""
         self.mode_menu = {
-            'sides': list(self.SIDE_OPTIONS),
-            'opponents': list(self.OPPONENT_OPTIONS),
+            'white': list(self.PLAYER_OPTIONS),
+            'black': list(self.PLAYER_OPTIONS),
         }
 
     def close_mode_menu(self):
@@ -566,40 +588,177 @@ class Game:
         self.mode_menu = None
         self.mode_menu_rects = []
 
-    def apply_mode_selection(self, side=None, opponent=None):
-        """Apply a mode-menu selection. Each argument is optional — pass only
-        `side` to switch the human's colour, only `opponent` to switch the
-        computer opponent, or both. Raises ValueError on unknown keys. Does
-        NOT auto-close the menu (live-settings model — the user closes via
-        M / Esc / `close_mode_menu()`)."""
-        if side is not None:
-            valid = {opt['key'] for opt in self.SIDE_OPTIONS}
-            if side not in valid:
+    def apply_mode_selection(self, white_player=None, black_player=None,
+                             side=None, opponent=None):
+        """Apply a mode-menu selection.
+
+        Primary API (CvC-aware): set `white_player` and/or `black_player`
+        independently. Each is a key from PLAYER_OPTIONS.
+
+        Backwards-compat API (pre-CvC): `side` ('white'|'black' — which
+        colour the human plays) and `opponent` (a PLAYER_OPTIONS key) are
+        also accepted and translated to the new per-side fields. Useful
+        for tests and callers written against the original two-slot menu.
+
+        Raises ValueError on unknown keys. Does NOT auto-close the menu
+        (live-settings model — close via M / Esc / `close_mode_menu()`).
+        """
+        valid_players = {opt['key'] for opt in self.PLAYER_OPTIONS}
+
+        # Resolve the legacy (side, opponent) pair to (white_player,
+        # black_player) edits if either was passed. The legacy two-slot
+        # model encoded "the human plays `side`; the OTHER side is
+        # `opponent`." We translate that into the per-side fields, and
+        # also record `side` into `_perspective_side` so the human's
+        # preferred colour survives in HvH (where the per-side fields
+        # alone can't express it).
+        if side is not None or opponent is not None:
+            if side is not None and side not in ('white', 'black'):
                 raise ValueError(
-                    f"Unknown side: {side!r}; valid: {sorted(valid)}")
-            self.user_side = side
-        if opponent is not None:
-            valid = {opt['key'] for opt in self.OPPONENT_OPTIONS}
-            if opponent not in valid:
+                    f"Unknown side: {side!r}; valid: ['black', 'white']")
+            if opponent is not None and opponent not in valid_players:
                 raise ValueError(
-                    f"Unknown opponent: {opponent!r}; valid: {sorted(valid)}")
-            self.opponent = opponent
+                    f"Unknown opponent: {opponent!r}; "
+                    f"valid: {sorted(valid_players)}")
+            if side is not None:
+                self._perspective_side = side
+            # Compute the resulting (white, black) the legacy way: human
+            # on the chosen side, opponent on the OTHER side. If only one
+            # of (side, opponent) was given, the unspecified one comes
+            # from current state.
+            current_perspective = self._perspective_side
+            current_opponent_key = (
+                self.opponent if self.opponent is not None else 'human')
+            new_perspective = side if side is not None \
+                else current_perspective
+            new_opponent_key = opponent if opponent is not None \
+                else current_opponent_key
+            if new_perspective == 'white':
+                if white_player is None:
+                    white_player = 'human'
+                if black_player is None:
+                    black_player = new_opponent_key
+            else:
+                if black_player is None:
+                    black_player = 'human'
+                if white_player is None:
+                    white_player = new_opponent_key
+
+        if white_player is not None:
+            if white_player not in valid_players:
+                raise ValueError(
+                    f"Unknown white_player: {white_player!r}; "
+                    f"valid: {sorted(valid_players)}")
+            self.white_player = white_player
+        if black_player is not None:
+            if black_player not in valid_players:
+                raise ValueError(
+                    f"Unknown black_player: {black_player!r}; "
+                    f"valid: {sorted(valid_players)}")
+            self.black_player = black_player
         self._refresh_ai()
 
     def _refresh_ai(self):
-        """Recompute `mode`, `ai_color`, `ai_controller` from the current
-        (user_side, opponent) selection. Called after every state change so
-        the derived AI state stays in sync."""
-        if self.opponent == 'human':
+        """Recompute `mode` + per-side `ai_controllers` from the current
+        (white_player, black_player) selection. Called after every state
+        change so the derived AI state stays in sync.
+
+        Mode-string convention (kept for back-compat with pre-CvC code):
+          - HvH    -> 'human_vs_human'
+          - HvAI   -> f'human_vs_{ai_key}'  (e.g. 'human_vs_random')
+          - CvC    -> 'computer_vs_computer'
+        """
+        humans = sum(1 for p in (self.white_player, self.black_player)
+                     if p == 'human')
+        if humans == 2:
             self.mode = 'human_vs_human'
-            self.ai_color = None
-            self.ai_controller = None
-            return
+        elif humans == 1:
+            ai_key = (self.black_player if self.white_player == 'human'
+                      else self.white_player)
+            self.mode = f'human_vs_{ai_key}'
+        else:
+            self.mode = 'computer_vs_computer'
+
+        # Build per-side AIController objects (None for human slots).
         from ai_controller import AIController
-        self.mode = f'human_vs_{self.opponent}'
-        self.ai_color = 'black' if self.user_side == 'white' else 'white'
-        self.ai_controller = AIController(
-            self.ai_color, player=self._make_ai_player(self.opponent))
+        new_controllers = {}
+        for color, player_key in (('white', self.white_player),
+                                  ('black', self.black_player)):
+            if player_key == 'human':
+                new_controllers[color] = None
+            else:
+                new_controllers[color] = AIController(
+                    color, player=self._make_ai_player(player_key))
+        self.ai_controllers = new_controllers
+
+    # ---- derived back-compat properties --------------------------------
+
+    @property
+    def user_side(self):
+        """The colour the human plays.
+
+        - HvH: `_perspective_side` (defaults to 'white'; updated when
+          `apply_mode_selection(side=...)` is used). Lets HvH retain
+          a stable human-side perspective for UI/legacy callers.
+        - HvAI: the human's colour.
+        - CvC: None (no human side exists — callers must handle this).
+        """
+        if self.white_player == 'human' and self.black_player == 'human':
+            return self._perspective_side
+        if self.white_player == 'human' and self.black_player != 'human':
+            return 'white'
+        if self.black_player == 'human' and self.white_player != 'human':
+            return 'black'
+        return None  # CvC
+
+    @property
+    def opponent(self):
+        """The 'opponent' player key in the legacy two-slot mental model.
+
+        - HvH: 'human'.
+        - HvAI: the AI's player key (e.g. 'random').
+        - CvC: None (there is no single 'opponent' — both sides are AI).
+        """
+        if self.white_player == 'human' and self.black_player == 'human':
+            return 'human'
+        if self.white_player == 'human':
+            return self.black_player
+        if self.black_player == 'human':
+            return self.white_player
+        return None  # CvC
+
+    @property
+    def ai_color(self):
+        """The single AI's colour in HvAI; None in HvH or CvC.
+
+        Computed from the per-side keys directly (not from `self.mode`),
+        so that even with the specific mode-string convention
+        ('human_vs_random', etc.) this still works for any AI key.
+        """
+        white_is_ai = self.white_player != 'human'
+        black_is_ai = self.black_player != 'human'
+        if white_is_ai and not black_is_ai:
+            return 'white'
+        if black_is_ai and not white_is_ai:
+            return 'black'
+        return None  # HvH or CvC
+
+    @property
+    def ai_controller(self):
+        """The single AIController in HvAI; None in HvH or CvC. CvC has TWO
+        controllers — callers needing CvC support should use
+        `ai_controllers[color]` or `current_ai_controller()` instead."""
+        color = self.ai_color
+        return self.ai_controllers[color] if color is not None else None
+
+    def current_ai_controller(self):
+        """The AIController for whichever colour is to move RIGHT NOW, or
+        None if that side is human / the game is over. Drives the AI-takes-
+        turn check in main.py uniformly across HvAI and CvC.
+        """
+        if self.winner is not None:
+            return None
+        return self.ai_controllers.get(self.next_player)
 
     @classmethod
     def _resolve_ai_checkpoint(cls, opponent_key):
@@ -702,10 +861,13 @@ class Game:
         """Render the mode-selection menu, if open, and populate
         `mode_menu_rects` for click detection. No-op when closed.
 
-        Renders two button rows: 'Your side' and 'Opponent'. The currently-
-        selected button in each row is highlighted. Each entry pushed onto
-        `mode_menu_rects` is a (pygame.Rect, group_key, option_key) tuple
-        where group_key is 'side' or 'opponent'."""
+        Renders two stacked sections — 'White player' and 'Black player' —
+        each a vertical column of the PLAYER_OPTIONS catalog. The
+        currently-selected button in each section is highlighted. Each
+        entry pushed onto `mode_menu_rects` is a (pygame.Rect, side,
+        player_key) tuple where side ∈ {'white', 'black'}. main.py
+        dispatches clicks back via apply_mode_selection(
+        white_player=...) or (black_player=...)."""
         if self.mode_menu is None:
             return
         self.mode_menu_rects = []
@@ -717,61 +879,32 @@ class Game:
         section_font = pygame.font.SysFont('arial', 20, bold=True)
         option_font = pygame.font.SysFont('arial', 20)
         title = title_font.render(
-            'Select side and opponent  (M / Esc to close)', True,
+            'Choose player for each side  (M / Esc to close)', True,
             (255, 255, 255))
-        surface.blit(title, title.get_rect(center=(w // 2, h // 6)))
+        surface.blit(title, title.get_rect(center=(w // 2, h // 12)))
 
-        def render_section(label, opts, group_key, current_key, section_top,
-                           orientation='horizontal'):
-            """Render a section title and a row (or column) of buttons.
-
-            orientation='horizontal' is used for the 'Your side' row (2
-            options fit easily). orientation='vertical' stacks buttons one
-            per line — used for 'Opponent' so the menu doesn't overflow
-            the screen width as AI difficulty entries are added.
-
-            Returns the y-coordinate just below the last button (so the
-            caller can stack the next section).
-            """
+        def render_section(label, opts, side, current_key, col_left,
+                           section_top, btn_w):
+            """Render one side's section: a header + a vertical column of
+            player-type buttons. AI options whose checkpoint isn't on disk
+            yet render dimmer and are NOT added to mode_menu_rects, so
+            clicks on them are ignored."""
             section_label = section_font.render(label, True, (220, 220, 220))
             surface.blit(section_label, section_label.get_rect(
-                center=(w // 2, section_top)))
+                center=(col_left + btn_w // 2, section_top)))
             btn_h = 40
-            gap = 10
-            top_y = section_top + 34
-
-            if orientation == 'horizontal':
-                btn_w = min(180, int(w * 0.22))
-                n = len(opts)
-                row_w = n * btn_w + (n - 1) * gap
-                row_left = (w - row_w) // 2
-                def rect_for(i):
-                    return pygame.Rect(
-                        row_left + i * (btn_w + gap), top_y, btn_w, btn_h)
-                end_y = top_y + btn_h
-            else:  # 'vertical'
-                btn_w = min(240, int(w * 0.32))
-                col_left = (w - btn_w) // 2
-                def rect_for(i):
-                    return pygame.Rect(
-                        col_left, top_y + i * (btn_h + gap), btn_w, btn_h)
-                n = len(opts)
-                end_y = top_y + n * btn_h + (n - 1) * gap
-
+            gap = 8
+            top_y = section_top + 28
             for i, opt in enumerate(opts):
-                rect = rect_for(i)
+                rect = pygame.Rect(
+                    col_left, top_y + i * (btn_h + gap), btn_w, btn_h)
                 active = (opt['key'] == current_key)
-                # AI opponents whose checkpoint isn't on disk yet render
-                # dimmer and are NOT added to mode_menu_rects, so clicks
-                # on them are ignored.
-                available = (group_key != 'opponent'
-                             or self._ai_checkpoint_available(opt['key']))
+                available = self._ai_checkpoint_available(opt['key'])
                 if available:
                     bg = (80, 140, 200) if active else (60, 60, 60)
                     border = (200, 200, 200)
                     text_color = (255, 255, 255)
                 else:
-                    # Unavailable AI options: dim background + dim text.
                     bg = (40, 40, 40)
                     border = (100, 100, 100)
                     text_color = (130, 130, 130)
@@ -782,19 +915,23 @@ class Game:
                     opt['label'], True, text_color)
                 surface.blit(label_surf, label_surf.get_rect(center=rect.center))
                 if available:
-                    self.mode_menu_rects.append(
-                        (rect, group_key, opt['key']))
-            return end_y
+                    self.mode_menu_rects.append((rect, side, opt['key']))
 
-        # 'Your side' stays horizontal (2 options fit naturally).
-        # 'Opponent' renders vertically so the menu doesn't overflow the
-        # screen width as more difficulty entries are added.
-        bottom = render_section(
-            'Your side', self.mode_menu['sides'], 'side',
-            self.user_side, h // 4, orientation='horizontal')
+        # Two vertical columns: White (left) and Black (right). Renders
+        # the same PLAYER_OPTIONS catalog twice, one per side, so the user
+        # can pick any combination including AI-vs-AI.
+        btn_w = min(220, int(w * 0.30))
+        gap_between_cols = min(40, int(w * 0.04))
+        total_w = btn_w * 2 + gap_between_cols
+        left_col_x = (w - total_w) // 2
+        right_col_x = left_col_x + btn_w + gap_between_cols
+        section_top = h // 6 + 30
         render_section(
-            'Opponent', self.mode_menu['opponents'], 'opponent',
-            self.opponent, bottom + 32, orientation='vertical')
+            'White player', self.mode_menu['white'], 'white',
+            self.white_player, left_col_x, section_top, btn_w)
+        render_section(
+            'Black player', self.mode_menu['black'], 'black',
+            self.black_player, right_col_x, section_top, btn_w)
 
     def show_transform_menu(self, surface):
         """Draw the vertical strip transformation menu."""

--- a/src/main.py
+++ b/src/main.py
@@ -132,11 +132,16 @@ class Main:
             if dragger.dragging:
                 dragger.update_blit(screen)
 
-            # Human-vs-AI: when it's the AI side's turn, let the AI take it.
-            # The mode menu (if open) blocks AI play so the user can finish
+            # Human-vs-AI OR Computer-vs-Computer: when the side to move is
+            # an AI, let that side's AIController take the turn. Works
+            # uniformly across HvAI (one controller) and CvC (two
+            # controllers — whichever colour is on move drives). The mode
+            # menu (if open) blocks AI play so the user can finish
             # selecting a mode.
-            if (game.ai_controller and game.ai_controller.is_ai_turn(game)
-                    and game.mode_menu is None):
+            _ctrl = game.current_ai_controller()
+            if (_ctrl is not None and _ctrl.is_ai_turn(game)
+                    and game.mode_menu is None
+                    and not game.reset_confirm_pending):
                 # CRUCIAL: push the (already-redrawn) post-human-move backbuffer
                 # to the screen BEFORE pausing.
                 #
@@ -164,7 +169,7 @@ class Main:
                             pygame.quit()
                             raise SystemExit
                     pygame.time.delay(15)
-                game.ai_controller.take_turn(game)
+                _ctrl.take_turn(game)
                 continue  # re-render the resulting position
 
             for event in pygame.event.get():
@@ -194,19 +199,22 @@ class Main:
                         continue
 
                     # Handle mode-selector menu clicks (left-click on option).
-                    # Each menu_rects entry is (rect, group_key, option_key)
-                    # where group_key is 'side' or 'opponent'. Clicking a
-                    # button updates only that dimension and leaves the menu
-                    # open (live-settings model) so the user can also change
-                    # the other dimension. Close via M / Esc (KEYDOWN handler).
+                    # Each menu_rects entry is (rect, side, player_key)
+                    # where side is 'white' or 'black'. Clicking a button
+                    # updates only that side and leaves the menu open
+                    # (live-settings model) so the user can also configure
+                    # the other side — supporting HvH / HvAI / CvC
+                    # transparently. Close via M / Esc (KEYDOWN handler).
                     if game.mode_menu and event.button == 1:
                         mx, my = event.pos
-                        for rect, group_key, option_key in game.mode_menu_rects:
+                        for rect, side, player_key in game.mode_menu_rects:
                             if rect.collidepoint(mx, my):
-                                if group_key == 'side':
-                                    game.apply_mode_selection(side=option_key)
-                                elif group_key == 'opponent':
-                                    game.apply_mode_selection(opponent=option_key)
+                                if side == 'white':
+                                    game.apply_mode_selection(
+                                        white_player=player_key)
+                                elif side == 'black':
+                                    game.apply_mode_selection(
+                                        black_player=player_key)
                                 break
                         continue
 

--- a/tests/test_cvc_mode.py
+++ b/tests/test_cvc_mode.py
@@ -1,0 +1,426 @@
+"""Tests for Computer-vs-Computer (CvC) mode and the generalised
+per-side player-selection menu.
+
+The earlier menu used two slots: a 'side' (which colour the human plays)
+and an 'opponent' (who plays the other colour). That made human-vs-human
+and human-vs-AI possible but couldn't express AI-vs-AI.
+
+The new menu lets EACH SIDE be independently set to any of:
+    'human' | 'random' | 'easy' | 'medium' | 'hard'
+
+Modes (derived from the two per-side choices):
+    HvH ->  both 'human'
+    HvAI -> exactly one 'human'
+    CvC ->  neither 'human' (the two AIs may be the same or different)
+
+Backwards compat: `user_side`, `opponent`, `ai_color`, `ai_controller`
+remain as derived properties so existing callers keep working in
+HvH/HvAI. In CvC they read None (no single canonical human side / AI
+controller).
+
+These tests are headless: pygame uses SDL dummy drivers.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import random
+import pytest
+
+from game import Game
+from ai_controller import AIController
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+    try:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
+    except pygame.error:
+        pass
+
+
+# ---- catalog --------------------------------------------------------------
+
+def test_player_options_catalog_lists_all_player_types():
+    """PLAYER_OPTIONS lists EVERY available player type. The same catalog
+    is shown for both sides of the menu — there's no longer a separate
+    'side' vs 'opponent' distinction."""
+    keys = [opt['key'] for opt in Game.PLAYER_OPTIONS]
+    for required in ('human', 'random', 'easy', 'medium', 'hard'):
+        assert required in keys, f"PLAYER_OPTIONS missing {required!r}"
+    for opt in Game.PLAYER_OPTIONS:
+        assert 'label' in opt
+        assert isinstance(opt['label'], str) and opt['label']
+
+
+def test_default_white_and_black_player_are_human():
+    """Default state is HvH: both sides start as 'human'."""
+    g = Game()
+    assert g.white_player == 'human'
+    assert g.black_player == 'human'
+    assert g.mode == 'human_vs_human'
+
+
+# ---- apply_mode_selection: new per-side API --------------------------------
+
+def test_apply_white_player_only_updates_white():
+    g = Game()
+    g.apply_mode_selection(white_player='random')
+    assert g.white_player == 'random'
+    assert g.black_player == 'human'  # unchanged
+
+
+def test_apply_black_player_only_updates_black():
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert g.black_player == 'random'
+    assert g.white_player == 'human'
+
+
+def test_apply_both_sides_simultaneously():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.white_player == 'random'
+    assert g.black_player == 'random'
+
+
+def test_apply_invalid_white_player_raises():
+    g = Game()
+    with pytest.raises(ValueError):
+        g.apply_mode_selection(white_player='cheese')
+
+
+def test_apply_invalid_black_player_raises():
+    g = Game()
+    with pytest.raises(ValueError):
+        g.apply_mode_selection(black_player='cheese')
+
+
+# ---- mode derivation -------------------------------------------------------
+
+def test_mode_human_vs_human_when_both_human():
+    g = Game()
+    assert g.mode == 'human_vs_human'
+    g.apply_mode_selection(white_player='human', black_player='human')
+    assert g.mode == 'human_vs_human'
+
+
+def test_mode_human_vs_ai_when_one_side_human():
+    """Mode string carries the AI key for legacy callers
+    (e.g. 'human_vs_random'). The new CvC tests don't pin a single
+    'human_vs_ai' literal; they accept the prefix instead."""
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert g.mode == 'human_vs_random'
+    assert g.mode.startswith('human_vs_')
+    assert g.mode != 'human_vs_human'
+
+    g2 = Game()
+    g2.apply_mode_selection(white_player='random')
+    assert g2.mode == 'human_vs_random'
+
+
+def test_mode_computer_vs_computer_when_neither_human():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.mode == 'computer_vs_computer'
+
+    g2 = Game()
+    g2.apply_mode_selection(white_player='random', black_player='easy')
+    # Even when the two AIs differ, mode is CvC.
+    # ('easy' may be unavailable on disk depending on checkpoints; the mode
+    # is computed from the player keys regardless — availability gates the
+    # MENU, not the mode model.)
+    assert g2.mode == 'computer_vs_computer'
+
+
+# ---- ai_controllers per side ----------------------------------------------
+
+def test_ai_controllers_dict_has_both_keys_with_none_in_hvh():
+    g = Game()
+    assert g.ai_controllers == {'white': None, 'black': None}
+
+
+def test_ai_controllers_white_set_when_white_is_ai():
+    g = Game()
+    g.apply_mode_selection(white_player='random')
+    assert isinstance(g.ai_controllers['white'], AIController)
+    assert g.ai_controllers['white'].color == 'white'
+    assert g.ai_controllers['black'] is None
+
+
+def test_ai_controllers_black_set_when_black_is_ai():
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert isinstance(g.ai_controllers['black'], AIController)
+    assert g.ai_controllers['black'].color == 'black'
+    assert g.ai_controllers['white'] is None
+
+
+def test_ai_controllers_both_set_in_cvc():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert isinstance(g.ai_controllers['white'], AIController)
+    assert isinstance(g.ai_controllers['black'], AIController)
+    assert g.ai_controllers['white'].color == 'white'
+    assert g.ai_controllers['black'].color == 'black'
+
+
+def test_switching_player_to_human_clears_that_sides_controller():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    g.apply_mode_selection(white_player='human')
+    assert g.ai_controllers['white'] is None
+    assert g.ai_controllers['black'] is not None  # untouched
+
+
+# ---- backward-compat derived properties (HvH/HvAI keep working) ----------
+
+def test_legacy_user_side_in_hvh_defaults_to_white():
+    """HvH has no 'AI side' to subtract — keep the long-standing default
+    that the human's perspective is white."""
+    g = Game()
+    assert g.user_side == 'white'
+
+
+def test_legacy_user_side_in_hvai_is_the_human_color():
+    g = Game()
+    g.apply_mode_selection(white_player='random')
+    assert g.user_side == 'black'
+
+    g2 = Game()
+    g2.apply_mode_selection(black_player='random')
+    assert g2.user_side == 'white'
+
+
+def test_legacy_user_side_in_cvc_is_none():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.user_side is None
+
+
+def test_legacy_opponent_in_hvh_is_human():
+    g = Game()
+    assert g.opponent == 'human'
+
+
+def test_legacy_opponent_in_hvai_is_the_ai_key():
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert g.opponent == 'random'
+
+
+def test_legacy_opponent_in_cvc_is_none():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.opponent is None
+
+
+def test_legacy_ai_controller_in_hvai_returns_the_single_one():
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert g.ai_controller is g.ai_controllers['black']
+
+
+def test_legacy_ai_controller_in_cvc_is_none():
+    """In CvC there are TWO ai_controllers — the singular property is
+    None because there isn't ONE canonical AI."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.ai_controller is None
+
+
+def test_legacy_ai_color_in_hvai_is_the_ai_color():
+    g = Game()
+    g.apply_mode_selection(black_player='random')
+    assert g.ai_color == 'black'
+
+
+def test_legacy_ai_color_in_cvc_is_none():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.ai_color is None
+
+
+# ---- back-compat: old side= / opponent= apply_mode_selection kwargs -------
+
+def test_legacy_apply_mode_side_only():
+    """Old API: side='black' means the human plays black -> white side
+    becomes whatever the opponent was (default 'human' -> still HvH but
+    with the human's perspective flipped to black)."""
+    g = Game()
+    g.apply_mode_selection(side='black')
+    assert g.user_side == 'black'
+    assert g.white_player == 'human'  # opponent default
+    assert g.black_player == 'human'  # human's side
+    assert g.mode == 'human_vs_human'
+
+
+def test_legacy_apply_mode_opponent_only_with_default_side():
+    """Old API: opponent='random' with default user_side='white' ->
+    AI plays black."""
+    g = Game()
+    g.apply_mode_selection(opponent='random')
+    assert g.white_player == 'human'
+    assert g.black_player == 'random'
+    assert g.mode == 'human_vs_random'
+    assert g.ai_color == 'black'
+
+
+def test_legacy_apply_mode_side_and_opponent_together():
+    g = Game()
+    g.apply_mode_selection(side='black', opponent='random')
+    assert g.user_side == 'black'
+    assert g.white_player == 'random'
+    assert g.black_player == 'human'
+    assert g.ai_color == 'white'
+
+
+# ---- menu open/close + rendering -----------------------------------------
+
+def test_open_mode_menu_shape_carries_player_options_for_both_sides():
+    """The opened menu carries the per-side player options that
+    show_mode_menu will render."""
+    g = Game()
+    g.open_mode_menu()
+    assert g.mode_menu is not None
+    # New shape: per-side option lists.
+    assert 'white' in g.mode_menu
+    assert 'black' in g.mode_menu
+    # Each side's options are the PLAYER_OPTIONS catalog.
+    for side in ('white', 'black'):
+        keys = [opt['key'] for opt in g.mode_menu[side]]
+        assert set(keys) == {opt['key'] for opt in Game.PLAYER_OPTIONS}
+
+
+def test_show_mode_menu_rects_group_by_white_and_black():
+    """Each click rect is tagged with its side ('white' or 'black') and
+    its player key — main.py uses these to dispatch back into
+    apply_mode_selection(white_player=...) or (black_player=...)."""
+    g = Game()
+    g.open_mode_menu()
+    surface = pygame.Surface((800, 800))
+    g.show_mode_menu(surface)
+    groups = set(group for (_r, group, _k) in g.mode_menu_rects)
+    assert 'white' in groups
+    assert 'black' in groups
+    # No leftover 'side' / 'opponent' tags from the old design.
+    assert 'side' not in groups
+    assert 'opponent' not in groups
+    # Per side, every AVAILABLE player option appears exactly once.
+    available_keys = [
+        opt['key'] for opt in Game.PLAYER_OPTIONS
+        if g._ai_checkpoint_available(opt['key'])]
+    for side in ('white', 'black'):
+        side_keys = [k for (_r, group, k) in g.mode_menu_rects if group == side]
+        assert sorted(side_keys) == sorted(available_keys)
+
+
+# ---- AI turn dispatch in CvC ----------------------------------------------
+
+def test_current_ai_controller_returns_white_when_white_to_move_in_cvc():
+    """main.py needs to know which AI controller (if any) drives the
+    CURRENT side to move. Expose a small helper so it doesn't have to
+    reach into ai_controllers itself."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.next_player == 'white'
+    assert g.current_ai_controller() is g.ai_controllers['white']
+
+
+def test_current_ai_controller_returns_black_after_first_move_in_cvc():
+    random.seed(101)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    g.current_ai_controller().take_turn(g)
+    assert g.next_player == 'black'
+    assert g.current_ai_controller() is g.ai_controllers['black']
+
+
+def test_current_ai_controller_is_none_in_hvh():
+    g = Game()
+    assert g.current_ai_controller() is None
+
+
+def test_current_ai_controller_is_none_on_user_turn_in_hvai():
+    g = Game()
+    g.apply_mode_selection(black_player='random')  # AI=black, user=white
+    assert g.next_player == 'white'
+    assert g.current_ai_controller() is None
+
+
+def test_cvc_can_play_multiple_full_turns_via_take_turn():
+    """Sanity: a CvC game can be driven forward by calling
+    current_ai_controller().take_turn repeatedly until it ends (or hits
+    a turn cap)."""
+    random.seed(103)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    turns_played = 0
+    for _ in range(50):
+        ctrl = g.current_ai_controller()
+        if ctrl is None or g.winner is not None:
+            break
+        before = g.board.turn_number
+        ok = ctrl.take_turn(g)
+        assert ok is True
+        assert g.board.turn_number == before + 1
+        turns_played += 1
+    assert turns_played > 0
+
+
+# ---- undo / redo in CvC ---------------------------------------------------
+
+def _advance_cvc(g, n):
+    for _ in range(n):
+        if g.winner is not None:
+            return
+        ctrl = g.current_ai_controller()
+        if ctrl is None:
+            return
+        ctrl.take_turn(g)
+
+
+def test_undo_in_cvc_is_single_step():
+    """CvC has no 'user side' to anchor on — undo steps back ONE ply,
+    same as HvH. (Skip-AI-turn undo is only HvAI behaviour.)"""
+    random.seed(107)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 4)
+    assert g.board.turn_number == 4
+    assert g.undo() is True
+    assert g.board.turn_number == 3  # single step
+    assert g.undo() is True
+    assert g.board.turn_number == 2
+
+
+def test_redo_in_cvc_is_single_step():
+    random.seed(109)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 4)
+    g.undo()
+    g.undo()
+    assert g.board.turn_number == 2
+    assert g.redo() is True
+    assert g.board.turn_number == 3
+    assert g.redo() is True
+    assert g.board.turn_number == 4

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -1,19 +1,22 @@
 """Tests for the in-UI mode selector AND AI-aware undo/redo.
 
-The Game owns:
+Historical note: the menu was originally a two-slot design — a 'side'
+(which colour the human plays) and an 'opponent' (the other side). With
+the addition of Computer-vs-Computer mode (2026-05-30), the menu is now
+per-side: `white_player` and `black_player` each pick independently from
+the same PLAYER_OPTIONS catalog ('human' | 'random' | 'easy' | 'medium' |
+'hard'). The old `side` / `opponent` kwargs and the `user_side` /
+`opponent` / `ai_controller` / `ai_color` attributes still work via
+derived properties / a back-compat path in `apply_mode_selection` — this
+test file exercises both APIs side-by-side.
 
-  - `user_side` ('white' or 'black') — which side the human plays.
-  - `opponent`  ('human' or an AI key like 'random') — who plays the OTHER side.
+CvC-specific behaviour is covered in tests/test_cvc_mode.py.
 
-These two choices are INDEPENDENT in the in-UI menu (you don't have to pick
-between "Human (W) vs Random (B)" and "Random (W) vs Human (B)" — you pick a
-side AND an opponent). `mode`, `ai_color`, and `ai_controller` are derived
-from those two and are kept in sync automatically.
-
-Undo/redo respect the AI: in human-vs-AI mode the user expects the undo key
-to take them back to their PREVIOUS turn (rolling back both the AI's last
-move and the user's last move), not just the AI's last move. Redo
-symmetrically advances to the next user turn.
+Undo/redo respect the AI: in human-vs-AI mode the user expects the undo
+key to take them back to their PREVIOUS turn (rolling back both the AI's
+last move and the user's last move), not just the AI's last move. Redo
+symmetrically advances to the next user turn. In HvH and CvC undo is
+single-step (no user side to anchor on in CvC).
 """
 
 import sys
@@ -65,27 +68,13 @@ def test_default_state():
     assert g.mode_menu_rects == []
 
 
-def test_side_options_catalog():
-    keys = [opt['key'] for opt in Game.SIDE_OPTIONS]
-    assert keys == ['white', 'black']
-    for opt in Game.SIDE_OPTIONS:
-        assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
-
-
-def test_opponent_options_catalog_has_human_and_random():
-    keys = [opt['key'] for opt in Game.OPPONENT_OPTIONS]
-    assert 'human' in keys
-    assert 'random' in keys
-    for opt in Game.OPPONENT_OPTIONS:
-        assert 'label' in opt and isinstance(opt['label'], str) and opt['label']
-
-
-def test_opponent_options_includes_ai_difficulties():
-    """Easy / Medium / Hard difficulty entries exist for the AI modes."""
-    keys = [opt['key'] for opt in Game.OPPONENT_OPTIONS]
-    assert 'easy' in keys
-    assert 'medium' in keys
-    assert 'hard' in keys
+def test_player_options_catalog_has_all_player_types():
+    """The PLAYER_OPTIONS catalog (used per-side) carries every player
+    type the menu offers. Catalog detail covered in test_cvc_mode.py;
+    this assertion lives here to keep the legacy-API tests grouped."""
+    keys = [opt['key'] for opt in Game.PLAYER_OPTIONS]
+    for required in ('human', 'random', 'easy', 'medium', 'hard'):
+        assert required in keys
 
 
 def test_ai_difficulty_targets_configured():
@@ -168,7 +157,8 @@ def test_open_close_mode_menu():
     g = Game()
     g.open_mode_menu()
     assert g.mode_menu is not None
-    assert 'sides' in g.mode_menu and 'opponents' in g.mode_menu
+    # New per-side shape (post-CvC): 'white' and 'black' columns.
+    assert 'white' in g.mode_menu and 'black' in g.mode_menu
     g.close_mode_menu()
     assert g.mode_menu is None
     assert g.mode_menu_rects == []
@@ -298,30 +288,27 @@ def test_show_mode_menu_noop_when_closed():
     assert g.mode_menu_rects == []
 
 
-def test_show_mode_menu_populates_rects_for_both_groups_when_open():
+def test_show_mode_menu_populates_rects_for_both_sides_when_open():
+    """Post-CvC menu: rects tagged by side ('white' or 'black'). Each
+    AI option whose checkpoint isn't on disk is dimmed and EXCLUDED from
+    mode_menu_rects (not clickable). 'human' / 'random' always render."""
     g = Game()
     g.open_mode_menu()
     surface = pygame.Surface((800, 800))
     g.show_mode_menu(surface)
-    # Entries are (rect, group_key, option_key)
-    groups = set(g for (_r, g, _k) in g.mode_menu_rects)
-    assert 'side' in groups
-    assert 'opponent' in groups
-    n_sides = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'side')
-    n_opps = sum(1 for (_r, g, _k) in g.mode_menu_rects if g == 'opponent')
-    assert n_sides == len(Game.SIDE_OPTIONS)
-    # Opponent options whose AI checkpoint is missing are deliberately
-    # excluded from mode_menu_rects (rendered dim, not clickable). So the
-    # rect count equals the number of opponents whose checkpoint exists
-    # (or which aren't AI keys at all).
-    expected_opps = sum(
-        1 for opt in Game.OPPONENT_OPTIONS
+    sides_seen = set(side for (_r, side, _k) in g.mode_menu_rects)
+    assert 'white' in sides_seen
+    assert 'black' in sides_seen
+    expected_per_side = sum(
+        1 for opt in Game.PLAYER_OPTIONS
         if g._ai_checkpoint_available(opt['key']))
-    assert n_opps == expected_opps
-    assert n_opps >= 2  # 'human' and 'random' are always available
-    for rect, group, key in g.mode_menu_rects:
+    assert expected_per_side >= 2  # 'human' + 'random' always available
+    for side in ('white', 'black'):
+        n = sum(1 for (_r, s, _k) in g.mode_menu_rects if s == side)
+        assert n == expected_per_side
+    for rect, side, key in g.mode_menu_rects:
         assert isinstance(rect, pygame.Rect)
-        assert group in ('side', 'opponent')
+        assert side in ('white', 'black')
         assert isinstance(key, str)
 
 


### PR DESCRIPTION
## Summary
- **Computer-vs-Computer mode**: refactored the mode menu from a two-slot ('side' + 'opponent') design to a per-side design. Each side (white / black) independently picks from `PLAYER_OPTIONS` ('human' | 'random' | 'easy' | 'medium' | 'hard'). Subsumes HvH, HvAI, and the new CvC. Main loop dispatches AI turns uniformly via `Game.current_ai_controller()`. All legacy properties (`user_side`, `opponent`, `ai_color`, `ai_controller`) and the legacy `apply_mode_selection(side=..., opponent=...)` API still work via `@property` and a back-compat translation path.
- **Easy AI cap 75 → 100**: at iter 64 the network was still blundering more than random in user testing. Easy now auto-tracks up to iter 100. Future differentiation should use temperature / blunder rate rather than another iteration step.
- **Goal 4 (GDL + GGP) kickoff doc**: `docs/goal4_gdl_ggp_planning.md`. GDL-I vs Ludii landscape, why this variant is a good GGP benchmark, formalization-difficulty ranking, 11-step incremental rollout plan starting with kings+base-queens, and 5 open questions waiting on user input.

## Test plan
- [x] 37 new tests in `tests/test_cvc_mode.py` covering catalog, per-side API, mode derivation, ai_controllers dict, all four back-compat @property accessors, legacy kwargs translation, new menu shape, current_ai_controller dispatch (HvH/HvAI/CvC), multi-turn CvC autoplay, single-step CvC undo/redo — all pass
- [x] `tests/test_mode_selection.py` updated for new menu group keys ('white'/'black' instead of 'side'/'opponent') — 34 pass
- [x] Full headless real-pygame suite (260 tests) pre-existing failures only — `test_v2_freeze::test_engine_manipulated_promotion_freezes_new_piece` and `test_v2_knight::test_repetition_blocks_knight_king_cycle_end_to_end` reproduce on main; not caused by this work
- [ ] Manual: launch main.py, open mode menu (M), verify both columns render, click "Random" on white + "Random" on black, watch the two AIs play each other; verify "Human" on either side gates the auto-play

🤖 Generated with [Claude Code](https://claude.com/claude-code)