### PR TITLE
CvC pause + PGN/FEN save-load dialog; Goal 4 step-1 GDL fragment

### DIFF
--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -289,3 +289,46 @@ Undo/redo in CvC: single-step (HvH-style). The skip-AI-turn behaviour is HvAI-on
 
 ### PR
 `claude/cvc-mode-easy-iter100-goal4` (this branch) — open PR after committing.
+
+## UPDATE (2026-05-30, later — PGN/FEN pause-dialog + Goal 4 step 1)
+
+### Training progress at this update
+- **iter 64/75 (unchanged since last update).** Iter 65 still in self-play / training phase — typical iter takes ~115 min, this is consistent. PID 68135 ELAPSED 3d 6h; caffeinate PID 25876 ELAPSED 1d 6h. Both alive. **The iter-counter has been static for hours**, which is normal: it ticks only when the training + buffer-update step for that iteration finishes; the user should not be alarmed unless it stays static for >3 hours.
+
+### CvC pause + PGN/FEN save-load dialog (NEW)
+The user reported that CvC mode "does not allow any key presses" — the autoplay loop never blocked for input. Plus they wanted a PGN/FEN-style save/load mechanism, with one key opening the dialog and a Copy button. They explicitly asked these two features be UNIFIED: the same dialog is both the "paused screen" for undo/redo and the save/load screen.
+
+**Design** (all landed in this update):
+- New `Game.pgn_dialog_open` flag + `open_pgn_dialog()` / `close_pgn_dialog()` / `show_pgn_dialog(surface)` methods. The dialog renders a dim backdrop, panel, human-readable header (mode + turn + player slots + winner), Copy / Load buttons, status message line, and the serialized text body.
+- New `Game.is_autoplay_paused()` predicate — wraps `is_any_menu_open()`; main.py uses this single predicate to gate CvC autoplay.
+- Mutual exclusion: `open_mode_menu` auto-closes the PGN dialog; `open_pgn_dialog` auto-closes the mode menu. User-spec'd transition between the two paused states.
+- New `Game.serialize_to_text()` / `Game.deserialize_from_text(text)` / `Game.load_from_text(text)` / `Game.copy_to_clipboard_action()` / `Game.load_from_clipboard_action()`.
+- Save format: human-readable header (`=== Chess Variant Save (v2 ruleset) ===`, mode, turn, players, winner) + a base64-encoded pickle payload wrapped between `___VARIANT_SAVE_V1_BEGIN___` / `___VARIANT_SAVE_V1_END___` markers. Payload carries board, next_player, winner, white/black player keys, `_perspective_side`, full `_history` undo stack, and `_redo_stack`. Round-trips perfectly through `deserialize_from_text` (covered by 12+ round-trip tests).
+- Clipboard: `Game._copy_to_clipboard` / `_read_clipboard` are staticmethod stubs that try pyperclip → pygame.scrap → fail gracefully. Tests monkeypatch these to verify the Copy/Load actions.
+- Key bindings (main.py):
+  - **P** toggles the dialog (open / close).
+  - **U / Y** in CvC auto-open the dialog before performing undo/redo (so CvC autoplay halts cleanly).
+  - **Esc** closes any open dialog (jump-capture cancel > mode menu > pgn dialog, in priority order).
+  - **M** opens mode menu, closing pgn dialog if open (mutual exclusion).
+  - **T / F** (theme / flip) — viewing prefs, always available regardless of which paused state is up.
+  - **R** opens reset-confirm — works from any paused state, the confirm overlay renders on top.
+  - All other keys (drag, etc.) are SUPPRESSED while the dialog is open (the dialog covers the board, mouse clicks on Copy/Load buttons consumed, fall-through clicks swallowed too).
+- Undo/redo in CvC: `_in_intermediate_state` does NOT include `pgn_dialog_open`, so undo/redo work from the paused state. Tests explicitly verify this.
+
+**Tests** (45 in `tests/test_pause_and_pgn.py`): per the user's "huge amount of test cases" request. Covers the dialog state machine (open/close/idempotency/inclusion in is_any_menu_open/is_autoplay_paused), the mutual exclusion with mode menu (both directions, plus the "closing mode menu doesn't reopen pgn dialog" invariant), reset-confirm interaction (both can coexist), rendering (no-op when closed, draws when open, button rects populated/cleared), 12+ serialization round-trip cases (initial game, HvH/HvAI/CvC mode preservation, `_perspective_side` preservation, post-turn state preservation, undo/redo history preservation, winner preservation), error handling (garbage/empty input returns False, mutates nothing), clipboard interaction (monkeypatched provider, Copy/Load actions), and CvC undo/redo while dialog open. All pass. Total focused test set: 133 tests across 6 files.
+
+### Goal 4 step 1 (kings + base queens GDL fragment) — LANDED
+Per the user's "get started" on Goal 4, with no explicit answers to the 5 open questions in `docs/goal4_gdl_ggp_planning.md` §6, defaults were taken (reversible):
+- **Dialect: GDL-I (Stanford)** — matches the recognised "GGP" framing in academic/ISEF context. Ludii remains the documented fallback.
+- **Fragment landed:** `docs/gdl/step1_kings_queens.gdl` (~150 lines including comments). Kings + base-form royal queens only at rulebook-correct starting squares (W K g1, Q b1; B K b8, Q g8). King-like 1-square move for both pieces. Plain captures. Win = capture both opponent royals. NO pawns/rook/bishop/knight/boulder/actions/reactive-captures/repetition/tiny-endgame (all deferred to later steps in the 11-step plan).
+- **Tests:** `tests/test_gdl_step1.py` — tiny S-expression parser + 8 structural invariants (parens balanced, both roles declared, white moves first, correct starting K + Q squares per RULEBOOK_v2.md, no extra piece types, `legal` clauses for both sides, `terminal` + `goal` rules exist, only known GDL-I top-level keywords used). Catches hand-edit bugs; does NOT verify legal-move equivalence with the Python engine.
+- **The real correctness gate (NOT done):** install a GDL-I reasoner (GGP-Base / Palamedes), enumerate legal moves from curated test positions, assert equality with `engine.get_all_legal_turns()`. This is the gating criterion to advance to step 2. Out of scope for the kickoff commit because it needs a toolchain decision + install.
+
+### What step 2 will need (already documented in goal4_gdl_ggp_planning.md update)
+1. Add pawns to `init` (rank 2 / rank 7).
+2. Pawn move rules: forward/left/right 1 (NOT backward) — the sideways-move-but-not-capture asymmetry is the first non-trivial deviation from standard chess.
+3. Promotion to base queen on last rank (multi-form queen deferred to step 7).
+4. ~60–100 lines additional GDL; ~10 additional structural tests.
+
+### Branch
+`claude/pgn-fen-pause-and-gdl-fragment` (this branch) — open PR after committing.

--- a/docs/gdl/step1_kings_queens.gdl
+++ b/docs/gdl/step1_kings_queens.gdl
@@ -1,0 +1,204 @@
+; ============================================================================
+; Step 1 GDL-I fragment: kings + base-form royal queens only.
+;
+; This is the FIRST step of the Goal-4 incremental rollout described in
+; docs/goal4_gdl_ggp_planning.md. Scope is intentionally tiny — just
+; enough game to (1) bootstrap toolchain fluency, (2) verify our chosen
+; dialect parses and runs in an off-the-shelf GGP reasoner, and
+; (3) anchor the position-equality test harness that every later step
+; will reuse.
+;
+; What it covers:
+;   - 8x8 board (files a-h, ranks 1-8)
+;   - Two roles (white, black)
+;   - One king + one royal queen per side at their rulebook-correct
+;     starting squares (rotational-symmetric setup):
+;         White king g1, White royal queen b1
+;         Black king b8, Black royal queen g8
+;   - King + queen both move one square in any of 8 directions
+;     (queen base form = king-like, NOT the standard-chess slider —
+;     this is the v2 variant rule)
+;   - Plain captures (move onto an enemy square)
+;   - Win condition: capture BOTH of the opponent's royals
+;
+; What it deliberately omits (deferred to later steps):
+;   - Pawns + promotion (step 2)
+;   - Rook 2-segment moves (step 3)
+;   - Knight radius-2 + jump-capture + invuln (steps 4, 8)
+;   - Bishop teleport + reactive capture (steps 5, 9)
+;   - Boulder + cooldown + no-return memory (step 6)
+;   - Queen actions: Manipulation + Transformation (step 7)
+;   - Repetition rule (step 10)
+;   - Tiny endgame rule (step 11)
+;   - No-legal-moves loss (folded in as soon as a real legal-move
+;     enumerator exists; here, with two royals each, no-legal is
+;     practically impossible)
+;
+; Dialect: GDL-I (Stanford GGP). Tested structurally by
+; tests/test_gdl_step1.py; reasoner-level legal-move equivalence
+; against src/engine.py is the gating criterion to advance to step 2
+; and is implemented when the toolchain is chosen (open question
+; §6 Q1 in goal4_gdl_ggp_planning.md).
+; ============================================================================
+
+; ---- Roles --------------------------------------------------------------
+(role white)
+(role black)
+
+; ---- Initial state ------------------------------------------------------
+;
+; cell facts: (cell <file> <rank> <color> <piece>)
+; White moves first via (control white).
+;
+(init (cell g 1 white king))
+(init (cell b 1 white queen))
+(init (cell g 8 black queen))
+(init (cell b 8 black king))
+(init (control white))
+
+; ---- Helpers ------------------------------------------------------------
+;
+; opponent: pair up the two roles.
+(<= (opponent white black))
+(<= (opponent black white))
+
+; file_adj / rank_adj: adjacency along files (a..h) and ranks (1..8).
+; Both are unordered pairs of NEIGHBOURING squares (chebyshev-1 along
+; the axis).
+(<= (file_adj a b))
+(<= (file_adj b c))
+(<= (file_adj c d))
+(<= (file_adj d e))
+(<= (file_adj e f))
+(<= (file_adj f g))
+(<= (file_adj g h))
+(<= (file_adj ?x ?y) (file_adj ?y ?x))    ; symmetric
+
+(<= (rank_adj 1 2))
+(<= (rank_adj 2 3))
+(<= (rank_adj 3 4))
+(<= (rank_adj 4 5))
+(<= (rank_adj 5 6))
+(<= (rank_adj 6 7))
+(<= (rank_adj 7 8))
+(<= (rank_adj ?x ?y) (rank_adj ?y ?x))    ; symmetric
+
+; same_file / same_rank: trivial reflexivity for the king/queen
+; 1-step-in-any-direction move enumeration below.
+(<= (same_file ?x ?x))
+(<= (same_rank ?x ?x))
+
+; chebyshev-1 = step in any of 8 directions = (file diff in {-1,0,+1})
+; AND (rank diff in {-1,0,+1}) AND NOT (both zero).
+; In GDL: at least one of file/rank is adjacent, and the other is
+; equal-or-adjacent. The "not both equal" clause is enforced by
+; requiring different squares (?from != ?to).
+(<= (king_step ?ff ?fr ?tf ?tr)
+    (file_adj ?ff ?tf)
+    (or (rank_adj ?fr ?tr) (same_rank ?fr ?tr)))
+(<= (king_step ?ff ?fr ?tf ?tr)
+    (same_file ?ff ?tf)
+    (rank_adj ?fr ?tr))
+
+; A square is occupied if any piece sits on it (we don't care whose).
+(<= (occupied ?f ?r)
+    (true (cell ?f ?r ?c ?p)))
+
+; A square is enemy-occupied (for ?mover) if a piece of the opposing
+; colour sits there.
+(<= (enemy_at ?mover ?f ?r)
+    (true (cell ?f ?r ?other ?p))
+    (opponent ?mover ?other))
+
+; A square is friend-occupied (for ?mover) if a piece of the same
+; colour sits there.
+(<= (friend_at ?mover ?f ?r)
+    (true (cell ?f ?r ?mover ?p)))
+
+; ---- Legal moves --------------------------------------------------------
+;
+; Both king and base-form queen move 1 square in any direction.
+;
+; A move is (move ?piece ?from_file ?from_rank ?to_file ?to_rank).
+; Legality requires:
+;   (a) it is the player's turn (control ?player),
+;   (b) the player owns a king or queen at the from-square,
+;   (c) the to-square is a chebyshev-1 step from the from-square,
+;   (d) the to-square is either empty or enemy-occupied (no
+;       self-capture; in this fragment we omit the v2 king's
+;       friendly-capture ability — irrelevant here since each side
+;       has only two pieces and the king can't usefully capture its
+;       own queen).
+(<= (legal ?player (move ?piece ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player ?piece))
+    (or (= ?piece king) (= ?piece queen))
+    (king_step ?ff ?fr ?tf ?tr)
+    (not (friend_at ?player ?tf ?tr)))
+
+; Non-moving role must noop each turn (GDL-I synchronous-turn
+; convention).
+(<= (legal ?player noop)
+    (true (control ?other))
+    (opponent ?other ?player))
+
+; ---- State transitions --------------------------------------------------
+;
+; Three things change between states when ?mover plays
+; (move ?piece ?ff ?fr ?tf ?tr):
+;   1. The moving piece leaves its from-cell.
+;   2. The moving piece arrives at the to-cell, REPLACING any piece
+;      that was there (capture).
+;   3. Control passes to the opponent.
+;
+; All OTHER cells persist (frame axiom).
+;
+; The captured piece (if any) is removed: it doesn't appear in next
+; because we only add the moving piece at the to-cell.
+
+; (1) Frame axiom for every non-affected cell.
+(<= (next (cell ?f ?r ?c ?p))
+    (true (cell ?f ?r ?c ?p))
+    (does ?mover (move ?piece ?ff ?fr ?tf ?tr))
+    (or (distinct ?f ?ff) (distinct ?r ?fr))
+    (or (distinct ?f ?tf) (distinct ?r ?tr)))
+
+; (2) Moving piece arrives at to-cell.
+(<= (next (cell ?tf ?tr ?mover ?piece))
+    (does ?mover (move ?piece ?ff ?fr ?tf ?tr)))
+
+; (3) Opponent gets control.
+(<= (next (control ?next))
+    (true (control ?mover))
+    (opponent ?mover ?next))
+
+; ---- Terminal & goals ---------------------------------------------------
+;
+; Win condition (RULEBOOK_v2.md §Objective): capture BOTH of the
+; opponent's royals — in this fragment, both king AND queen.
+;
+; "Captured" = the piece is absent from the board in the current state.
+; We test absence by saying NO cell holds that role+piece.
+;
+; alive(?player, ?piece): some cell holds it.
+(<= (alive ?player ?piece)
+    (true (cell ?f ?r ?player ?piece)))
+
+; dead(?player, ?piece): no cell holds it.
+(<= (dead ?player ?piece)
+    (not (alive ?player ?piece)))
+
+; A player has LOST iff both their royals are dead.
+(<= (lost ?player)
+    (dead ?player king)
+    (dead ?player queen))
+
+; Game ends when either side has lost.
+(<= terminal (lost white))
+(<= terminal (lost black))
+
+; Standard GGP goal scoring: 100 for the winner, 0 for the loser.
+(<= (goal white 100) (lost black))
+(<= (goal black 100) (lost white))
+(<= (goal white 0)   (lost white))
+(<= (goal black 0)   (lost black))

--- a/docs/goal4_gdl_ggp_planning.md
+++ b/docs/goal4_gdl_ggp_planning.md
@@ -250,3 +250,62 @@ These should be decided before any GDL writing begins:
 When the user picks a dialect (§6 Q1), step 1 of §5 ("kings + base
 queens only") can be drafted in a few hundred lines of GDL. Until then,
 this doc is the kickoff record and the rulebook stays the source of truth.
+
+---
+
+## UPDATE — 2026-05-30: Step 1 landed (default dialect: GDL-I)
+
+The user opted to "get started" on Goal 4 without explicitly answering
+the open questions in §6, so the following defaults were taken; they
+remain reversible:
+
+- **Dialect: GDL-I (Stanford).** Lean from §6 Q1 carried over —
+  matches the recognised "GGP" framing in ISEF / academic context.
+  Ludii remains the fallback if GDL-I tooling becomes a blocker.
+- **Step 1 written:** `docs/gdl/step1_kings_queens.gdl` — kings +
+  base-form royal queens only, both starting at rulebook-correct
+  squares (W K g1, W Q b1; B K b8, B Q g8 — rotational-symmetric
+  setup), king-like 1-square move for both pieces, plain captures,
+  win = capture both opponent royals.
+- **Tests:** `tests/test_gdl_step1.py` — small S-expression parser
+  + 8 structural invariants (parens balanced; both roles declared;
+  white moves first; correct starting squares for K and Q; no extra
+  piece types; at least one `legal` rule per side; `terminal` + `goal`
+  rules exist; only known GDL-I top-level keywords used). These
+  catch the kinds of bugs that come from hand-editing a GDL file
+  (typos, missing role, wrong square). They do NOT verify legal-move
+  equivalence with the Python engine — that's the gating criterion
+  for step 2 and is implemented once a GDL reasoner is wired in.
+
+**Reasoner integration (still NOT done):** the structural test is a
+cheap sanity check; the real correctness gate is "parse this file in
+a GGP reasoner (e.g. GGP-Base, Palamedes), enumerate legal moves
+from a curated set of test positions, assert equality with
+`engine.get_all_legal_turns()`." This requires installing a
+reasoner — out of scope for the kickoff commit.
+
+Choice of `(distinct ?x ?y)` semantics in next clauses: GDL-I's
+standard convention is `(distinct ?x ?y)` as a built-in for
+inequality. Used inline in the frame-axiom clause. If the chosen
+reasoner uses `(not (= ?x ?y))` instead, that's a 5-minute
+substitution.
+
+### What step 2 will need
+
+1. Add pawns to `init`. Setup: white pawns rank 2, black pawns rank 7.
+2. Pawn move rules: forward/left/right 1 square (NOT backward) —
+   the v2 sideways-move-but-not-capture asymmetry is the first
+   non-trivial difference from standard chess. Adds `pawn_forward`
+   and `pawn_capture_dir` helpers per colour.
+3. Promotion on reaching the last rank: choose a queen form. For step
+   2 we likely just promote to base queen (matching step 1's only
+   non-king piece) — the multi-form queen + transformation comes in
+   step 7.
+4. Extend `lost` if needed: pawns don't count toward royal-capture
+   victory, so `(lost ?player)` is unchanged. But pawn captures DO
+   need a `next` clause that removes the captured pawn — the frame
+   axiom handles this implicitly (the to-cell is replaced by the
+   moving piece), so no change needed.
+
+Estimated size: 60–100 lines additional GDL; ~10 additional
+structural-test cases.

--- a/src/game.py
+++ b/src/game.py
@@ -1,10 +1,55 @@
+import base64
 import copy
 import os
+import pickle
 import re
 
 import pygame
 from pygame import gfxdraw
 from PIL import Image
+
+
+# Serialization markers + version. Bump SAVE_VERSION when the pickled
+# payload's shape changes in a way that breaks back-compat.
+_SAVE_BEGIN = '___VARIANT_SAVE_V1_BEGIN___'
+_SAVE_END = '___VARIANT_SAVE_V1_END___'
+_SAVE_VERSION = 1
+
+
+def _default_copy_to_clipboard(text):
+    """Best-effort clipboard write. Tries pyperclip first, then
+    pygame.scrap. Returns True on success. Designed to be overridable
+    via Game._copy_to_clipboard for tests / different host setups."""
+    try:
+        import pyperclip
+        pyperclip.copy(text)
+        return True
+    except Exception:
+        pass
+    try:
+        pygame.scrap.init()
+        pygame.scrap.put(pygame.SCRAP_TEXT, text.encode('utf-8'))
+        return True
+    except Exception:
+        return False
+
+
+def _default_read_clipboard():
+    """Best-effort clipboard read. Returns the string or None."""
+    try:
+        import pyperclip
+        data = pyperclip.paste()
+        return data if data else None
+    except Exception:
+        pass
+    try:
+        pygame.scrap.init()
+        raw = pygame.scrap.get(pygame.SCRAP_TEXT)
+        if raw is None:
+            return None
+        return raw.decode('utf-8', errors='replace')
+    except Exception:
+        return None
 
 from const import *
 from board import Board
@@ -303,6 +348,23 @@ class Game:
         # overlay is rendered by show_reset_confirm; main.py treats it like
         # any other open menu (no interactions while up).
         self.reset_confirm_pending = False
+        # Pause / PGN-FEN dialog. Opened via 'P', or implicitly when
+        # undo/redo is pressed during CvC autoplay (the user-spec'd
+        # "paused screen for undo/redo that doesn't interfere with CvC
+        # playing"). The same dialog renders a serialized game string
+        # with Copy / Load buttons (the user's "PGN/FEN + save/load"
+        # ask). Mutually exclusive with mode_menu: opening either
+        # closes the other (both are paused-game states; only one is
+        # on screen at a time).
+        self.pgn_dialog_open = False
+        # Click rects for the dialog's buttons, populated on each
+        # render and consumed by main.py's MOUSEBUTTONDOWN dispatch.
+        self.pgn_dialog_copy_rect = None
+        self.pgn_dialog_load_rect = None
+        # Optional status message shown in the dialog (e.g. "Copied!"
+        # after a successful Copy click). Cleared when the dialog is
+        # closed.
+        self.pgn_dialog_status = None
         # Per-side player choice — the primary mode state. Both default to
         # 'human' (HvH). `user_side`, `opponent`, `ai_color`,
         # `ai_controller` are derived @property values kept for back-compat
@@ -577,7 +639,15 @@ class Game:
 
         Menu shape is {'white': [PLAYER_OPTIONS], 'black': [PLAYER_OPTIONS]}.
         Each side renders the same catalog; selecting a button on one side
-        only updates that side."""
+        only updates that side.
+
+        If the PGN dialog is open, this CLOSES it first — both are
+        paused-game states and only one is on screen at a time. (User
+        spec: "mode menu should be able to be opened during pause, which
+        will close the pause screen and open the mode menu".)
+        """
+        if self.pgn_dialog_open:
+            self.close_pgn_dialog()
         self.mode_menu = {
             'white': list(self.PLAYER_OPTIONS),
             'black': list(self.PLAYER_OPTIONS),
@@ -587,6 +657,324 @@ class Game:
         """Close the mode-selection menu and drop its click rects."""
         self.mode_menu = None
         self.mode_menu_rects = []
+
+    # ---- PGN / FEN pause-and-save dialog -------------------------------
+
+    def open_pgn_dialog(self):
+        """Open the paused-game save/load dialog (the user's "PGN/FEN"
+        screen + pause-screen, unified per spec). Idempotent. If the mode
+        menu is currently open, it CLOSES first — they're mutually
+        exclusive paused-game states."""
+        if self.mode_menu is not None:
+            self.close_mode_menu()
+        self.pgn_dialog_open = True
+        self.pgn_dialog_status = None  # fresh dialog: no stale "Copied!" etc.
+
+    def close_pgn_dialog(self):
+        """Close the dialog and drop its click rects + status message."""
+        self.pgn_dialog_open = False
+        self.pgn_dialog_copy_rect = None
+        self.pgn_dialog_load_rect = None
+        self.pgn_dialog_status = None
+
+    def show_pgn_dialog(self, surface):
+        """Render the paused/PGN-FEN dialog if open. No-op when closed
+        — also clears stale click rects."""
+        if not self.pgn_dialog_open:
+            self.pgn_dialog_copy_rect = None
+            self.pgn_dialog_load_rect = None
+            return
+        w, h = surface.get_size()
+        # Dim backdrop.
+        backdrop = pygame.Surface((w, h), pygame.SRCALPHA)
+        backdrop.fill((0, 0, 0, 180))
+        surface.blit(backdrop, (0, 0))
+
+        # Panel rect — leaves margins on all sides.
+        pad = min(40, int(w * 0.05))
+        panel = pygame.Rect(pad, pad, w - 2 * pad, h - 2 * pad)
+        pygame.draw.rect(surface, (35, 35, 40), panel, border_radius=10)
+        pygame.draw.rect(
+            surface, (200, 200, 200), panel, width=2, border_radius=10)
+
+        title_font = pygame.font.SysFont('arial', 22, bold=True)
+        header_font = pygame.font.SysFont('arial', 16, bold=True)
+        body_font = pygame.font.SysFont('couriernew', 12)
+        button_font = pygame.font.SysFont('arial', 16, bold=True)
+        hint_font = pygame.font.SysFont('arial', 14)
+
+        # Title row.
+        title = title_font.render(
+            'Game Save / Load  (P or Esc to close)',
+            True, (255, 255, 255))
+        surface.blit(title, (panel.left + 16, panel.top + 12))
+
+        # Human-readable header summarising the current game.
+        humans = sum(1 for p in (self.white_player, self.black_player)
+                     if p == 'human')
+        turn_label = (f'Turn {self.board.turn_number}  '
+                      f'({self.next_player} to move)')
+        header_lines = [
+            f'Mode: {self.mode}',
+            f'White: {self.white_player}   Black: {self.black_player}',
+            turn_label,
+        ]
+        if self.winner:
+            header_lines.append(f'Winner: {self.winner}')
+        y = panel.top + 48
+        for line in header_lines:
+            surf = header_font.render(line, True, (220, 220, 220))
+            surface.blit(surf, (panel.left + 16, y))
+            y += 22
+
+        # Buttons row: [Copy]  [Load from clipboard]
+        btn_y = y + 8
+        btn_h = 32
+        btn_w = 180
+        gap = 16
+        self.pgn_dialog_copy_rect = pygame.Rect(
+            panel.left + 16, btn_y, btn_w, btn_h)
+        self.pgn_dialog_load_rect = pygame.Rect(
+            panel.left + 16 + btn_w + gap, btn_y, btn_w + 40, btn_h)
+        for rect, label in (
+                (self.pgn_dialog_copy_rect, 'Copy'),
+                (self.pgn_dialog_load_rect, 'Load from clipboard')):
+            pygame.draw.rect(surface, (60, 100, 160), rect, border_radius=6)
+            pygame.draw.rect(
+                surface, (200, 200, 200), rect, width=2, border_radius=6)
+            text_surf = button_font.render(label, True, (255, 255, 255))
+            surface.blit(text_surf, text_surf.get_rect(center=rect.center))
+
+        # Status line (e.g. "Copied!" / "Load failed").
+        status_y = btn_y + btn_h + 8
+        if self.pgn_dialog_status:
+            status = hint_font.render(
+                self.pgn_dialog_status, True, (180, 220, 180))
+            surface.blit(status, (panel.left + 16, status_y))
+            status_y += 20
+
+        # Serialized text region.
+        body_top = status_y + 8
+        body_rect = pygame.Rect(
+            panel.left + 16, body_top,
+            panel.right - panel.left - 32, panel.bottom - body_top - 50)
+        pygame.draw.rect(surface, (20, 20, 25), body_rect, border_radius=6)
+        pygame.draw.rect(
+            surface, (90, 90, 90), body_rect, width=1, border_radius=6)
+
+        # Word-wrap the serialized text into the body rect. Truncate
+        # with an ellipsis if it overflows — the user can still use Copy
+        # to get the full text via the clipboard.
+        text = self.serialize_to_text()
+        line_h = body_font.get_height() + 2
+        max_lines = max(1, body_rect.height // line_h - 1)
+        # Soft-wrap at fixed character width based on the font's typical
+        # advance — couriernew is monospace so this is reasonable.
+        char_w = max(6, body_font.size('M')[0])
+        chars_per_line = max(10, (body_rect.width - 16) // char_w)
+        wrapped = []
+        for raw_line in text.split('\n'):
+            if not raw_line:
+                wrapped.append('')
+                continue
+            for i in range(0, len(raw_line), chars_per_line):
+                wrapped.append(raw_line[i:i + chars_per_line])
+                if len(wrapped) >= max_lines:
+                    break
+            if len(wrapped) >= max_lines:
+                break
+        if len(wrapped) >= max_lines:
+            wrapped = wrapped[:max_lines - 1] + ['... (use Copy for full)']
+        for i, ln in enumerate(wrapped):
+            surf = body_font.render(ln, True, (200, 220, 200))
+            surface.blit(surf, (body_rect.left + 8,
+                                body_rect.top + 6 + i * line_h))
+
+        hint = hint_font.render(
+            'U/Y to undo/redo while paused.  M opens mode menu (closes this). '
+            ' T / F always available.',
+            True, (160, 160, 160))
+        surface.blit(hint, (panel.left + 16, panel.bottom - 26))
+
+    # ---- serialization / save-load --------------------------------------
+
+    _copy_to_clipboard = staticmethod(_default_copy_to_clipboard)
+    _read_clipboard = staticmethod(_default_read_clipboard)
+
+    def serialize_to_text(self):
+        """Serialize the entire game state to a human-prefixed text
+        block. Round-trips perfectly through `deserialize_from_text`.
+
+        Format:
+
+            === Chess Variant Save (v2 ruleset) ===
+            Mode: <mode>
+            Turn: <n> (<color> to move)
+            White: <player>   Black: <player>
+            Winner: <winner>          (only present if a winner exists)
+
+            ___VARIANT_SAVE_V1_BEGIN___
+            <base64-encoded pickle payload>
+            ___VARIANT_SAVE_V1_END___
+
+        The header is human-readable; the payload between the markers
+        is the canonical record. Loaders read the payload only; the
+        header is decorative."""
+        payload = {
+            'version': _SAVE_VERSION,
+            'board': self.board,
+            'next_player': self.next_player,
+            'winner': self.winner,
+            'white_player': self.white_player,
+            'black_player': self.black_player,
+            '_perspective_side': self._perspective_side,
+            '_history': self._history,
+            '_redo_stack': self._redo_stack,
+        }
+        # protocol=4 is the default since 3.8 and is stable / portable.
+        pickled = pickle.dumps(payload, protocol=4)
+        encoded = base64.b64encode(pickled).decode('ascii')
+        header_lines = [
+            '=== Chess Variant Save (v2 ruleset) ===',
+            f'Mode: {self.mode}',
+            f'Turn: {self.board.turn_number} ({self.next_player} to move)',
+            f'White: {self.white_player}   Black: {self.black_player}',
+        ]
+        if self.winner:
+            header_lines.append(f'Winner: {self.winner}')
+        return (
+            '\n'.join(header_lines)
+            + '\n\n'
+            + _SAVE_BEGIN + '\n'
+            + encoded + '\n'
+            + _SAVE_END + '\n'
+        )
+
+    @classmethod
+    def deserialize_from_text(cls, text):
+        """Reconstruct a Game from text produced by serialize_to_text.
+        Raises ValueError on any parse failure (bad header, missing
+        markers, garbage payload, wrong version)."""
+        if not isinstance(text, str) or not text:
+            raise ValueError('empty input')
+        begin = text.find(_SAVE_BEGIN)
+        end = text.find(_SAVE_END)
+        if begin == -1 or end == -1 or end <= begin:
+            raise ValueError('missing save markers')
+        encoded = text[begin + len(_SAVE_BEGIN):end].strip()
+        try:
+            pickled = base64.b64decode(encoded.encode('ascii'))
+            payload = pickle.loads(pickled)
+        except Exception as e:
+            raise ValueError(f'corrupt save payload: {e}')
+        if not isinstance(payload, dict):
+            raise ValueError('save payload not a dict')
+        if payload.get('version') != _SAVE_VERSION:
+            raise ValueError(
+                f"unsupported save version {payload.get('version')!r}")
+        g = cls()
+        g._apply_loaded_payload(payload)
+        return g
+
+    def load_from_text(self, text):
+        """Replace this game's state with the deserialized state from
+        `text`. Returns True on success, False on any error (game state
+        is NOT mutated on failure).
+
+        Uses in-place mutation of `self.board` so external callers
+        holding the board reference (main.py) stay valid — same
+        contract as `_restore`.
+        """
+        try:
+            payload = self._parse_save_payload(text)
+        except Exception:
+            return False
+        try:
+            self._apply_loaded_payload(payload)
+        except Exception:
+            return False
+        return True
+
+    @staticmethod
+    def _parse_save_payload(text):
+        """Extract + validate the pickled payload dict. Raises on
+        any error."""
+        if not isinstance(text, str) or not text:
+            raise ValueError('empty input')
+        begin = text.find(_SAVE_BEGIN)
+        end = text.find(_SAVE_END)
+        if begin == -1 or end == -1 or end <= begin:
+            raise ValueError('missing save markers')
+        encoded = text[begin + len(_SAVE_BEGIN):end].strip()
+        pickled = base64.b64decode(encoded.encode('ascii'))
+        payload = pickle.loads(pickled)
+        if not isinstance(payload, dict):
+            raise ValueError('save payload not a dict')
+        if payload.get('version') != _SAVE_VERSION:
+            raise ValueError(
+                f"unsupported save version {payload.get('version')!r}")
+        return payload
+
+    def _apply_loaded_payload(self, payload):
+        """Internal: install a deserialized payload onto this Game.
+
+        Mirrors `_restore` for the board (in-place mutation to preserve
+        external references) and additionally restores the mode state
+        and undo/redo stacks. Refreshes derived AI controllers so the
+        loaded game is immediately playable in HvAI/CvC."""
+        loaded_board = copy.deepcopy(payload['board'])
+        self.board.__dict__.update(loaded_board.__dict__)
+        self.next_player = payload['next_player']
+        self.winner = payload['winner']
+        self.white_player = payload.get('white_player', 'human')
+        self.black_player = payload.get('black_player', 'human')
+        self._perspective_side = payload.get('_perspective_side', 'white')
+        # Re-deepcopy history/redo so the loaded game and the payload
+        # don't alias.
+        self._history = copy.deepcopy(payload.get('_history', []))
+        self._redo_stack = copy.deepcopy(payload.get('_redo_stack', []))
+        # Reset dialog/menu UI state on a loaded game — these are not
+        # part of the saved data.
+        self.pgn_dialog_open = False
+        self.pgn_dialog_copy_rect = None
+        self.pgn_dialog_load_rect = None
+        self.pgn_dialog_status = None
+        self.mode_menu = None
+        self.mode_menu_rects = []
+        self.reset_confirm_pending = False
+        if self.dragger is not None:
+            self.dragger.dragging = False
+            self.dragger.piece = None
+        # Rebuild ai_controllers + mode from the loaded per-side keys.
+        self._refresh_ai()
+
+    def copy_to_clipboard_action(self):
+        """Serialize the game and push it to the clipboard. Returns
+        True on success. Designed to be invoked from the dialog's Copy
+        button click handler."""
+        text = self.serialize_to_text()
+        ok = Game._copy_to_clipboard(text)
+        if ok:
+            self.pgn_dialog_status = 'Copied to clipboard.'
+        else:
+            self.pgn_dialog_status = (
+                'Copy failed (clipboard unavailable — '
+                'select & copy manually).')
+        return ok
+
+    def load_from_clipboard_action(self):
+        """Read text from the clipboard and load it. Returns True on
+        success. Updates pgn_dialog_status either way for UI feedback."""
+        text = Game._read_clipboard()
+        if not text:
+            self.pgn_dialog_status = 'Clipboard empty or unavailable.'
+            return False
+        ok = self.load_from_text(text)
+        if ok:
+            self.pgn_dialog_status = 'Loaded.'
+        else:
+            self.pgn_dialog_status = 'Load failed (not a valid save).'
+        return ok
 
     def apply_mode_selection(self, white_player=None, black_player=None,
                              side=None, opponent=None):
@@ -838,7 +1226,15 @@ class Game:
             or self.promotion_menu is not None
             or self.mode_menu is not None
             or self.reset_confirm_pending
+            or self.pgn_dialog_open
         )
+
+    def is_autoplay_paused(self):
+        """True iff CvC autoplay should hold off. Same as
+        is_any_menu_open in current scope, but exposed as a separate
+        predicate so callers reading "is autoplay paused?" don't have
+        to think about whether menus block autoplay (they always do)."""
+        return self.is_any_menu_open()
 
     def show_reset_confirm(self, surface):
         """Render the reset-game confirmation overlay if pending."""

--- a/src/main.py
+++ b/src/main.py
@@ -124,6 +124,7 @@ class Main:
             game.show_transform_menu(screen)
             game.show_promotion_menu(screen)
             game.show_mode_menu(screen)
+            game.show_pgn_dialog(screen)
             game.show_winner(screen)
             game.show_reset_confirm(screen)
             board.update_lines_of_sight()
@@ -135,13 +136,14 @@ class Main:
             # Human-vs-AI OR Computer-vs-Computer: when the side to move is
             # an AI, let that side's AIController take the turn. Works
             # uniformly across HvAI (one controller) and CvC (two
-            # controllers — whichever colour is on move drives). The mode
-            # menu (if open) blocks AI play so the user can finish
-            # selecting a mode.
+            # controllers — whichever colour is on move drives). Any
+            # paused-game state (mode menu, reset-confirm, pgn dialog)
+            # halts autoplay via the single `is_autoplay_paused`
+            # predicate so the user can interact (undo/redo via the
+            # PGN dialog, change mode, confirm reset, etc.).
             _ctrl = game.current_ai_controller()
             if (_ctrl is not None and _ctrl.is_ai_turn(game)
-                    and game.mode_menu is None
-                    and not game.reset_confirm_pending):
+                    and not game.is_autoplay_paused()):
                 # CRUCIAL: push the (already-redrawn) post-human-move backbuffer
                 # to the screen BEFORE pausing.
                 #
@@ -193,6 +195,32 @@ class Main:
                     clicked_row, clicked_col = game.screen_to_board(
                         screen_clicked_row, screen_clicked_col
                     )
+
+                    # PGN/pause dialog button clicks. The dialog renders
+                    # over the board; consume clicks on its Copy / Load
+                    # buttons here so they don't leak through to piece
+                    # interactions. Clicks anywhere else inside the
+                    # dialog area are swallowed too (no piece dragging
+                    # while paused). Allowed even when game.winner is
+                    # set so the user can still copy/load a finished
+                    # game.
+                    if game.pgn_dialog_open and event.button == 1:
+                        mx, my = event.pos
+                        if (game.pgn_dialog_copy_rect is not None
+                                and game.pgn_dialog_copy_rect.collidepoint(
+                                    mx, my)):
+                            game.copy_to_clipboard_action()
+                        elif (game.pgn_dialog_load_rect is not None
+                              and game.pgn_dialog_load_rect.collidepoint(
+                                  mx, my)):
+                            if game.load_from_clipboard_action():
+                                # Reset local refs in case load swapped state.
+                                game = self.game
+                                board = self.game.board
+                                dragger = self.game.dragger
+                        # Either way, consume the click — no fall-through
+                        # to piece drag while the dialog is up.
+                        continue
 
                     # Block all interactions when game is over
                     if game.winner:
@@ -703,21 +731,24 @@ class Main:
                         continue
 
                     # Esc: cancel an in-progress jump-capture second click,
-                    # OR close the mode menu if it's open. (If neither is
-                    # active, Esc does nothing — we don't want it to also
-                    # close other menus or quit.)
+                    # OR close the mode menu if it's open, OR close the
+                    # PGN/pause dialog. (If none is active, Esc does
+                    # nothing — we don't want it to also close other
+                    # menus or quit.)
                     if event.key == pygame.K_ESCAPE:
                         if game.jump_capture_targets is not None:
                             game.cancel_jump_capture()
                             game.play_sound(captured=False)
                         elif game.mode_menu is not None:
                             game.close_mode_menu()
+                        elif game.pgn_dialog_open:
+                            game.close_pgn_dialog()
                         continue
 
-                    # M: toggle the mode-selector menu (Goal 2 — pick the
-                    # opponent: Human, Random AI as Black/White, ...). The
-                    # mainloop pauses AI play while the menu is open so the
-                    # user can finish selecting.
+                    # M: toggle the mode-selector menu. Opening it from
+                    # the PGN dialog closes the dialog (the user-spec'd
+                    # transition between the two paused states); the
+                    # Game.open_mode_menu helper handles that.
                     if event.key == pygame.K_m:
                         if game.mode_menu is None:
                             game.open_mode_menu()
@@ -725,16 +756,37 @@ class Main:
                             game.close_mode_menu()
                         continue
 
-                    # U: undo the most recent completed turn. Disallowed
-                    # mid-action (jump-capture pending, transform/promotion
-                    # menu open) — Game.can_undo enforces the guard.
+                    # P: toggle the PGN/FEN save-load dialog (also the
+                    # paused-game screen for undo/redo in CvC). Opening
+                    # from the mode menu closes the mode menu via
+                    # Game.open_pgn_dialog's mutual-exclusion guard.
+                    if event.key == pygame.K_p:
+                        if game.pgn_dialog_open:
+                            game.close_pgn_dialog()
+                        else:
+                            game.open_pgn_dialog()
+                        continue
+
+                    # U: undo. In CvC, AUTO-OPEN the PGN/pause dialog
+                    # first so the autoplay halts cleanly and the user
+                    # can see what state they undid to before resuming.
+                    # (User spec: "make a paused game screen when undo/
+                    # redo is pressed so that the undo/redo can be done
+                    # without interfering with computer vs computer".)
+                    # In HvH / HvAI the existing direct-undo behaviour
+                    # is preserved.
                     if event.key == pygame.K_u:
+                        if (game.mode == 'computer_vs_computer'
+                                and not game.pgn_dialog_open):
+                            game.open_pgn_dialog()
                         game.undo()
                         continue
 
-                    # Y: redo a previously-undone turn. Same intermediate-
-                    # state guard as undo.
+                    # Y: redo. Same CvC auto-pause as undo above.
                     if event.key == pygame.K_y:
+                        if (game.mode == 'computer_vs_computer'
+                                and not game.pgn_dialog_open):
+                            game.open_pgn_dialog()
                         game.redo()
                         continue
 

--- a/tests/test_gdl_step1.py
+++ b/tests/test_gdl_step1.py
@@ -1,0 +1,229 @@
+"""Structural tests for the Goal-4 GDL step-1 fragment
+(`docs/gdl/step1_kings_queens.gdl`).
+
+We don't have a GDL reasoner wired into the test harness yet (that's a
+later sub-step of Goal 4 — see docs/goal4_gdl_ggp_planning.md). What
+this test file does provide is a small S-expression parser plus a set
+of structural invariants that any valid GDL-I fragment for this game
+must satisfy:
+
+  - Two players are declared (`(role white)`, `(role black)`).
+  - Initial facts place each side's king and base-form royal queen on
+    the correct starting squares (per RULEBOOK_v2.md: White K g1, Q b1;
+    Black K b8, Q g8 — rotationally symmetric setup).
+  - White moves first (`(init (control white))`).
+  - There are at least four `legal` clauses (the four directions a
+    piece can move are present in some form).
+  - There is a `terminal` predicate and the `goal` clauses sum to a
+    win/draw structure (one side 100 / other 0 in a decisive end).
+  - The spec is parseable as balanced S-expressions and contains only
+    keywords from the GDL-I core grammar.
+
+These checks catch the kinds of bugs you get from hand-editing a GDL
+file (unbalanced parens, missing role declaration, wrong starting
+square). They do NOT verify legal-move equivalence with the Python
+engine — that's a later step requiring a GDL reasoner.
+"""
+
+import os
+import re
+import pytest
+
+
+GDL_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'docs', 'gdl', 'step1_kings_queens.gdl')
+
+
+def _strip_comments(text):
+    """Remove ';' line comments (GDL/Prolog style)."""
+    out = []
+    for line in text.splitlines():
+        idx = line.find(';')
+        if idx >= 0:
+            line = line[:idx]
+        out.append(line)
+    return '\n'.join(out)
+
+
+def _tokenize(text):
+    """Tokenize parens + atoms. Atoms are non-whitespace, non-paren runs."""
+    tokens = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in '()':
+            tokens.append(ch)
+            i += 1
+            continue
+        # atom
+        j = i
+        while j < len(text) and not text[j].isspace() and text[j] not in '()':
+            j += 1
+        tokens.append(text[i:j])
+        i = j
+    return tokens
+
+
+def _parse_all(tokens):
+    """Parse a stream of S-expressions; return a list of trees.
+    Each tree is either a string (atom) or a tuple of trees."""
+    pos = [0]
+
+    def parse_one():
+        if pos[0] >= len(tokens):
+            raise ValueError('unexpected EOF')
+        tok = tokens[pos[0]]
+        if tok == '(':
+            pos[0] += 1
+            items = []
+            while pos[0] < len(tokens) and tokens[pos[0]] != ')':
+                items.append(parse_one())
+            if pos[0] >= len(tokens):
+                raise ValueError('unbalanced paren (no closing)')
+            pos[0] += 1  # skip )
+            return tuple(items)
+        if tok == ')':
+            raise ValueError('unexpected )')
+        pos[0] += 1
+        return tok
+
+    forms = []
+    while pos[0] < len(tokens):
+        forms.append(parse_one())
+    return forms
+
+
+@pytest.fixture(scope='module')
+def parsed():
+    assert os.path.exists(GDL_PATH), \
+        f"GDL fragment missing at {GDL_PATH}"
+    with open(GDL_PATH) as f:
+        text = f.read()
+    return _parse_all(_tokenize(_strip_comments(text)))
+
+
+# ---- structural checks ----------------------------------------------------
+
+def test_file_parses_as_balanced_s_expressions(parsed):
+    # If _parse_all returned without raising, the parens are balanced.
+    assert len(parsed) > 0
+
+
+def test_both_roles_declared(parsed):
+    roles = {f[1] for f in parsed
+             if isinstance(f, tuple) and len(f) == 2 and f[0] == 'role'}
+    assert roles == {'white', 'black'}, \
+        f"expected roles white+black, got {roles}"
+
+
+def test_white_moves_first(parsed):
+    """White moves first via (init (control white))."""
+    has_control_white_init = any(
+        isinstance(f, tuple) and len(f) == 2 and f[0] == 'init'
+        and isinstance(f[1], tuple) and f[1] == ('control', 'white')
+        for f in parsed)
+    assert has_control_white_init, \
+        "missing (init (control white)) — white must move first"
+
+
+def test_initial_king_squares_match_rulebook(parsed):
+    """Per RULEBOOK_v2.md back rank: White king g1, Black king b8."""
+    init_pieces = [
+        f[1] for f in parsed
+        if isinstance(f, tuple) and len(f) == 2 and f[0] == 'init'
+        and isinstance(f[1], tuple) and f[1][0] == 'cell'
+    ]
+    # cell facts: (cell <file> <rank> <color> <piece>)
+    pieces = {(p[1], p[2]): (p[3], p[4]) for p in init_pieces
+              if len(p) == 5}
+    assert pieces.get(('g', '1')) == ('white', 'king'), \
+        f"expected white king at g1; got {pieces.get(('g', '1'))}"
+    assert pieces.get(('b', '8')) == ('black', 'king'), \
+        f"expected black king at b8; got {pieces.get(('b', '8'))}"
+
+
+def test_initial_queen_squares_match_rulebook(parsed):
+    """White royal queen b1, Black royal queen g8 (rotational symmetry)."""
+    init_pieces = [
+        f[1] for f in parsed
+        if isinstance(f, tuple) and len(f) == 2 and f[0] == 'init'
+        and isinstance(f[1], tuple) and f[1][0] == 'cell'
+    ]
+    pieces = {(p[1], p[2]): (p[3], p[4]) for p in init_pieces
+              if len(p) == 5}
+    assert pieces.get(('b', '1')) == ('white', 'queen'), \
+        f"expected white queen at b1; got {pieces.get(('b', '1'))}"
+    assert pieces.get(('g', '8')) == ('white', 'queen') or \
+        pieces.get(('g', '8')) == ('black', 'queen'), \
+        f"expected black queen at g8; got {pieces.get(('g', '8'))}"
+
+
+def test_no_extra_initial_pieces_for_step1(parsed):
+    """Step 1 fragment is kings + queens only; no pawns / rooks /
+    bishops / knights / boulder."""
+    init_pieces = [
+        f[1] for f in parsed
+        if isinstance(f, tuple) and len(f) == 2 and f[0] == 'init'
+        and isinstance(f[1], tuple) and f[1][0] == 'cell'
+    ]
+    piece_types = {p[4] for p in init_pieces if len(p) == 5}
+    allowed = {'king', 'queen'}
+    extras = piece_types - allowed
+    assert not extras, \
+        f"step-1 fragment contains forbidden piece types {extras}; " \
+        f"this is the kings+base-queens subset."
+
+
+def test_has_legal_clauses(parsed):
+    """At least one (<= (legal ...) ...) rule exists per role."""
+    legal_heads = []
+    for f in parsed:
+        # (<= head body...) form
+        if (isinstance(f, tuple) and len(f) >= 2 and f[0] == '<='
+                and isinstance(f[1], tuple) and len(f[1]) >= 2
+                and f[1][0] == 'legal'):
+            legal_heads.append(f[1])
+    assert len(legal_heads) > 0, "no (<= (legal ...) ...) rules found"
+    # At least one for each colour SHOULD exist (either via explicit
+    # white/black branches or via a generic ?player variable).
+    seen_white = any('white' in str(h) or '?player' in str(h)
+                     for h in legal_heads)
+    seen_black = any('black' in str(h) or '?player' in str(h)
+                     for h in legal_heads)
+    assert seen_white and seen_black, \
+        "legal clauses must cover both colours (white/black or ?player)"
+
+
+def test_has_terminal_and_goal_clauses(parsed):
+    """(<= terminal ...) and (<= (goal ?role ?n) ...) must exist.
+    GDL-I convention: `terminal` is a 0-ary predicate written as a
+    bare atom in the rule head (not (terminal))."""
+    has_terminal = False
+    has_goal = False
+    for f in parsed:
+        if isinstance(f, tuple) and len(f) >= 2 and f[0] == '<=':
+            head = f[1]
+            # Accept bare 'terminal' atom OR (terminal) form.
+            if head == 'terminal':
+                has_terminal = True
+            if isinstance(head, tuple) and head and head[0] == 'terminal':
+                has_terminal = True
+            if isinstance(head, tuple) and head and head[0] == 'goal':
+                has_goal = True
+    assert has_terminal, "no (<= terminal ...) rule found"
+    assert has_goal, "no (<= (goal ...) ...) rule found"
+
+
+def test_only_known_gdl_keywords_at_top_level(parsed):
+    """Each top-level form must start with a known GDL-I keyword.
+    Catches typos like (rolw white) or (initt ...)."""
+    known = {'role', 'init', '<=', 'base', 'input'}  # base/input optional
+    for f in parsed:
+        if not isinstance(f, tuple) or not f:
+            raise AssertionError(f"odd top-level form: {f}")
+        head = f[0]
+        assert head in known, \
+            f"unknown top-level keyword {head!r} (forms: {known})"

--- a/tests/test_pause_and_pgn.py
+++ b/tests/test_pause_and_pgn.py
@@ -1,0 +1,588 @@
+"""Tests for the pause-screen + PGN/FEN serialize/load dialog.
+
+The dialog has TWO roles, intentionally unified per user spec:
+
+  1. A *paused-game screen* that lets the user undo/redo without
+     interfering with CvC autoplay. Opening the dialog halts the AI
+     loop; closing the dialog resumes it.
+  2. A *PGN/FEN-style save/load dialog* showing the serialized game
+     state (with a Copy button) and a Paste/Load control to restore
+     a previously-saved state.
+
+Single key (P) opens it. Undo/redo are gated on the dialog being open
+in CvC (otherwise they race the autoplay).
+
+State-machine rules tested below:
+
+  - The dialog open flag participates in `is_any_menu_open()` so it
+    blocks AI dispatch and other interactions uniformly.
+  - Opening the mode menu while the dialog is open CLOSES the dialog
+    and OPENS the mode menu (and vice-versa). They are both
+    paused-game states; only one is on screen at a time.
+  - Reset-confirm can be activated FROM the dialog (R press), and
+    the reset-confirm overlay takes precedence visually but the
+    dialog state survives a cancelled reset.
+  - Theme (T) and flip (F) work regardless of which paused state is
+    on screen (viewing preferences never interfere).
+  - All other keys (M / U / Y / R / P) have well-defined transitions.
+
+Serialization round-trip rules:
+
+  - serialize_to_text -> deserialize -> identical game (same board,
+    same next_player, same winner, same undo/redo history, same per-
+    side player choices, same _perspective_side).
+  - Round-trip preserves boulder cooldown + no-return memory, knight
+    invulnerability, manipulation freeze, repetition state-history
+    counts, and tiny-endgame distance counts (all stored on the
+    Board / its substructures).
+  - Round-trip works in HvH, HvAI, and CvC modes.
+  - Bad / truncated / wrong-version text raises a clean error
+    (ValueError or similar) and leaves the existing game untouched.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import copy
+import random
+import pytest
+
+from game import Game
+from ai_controller import AIController
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+    try:
+        if not pygame.mixer.get_init():
+            pygame.mixer.init()
+    except pygame.error:
+        pass
+
+
+# ===========================================================================
+# Section 1 — pause-dialog state machine
+# ===========================================================================
+
+def test_pgn_dialog_default_closed():
+    """Fresh game: no paused dialog open."""
+    g = Game()
+    assert g.pgn_dialog_open is False
+
+
+def test_open_close_pgn_dialog():
+    g = Game()
+    g.open_pgn_dialog()
+    assert g.pgn_dialog_open is True
+    g.close_pgn_dialog()
+    assert g.pgn_dialog_open is False
+
+
+def test_open_pgn_dialog_is_idempotent():
+    """Opening twice in a row is fine — second call is a no-op."""
+    g = Game()
+    g.open_pgn_dialog()
+    g.open_pgn_dialog()
+    assert g.pgn_dialog_open is True
+
+
+def test_close_pgn_dialog_is_idempotent():
+    """Closing when already closed is fine."""
+    g = Game()
+    g.close_pgn_dialog()
+    assert g.pgn_dialog_open is False
+
+
+def test_is_any_menu_open_includes_pgn_dialog():
+    """The dialog blocks all input + AI dispatch via is_any_menu_open,
+    same as mode_menu / transform_menu / promotion_menu / reset_confirm."""
+    g = Game()
+    assert g.is_any_menu_open() is False
+    g.open_pgn_dialog()
+    assert g.is_any_menu_open() is True
+    g.close_pgn_dialog()
+    assert g.is_any_menu_open() is False
+
+
+def test_is_autoplay_paused_true_when_dialog_open():
+    """is_autoplay_paused is the question main.py asks before dispatching
+    a CvC AI turn. The pgn dialog must answer True."""
+    g = Game()
+    assert g.is_autoplay_paused() is False
+    g.open_pgn_dialog()
+    assert g.is_autoplay_paused() is True
+
+
+def test_is_autoplay_paused_true_when_mode_menu_open():
+    g = Game()
+    g.open_mode_menu()
+    assert g.is_autoplay_paused() is True
+
+
+def test_is_autoplay_paused_true_when_reset_confirm_pending():
+    g = Game()
+    g.reset_confirm_pending = True
+    assert g.is_autoplay_paused() is True
+
+
+# ---- mutual exclusion between mode menu and pgn dialog ---------------------
+
+def test_open_mode_menu_closes_pgn_dialog():
+    """User spec: 'mode menu should be able to be opened during pause
+    (which will close the pause screen and open the mode menu)'."""
+    g = Game()
+    g.open_pgn_dialog()
+    g.open_mode_menu()
+    assert g.mode_menu is not None
+    assert g.pgn_dialog_open is False
+
+
+def test_open_pgn_dialog_closes_mode_menu():
+    """Symmetric: opening the pgn dialog while mode menu is up closes
+    the mode menu."""
+    g = Game()
+    g.open_mode_menu()
+    g.open_pgn_dialog()
+    assert g.pgn_dialog_open is True
+    assert g.mode_menu is None
+
+
+def test_close_mode_menu_does_not_reopen_pgn_dialog():
+    """When the user has switched mode menu -> pgn dialog -> mode menu,
+    closing the mode menu must NOT auto-reopen the pgn dialog. The two
+    are independent paused states."""
+    g = Game()
+    g.open_pgn_dialog()
+    g.open_mode_menu()      # closes pgn
+    g.close_mode_menu()
+    assert g.pgn_dialog_open is False
+    assert g.mode_menu is None
+
+
+# ---- reset-confirm interaction --------------------------------------------
+
+def test_reset_confirm_can_be_triggered_while_dialog_open():
+    """The user spec allows 'R' to work during pause. We model this as:
+    the dialog stays open and the reset-confirm flag also goes up.
+    Both contribute to is_any_menu_open (still paused)."""
+    g = Game()
+    g.open_pgn_dialog()
+    g.reset_confirm_pending = True
+    assert g.is_any_menu_open() is True
+    # The dialog flag is unchanged — the reset-confirm overlay renders
+    # on top; main.py renders both, the confirm overlay covers the
+    # dialog visually.
+    assert g.pgn_dialog_open is True
+    assert g.reset_confirm_pending is True
+
+
+def test_reset_clears_pgn_dialog_flag():
+    """A full reset() reinitializes the game; the pgn dialog flag
+    starts False on the new state."""
+    g = Game()
+    g.open_pgn_dialog()
+    g.reset()
+    assert g.pgn_dialog_open is False
+
+
+# ---- dialog rendering ------------------------------------------------------
+
+def test_show_pgn_dialog_noop_when_closed():
+    """Closed dialog leaves the surface untouched."""
+    g = Game()
+    surface = pygame.Surface((400, 400))
+    surface.fill((10, 20, 30))
+    g.show_pgn_dialog(surface)
+    assert surface.get_at((200, 200))[:3] == (10, 20, 30)
+
+
+def test_show_pgn_dialog_draws_when_open():
+    g = Game()
+    g.open_pgn_dialog()
+    surface = pygame.Surface((600, 600))
+    surface.fill((10, 20, 30))
+    g.show_pgn_dialog(surface)
+    # Centre pixel should differ from background after the dialog draws.
+    assert surface.get_at((300, 300))[:3] != (10, 20, 30)
+
+
+def test_show_pgn_dialog_populates_button_rects():
+    """The dialog needs click rects for the Copy and Load buttons,
+    populated each render for main.py's MOUSEBUTTONDOWN dispatch."""
+    g = Game()
+    g.open_pgn_dialog()
+    surface = pygame.Surface((800, 800))
+    g.show_pgn_dialog(surface)
+    assert g.pgn_dialog_copy_rect is not None
+    assert g.pgn_dialog_load_rect is not None
+    assert isinstance(g.pgn_dialog_copy_rect, pygame.Rect)
+    assert isinstance(g.pgn_dialog_load_rect, pygame.Rect)
+
+
+def test_show_pgn_dialog_clears_rects_when_closed():
+    g = Game()
+    g.open_pgn_dialog()
+    surface = pygame.Surface((800, 800))
+    g.show_pgn_dialog(surface)
+    g.close_pgn_dialog()
+    g.show_pgn_dialog(surface)  # no-op
+    assert g.pgn_dialog_copy_rect is None
+    assert g.pgn_dialog_load_rect is None
+
+
+# ===========================================================================
+# Section 2 — serialize / deserialize (PGN/FEN-like text)
+# ===========================================================================
+
+def test_serialize_returns_a_non_empty_string():
+    g = Game()
+    text = g.serialize_to_text()
+    assert isinstance(text, str)
+    assert len(text) > 0
+
+
+def test_serialized_text_carries_a_recognizable_header():
+    """Human-readable header so the user can recognise it when pasted
+    in another window. Format details internal — just check a marker."""
+    g = Game()
+    text = g.serialize_to_text()
+    # Some sort of variant marker so loaders can detect wrong-format pastes.
+    assert 'VARIANT_SAVE' in text or 'variant' in text.lower()
+
+
+def test_serialized_text_includes_mode_and_turn_info():
+    """The header is human-readable; mode + current turn should be visible."""
+    g = Game()
+    g.apply_mode_selection(opponent='random')
+    text = g.serialize_to_text()
+    assert 'human_vs_random' in text or 'random' in text.lower()
+
+
+def test_round_trip_initial_game_preserves_board_and_turn():
+    g = Game()
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.next_player == g.next_player
+    assert g2.board.turn_number == g.board.turn_number
+    assert g2.winner == g.winner
+
+
+def test_round_trip_preserves_per_side_player_choices_hvh():
+    g = Game()
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.white_player == 'human'
+    assert g2.black_player == 'human'
+    assert g2.mode == 'human_vs_human'
+
+
+def test_round_trip_preserves_per_side_player_choices_hvai():
+    g = Game()
+    g.apply_mode_selection(opponent='random')   # AI = black
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.white_player == 'human'
+    assert g2.black_player == 'random'
+    assert g2.mode == 'human_vs_random'
+    assert g2.ai_color == 'black'
+
+
+def test_round_trip_preserves_cvc_mode():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.white_player == 'random'
+    assert g2.black_player == 'random'
+    assert g2.mode == 'computer_vs_computer'
+    assert g2.ai_controllers['white'] is not None
+    assert g2.ai_controllers['black'] is not None
+
+
+def test_round_trip_preserves_perspective_side_in_hvh():
+    g = Game()
+    g.apply_mode_selection(side='black')   # legacy: human plays black in HvH
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.user_side == 'black'
+    assert g2._perspective_side == 'black'
+
+
+def _take_random_turn(g):
+    """Drive one turn via a helper AIController (the simplest way to
+    apply a legal turn in tests)."""
+    helper = AIController(g.next_player)
+    helper.take_turn(g)
+
+
+def test_round_trip_after_a_few_turns_preserves_board_state():
+    random.seed(331)
+    g = Game()
+    for _ in range(4):
+        _take_random_turn(g)
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    # Board state hash equality is the strongest check for "same position".
+    assert g2.board.get_state_hash(g2.next_player) == \
+        g.board.get_state_hash(g.next_player)
+    assert g2.board.turn_number == g.board.turn_number
+
+
+def test_round_trip_preserves_undo_redo_history():
+    """A loaded game must support undo to the same depth as the original."""
+    random.seed(337)
+    g = Game()
+    for _ in range(5):
+        _take_random_turn(g)
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    # Both should report the same can_undo depth.
+    assert g2.can_undo() == g.can_undo()
+    # Undo on the loaded game should land on the same turn_number as
+    # undo on the original.
+    g.undo()
+    g2.undo()
+    assert g2.board.turn_number == g.board.turn_number
+    assert g2.next_player == g.next_player
+
+
+def test_round_trip_preserves_redo_stack_after_undo():
+    random.seed(347)
+    g = Game()
+    for _ in range(4):
+        _take_random_turn(g)
+    g.undo()
+    g.undo()
+    assert g.can_redo() is True
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.can_redo() == g.can_redo()
+    g.redo()
+    g2.redo()
+    assert g2.board.turn_number == g.board.turn_number
+
+
+def test_load_from_text_replaces_current_game_state_in_place():
+    """load_from_text mutates the existing game in place so callers
+    holding references (main.py's `board`, `dragger`) stay valid.
+    Returns True on success."""
+    random.seed(353)
+    g_source = Game()
+    for _ in range(3):
+        _take_random_turn(g_source)
+    text = g_source.serialize_to_text()
+
+    g = Game()
+    original_board_id = id(g.board)
+    ok = g.load_from_text(text)
+    assert ok is True
+    # board object identity preserved (in-place mutation).
+    assert id(g.board) == original_board_id
+    # state matches source
+    assert g.board.turn_number == g_source.board.turn_number
+    assert g.next_player == g_source.next_player
+
+
+def test_load_from_text_returns_false_on_garbage_input():
+    g = Game()
+    ok = g.load_from_text('not a real save file')
+    assert ok is False
+    # Game state untouched.
+    assert g.board.turn_number == 0
+
+
+def test_load_from_text_returns_false_on_empty_input():
+    g = Game()
+    ok = g.load_from_text('')
+    assert ok is False
+
+
+def test_deserialize_from_text_raises_on_garbage():
+    with pytest.raises(Exception):
+        Game.deserialize_from_text('not a save')
+
+
+def test_round_trip_preserves_winner_state():
+    """Winner string is preserved across round-trip."""
+    g = Game()
+    g.winner = 'white'
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.winner == 'white'
+
+
+# ===========================================================================
+# Section 3 — clipboard interaction (via mockable provider)
+# ===========================================================================
+
+def test_clipboard_provider_can_be_monkeypatched(monkeypatch):
+    """The dialog's Copy button calls Game._copy_to_clipboard; that
+    helper must be overridable for tests."""
+    captured = {}
+    def fake_copy(text):
+        captured['text'] = text
+        return True
+    monkeypatch.setattr(Game, '_copy_to_clipboard', staticmethod(fake_copy))
+    g = Game()
+    ok = Game._copy_to_clipboard(g.serialize_to_text())
+    assert ok is True
+    assert 'text' in captured
+    assert len(captured['text']) > 0
+
+
+def test_read_clipboard_can_be_monkeypatched(monkeypatch):
+    """Symmetric for the Load button: Game._read_clipboard is the
+    indirection."""
+    monkeypatch.setattr(
+        Game, '_read_clipboard', staticmethod(lambda: 'paste-result'))
+    assert Game._read_clipboard() == 'paste-result'
+
+
+def test_copy_action_emits_serialized_text(monkeypatch):
+    """Wrapping behavior: Game.copy_to_clipboard_action serializes the
+    current game and pushes it to the clipboard provider, returning
+    True on success."""
+    captured = {}
+    def fake_copy(text):
+        captured['text'] = text
+        return True
+    monkeypatch.setattr(Game, '_copy_to_clipboard', staticmethod(fake_copy))
+    g = Game()
+    ok = g.copy_to_clipboard_action()
+    assert ok is True
+    # The text pushed was a serialization that the same game can read back.
+    g2 = Game.deserialize_from_text(captured['text'])
+    assert g2.next_player == g.next_player
+
+
+def test_load_action_reads_from_clipboard_and_loads(monkeypatch):
+    """Game.load_from_clipboard_action calls _read_clipboard and feeds
+    the text to load_from_text. Returns True on success."""
+    random.seed(361)
+    g_source = Game()
+    for _ in range(3):
+        _take_random_turn(g_source)
+    serialized = g_source.serialize_to_text()
+    monkeypatch.setattr(
+        Game, '_read_clipboard', staticmethod(lambda: serialized))
+    g = Game()
+    ok = g.load_from_clipboard_action()
+    assert ok is True
+    assert g.board.turn_number == g_source.board.turn_number
+
+
+def test_load_action_returns_false_on_empty_clipboard(monkeypatch):
+    monkeypatch.setattr(Game, '_read_clipboard', staticmethod(lambda: None))
+    g = Game()
+    ok = g.load_from_clipboard_action()
+    assert ok is False
+
+
+def test_load_action_returns_false_on_bad_clipboard_content(monkeypatch):
+    monkeypatch.setattr(
+        Game, '_read_clipboard', staticmethod(lambda: 'not a save'))
+    g = Game()
+    ok = g.load_from_clipboard_action()
+    assert ok is False
+    # Game state untouched.
+    assert g.board.turn_number == 0
+
+
+# ===========================================================================
+# Section 4 — undo/redo in CvC require the dialog to be open
+# ===========================================================================
+
+def test_cvc_undo_works_when_dialog_open():
+    """In CvC, the user pauses (opens dialog), then undoes. The dialog-
+    open state must NOT block undo — the user explicitly opened the
+    dialog FOR the undo."""
+    random.seed(367)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    # advance a few turns via the per-side controllers
+    for _ in range(3):
+        g.current_ai_controller().take_turn(g)
+    assert g.board.turn_number == 3
+    g.open_pgn_dialog()
+    # can_undo's intermediate-state guard excludes the dialog
+    # (otherwise undo would never work from the paused state).
+    assert g.can_undo() is True
+    assert g.undo() is True
+    assert g.board.turn_number == 2
+
+
+def test_cvc_redo_works_when_dialog_open():
+    random.seed(373)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    for _ in range(4):
+        g.current_ai_controller().take_turn(g)
+    g.undo()
+    assert g.board.turn_number == 3
+    g.open_pgn_dialog()
+    assert g.can_redo() is True
+    assert g.redo() is True
+    assert g.board.turn_number == 4
+
+
+# ===========================================================================
+# Section 5 — robustness sanity checks
+# ===========================================================================
+
+def test_serialized_text_format_is_stable_across_two_calls():
+    """Same game serialized twice in a row should produce the same text
+    (deterministic encoding — no random salting, no timestamps in the
+    encoded payload)."""
+    g = Game()
+    a = g.serialize_to_text()
+    b = g.serialize_to_text()
+    assert a == b
+
+
+def test_load_into_running_cvc_game_takes_effect_immediately():
+    """A loaded game's mode is honoured by current_ai_controller right
+    after load (no manual _refresh_ai call required)."""
+    g_source = Game()
+    g_source.apply_mode_selection(
+        white_player='random', black_player='random')
+    text = g_source.serialize_to_text()
+
+    g = Game()
+    g.load_from_text(text)
+    assert g.current_ai_controller() is not None
+    assert g.current_ai_controller().color == 'white'
+
+
+def test_loading_a_finished_game_preserves_winner():
+    g_source = Game()
+    g_source.winner = 'black'
+    text = g_source.serialize_to_text()
+    g = Game()
+    g.load_from_text(text)
+    assert g.winner == 'black'
+
+
+def test_dialog_open_flag_is_not_persisted_in_save():
+    """Save the game with the dialog open; loaded game should NOT come
+    back with the dialog open (UI state isn't part of the game state)."""
+    g = Game()
+    g.open_pgn_dialog()
+    text = g.serialize_to_text()
+    g2 = Game.deserialize_from_text(text)
+    assert g2.pgn_dialog_open is False


### PR DESCRIPTION
## Summary
- **Paused-game + PGN/FEN save-load dialog** (unified per user spec): one key (P) opens a dialog that simultaneously pauses CvC autoplay AND shows the serialized game state. Copy button copies to clipboard; Load button restores from clipboard. Mutual exclusion with the mode menu (opening either auto-closes the other). U/Y in CvC auto-open the dialog before undo/redo so autoplay halts cleanly. T/F always available. R from any paused state opens reset-confirm.
- **Save format**: human-readable header + base64-encoded pickle payload between `___VARIANT_SAVE_V1_BEGIN___` / `_END___` markers. Round-trips the full game (board, mode, history stack, redo stack, perspective side) perfectly across HvH/HvAI/CvC.
- **Goal 4 step 1**: first GDL-I fragment — kings + base-form royal queens only, at the rulebook-correct starting squares. Tests structurally validate the file (parens balanced, roles declared, white moves first, correct squares, no extra piece types, legal/terminal/goal rules present, only known keywords). Defaults taken in the absence of explicit user direction: dialect = GDL-I (matches the recognised "GGP" framing for ISEF); reasoner integration deferred until a toolchain pick.

## Test plan
- [x] tests/test_pause_and_pgn.py — 45 new tests covering dialog state machine, mutual exclusion, serialization round-trip (HvH/HvAI/CvC, perspective side, undo/redo history, winner), error handling, clipboard via monkeypatched provider, CvC undo/redo while dialog open — all pass
- [x] tests/test_gdl_step1.py — 8 structural invariants on the GDL fragment — all pass
- [x] Full focused suite — 133 tests across 6 files all pass
- [ ] Manual CvC test: launch main.py, open mode menu (M), pick Random for both sides, watch autoplay; press P during play — autoplay halts and dialog appears; press U several times — game rewinds; press M — dialog closes and mode menu opens; press T / F at any time — theme/flip works

🤖 Generated with [Claude Code](https://claude.com/claude-code)