### PR TITLE
Fix CvC key dispatch; revert undo/redo auto-open; clarify boulder same-colour pawn capture

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -42,7 +42,7 @@ A turn includes legal boulder moves (either player may move the boulder).
 
 - **First move:** the boulder's first move must be to one of the four central squares (d4, d5, e4, e5). White may not move the boulder on their first turn.
 - **Subsequent moves:** like a king (one square in any direction).
-- **Capture rules:** the boulder may capture pawns only; only a king may capture the boulder.
+- **Capture rules:** the boulder may capture pawns only — of EITHER colour, including the moving player's own pawns (the boulder is neutral, so no same-colour-capture restriction applies). Only a king may capture the boulder.
 - **Neutral status:** the boulder is treated as a friendly piece by both sides for most purposes.
 - **Central intersection:** when on the central intersection, the boulder blocks diagonal lines only — not files or ranks.
 - **Cooldown:** after the boulder moves, both players must make one turn before the boulder may move again.

--- a/docs/RULEBOOK_v2_elaborated.md
+++ b/docs/RULEBOOK_v2_elaborated.md
@@ -77,9 +77,18 @@ Afterward it moves like a **king**.
 
 ### **Capture Rules**
 
-* The boulder may capture **pawns only**.
+* The boulder may capture **pawns only** — of **either colour**, including the moving player's own pawns.
 
 * Only a **king** may capture the boulder.
+
+#### **Why same-colour pawn capture is allowed**
+
+The boulder is **neutral**: it is owned by neither player. Two things follow from that:
+
+1. The standard "no same-colour capture" rule (only the king may capture friendly pieces) applies to **owned** pieces capturing pieces of their owner's colour. A neutral piece has no owner, so there is no "same colour" to violate. The boulder's restriction is purely "captures pawns only" — no colour qualifier.
+2. The "boulder is treated as a friendly piece by both sides for most purposes" clause (below, in *Neutral Status*) governs how **other** pieces treat the boulder — e.g., a knight may earn invulnerability by jumping over the boulder, neither player may manipulate the boulder, the boulder counts as friendly for blocking-passage purposes, etc. It does **not** restrict the boulder's own capture rules.
+
+Strategically, the player to move may use a boulder turn to capture a pawn of *either* colour. Capturing an enemy pawn is straightforwardly material gain. Capturing one of your own pawns is a sacrifice and is rarely useful, but the rule allows it — and there are occasional positional uses (clearing a key square that an opponent could otherwise block; removing a pawn that the opponent could otherwise manipulate to your detriment; eliminating a pawn that would soon promote in a position where the resulting queen would lose to a known refutation). The rule simply permits it; it does not encourage or compel it.
 
 ### **Neutral Status**
 

--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -486,3 +486,52 @@ Tests: `tests/test_gdl_step4.py` (13 structural assertions). All pass.
 
 ### Branch
 `claude/clipboard-fix-gdl-step4` (this branch).
+
+## UPDATE (2026-05-30, very late — CvC key dispatch + undo gating revert + boulder rule clarification)
+
+### Training progress at this update
+- **iter 68/75 still**. Same as previous update.
+
+### CvC key dispatch fix
+User reported: "in computer vs computer mode, all the key presses are disabled."
+
+Root cause: main.py's autoplay-wait loop (the 600 ms pre-AI-move pause) only handled `pygame.QUIT` and silently dropped all KEYDOWN events. So during CvC autoplay, the user could press M/P/T/F/U/Y/R and nothing would happen.
+
+Fix in `src/main.py`: extended the wait loop to also dispatch KEYDOWN events through `Game.handle_keydown(event.key)`. If a paused state opens as a result (the user pressed M or P), break out of the wait so we don't immediately take_turn over the user's request.
+
+The fix is small (~10 lines in the wait loop) and relies on `Game.handle_keydown` being correct (which has 32+ existing tests).
+
+### Undo/redo gating change — auto-open-dialog REVERTED
+User spec: "Instead of making undo/redo open the pause menu, disable undo/redo during computer vs computer mode and only enable it during the pause screen, mode menu, or reset confirmation screen."
+
+`_handle_undo_key` and `_handle_redo_key` updated:
+- In CvC + no paused state → U/Y are NO-OPs (do nothing, do NOT auto-open dialog).
+- In CvC + any paused state (pgn dialog / mode menu / reset confirm) → undo/redo work normally.
+- In HvH / HvAI → undo/redo always work (unchanged).
+
+The "auto-open dialog on U" behavior I added back at PR #92 is reverted. The new rule is more conservative and more consistent with the user's mental model: paused states are explicitly user-initiated, and once one is open, undo/redo are available there.
+
+Tests in `tests/test_cvc_keys_and_undo_gating.py` (15 new): T/F/M/P/R all work during CvC (autoplay-paused becomes True for M/P/R); U/Y are no-ops in CvC + no paused state; U/Y work in CvC + any of the 3 paused states; HvH and HvAI undo/redo unchanged. Older tests in `test_game_keydown_dispatch.py` updated to match the new spec (the previous "U auto-opens dialog in CvC" tests flipped to "U is no-op in CvC + no paused state").
+
+### Boulder rule clarification: same-colour pawn capture is LEGAL
+User asked: "should the boulder be able to capture pawns that are the same color as the player to move?"
+
+Engine inspection (`src/board.py` boulder_moves, ~line 2150): the only filter is `isinstance(target.piece, Pawn)` — NO colour check. So the engine ALREADY allows same-colour pawn capture by the boulder.
+
+Decision: **YES, this is the correct behaviour.** Rationale:
+- The boulder is neutral (color = 'none'). The "no same-colour capture" rule (only king captures friendlies) applies to OWNED pieces; the boulder has no owner, so there's no "same colour" to violate.
+- The "boulder treated as friendly by both sides for most purposes" clause governs how OTHER pieces treat the boulder (invuln support, manipulation eligibility), NOT how the boulder itself captures.
+- The boulder's rule simply says "captures pawns only" — no colour qualifier.
+
+Strategic: capturing your own pawn via boulder is rarely useful (it's a sacrifice) but occasionally a positional tool (clear a key square, dispose of a pawn the opponent could manipulate, etc.). The rule permits but does not encourage it.
+
+**Rulebook updates:**
+- `RULEBOOK_v2.md` (concise): updated the boulder's Capture rules line to mention "of EITHER colour, including the moving player's own pawns".
+- `docs/RULEBOOK_v2_elaborated.md`: added a "Why same-colour pawn capture is allowed" subsection explaining the neutrality reasoning + strategic note.
+
+**Tests in `tests/test_boulder_captures_friendly_pawn.py` (5 new):** boulder captures same-colour pawn / opposite-colour pawn / cannot capture non-pawn / both-colour test from same boulder position / capture-return-to-no-return-square works for same-colour pawn. All pass (engine already correct).
+
+### Total focused test count: 298 across 15 files (298 pass).
+
+### Branch
+`claude/cvc-keys-boulder-rule` (this branch).

--- a/src/game.py
+++ b/src/game.py
@@ -1426,19 +1426,24 @@ class Game:
         self.reset_confirm_pending = True
 
     def _handle_undo_key(self):
-        """U: undo. In CvC, auto-open the PGN dialog first so the
-        autoplay halts cleanly (per user spec)."""
+        """U: undo.
+
+        2026-05-30 user spec change: in CvC mode, undo is DISABLED
+        unless a paused state is open (pgn dialog, mode menu, or
+        reset confirm). The previous "auto-open the dialog on U"
+        behaviour is reverted — the user must explicitly open a
+        paused state first. In HvH / HvAI undo always works.
+        """
         if (self.mode == 'computer_vs_computer'
-                and not self.pgn_dialog_open
-                and self.mode_menu is None):
-            self.open_pgn_dialog()
+                and not self.is_autoplay_paused()):
+            return  # CvC + no paused state -> U is a no-op
         self.undo()
 
     def _handle_redo_key(self):
+        """Y as redo: same CvC gating as undo above."""
         if (self.mode == 'computer_vs_computer'
-                and not self.pgn_dialog_open
-                and self.mode_menu is None):
-            self.open_pgn_dialog()
+                and not self.is_autoplay_paused()):
+            return
         self.redo()
 
     # ---- serialization / save-load --------------------------------------

--- a/src/main.py
+++ b/src/main.py
@@ -161,16 +161,34 @@ class Main:
                 # eliminates that artefact.
                 pygame.display.update()
                 # Responsive wait: drain events during the pause so the OS
-                # doesn't mark the window unresponsive and QUIT is honoured.
-                # ~600 ms is long enough for the human to register their own
-                # move clearly before the AI responds.
+                # doesn't mark the window unresponsive AND so key presses
+                # still fire (T/F/M/P/R/U/Y) during CvC autoplay. Without
+                # the KEYDOWN dispatch below, the user reported "all keys
+                # disabled" in CvC because every keystroke landed inside
+                # this loop and was silently dropped. We dispatch into
+                # Game.handle_keydown — which has its own tests — and
+                # break out of the wait if the press opens a paused state
+                # (so we don't immediately take the AI's turn over the
+                # user's request).
                 start = pygame.time.get_ticks()
+                _aborted = False
                 while pygame.time.get_ticks() - start < 600:
                     for event in pygame.event.get():
                         if event.type == pygame.QUIT:
                             pygame.quit()
                             raise SystemExit
+                        if event.type == pygame.KEYDOWN:
+                            result = game.handle_keydown(event.key)
+                            if result.get('reset_happened'):
+                                game = self.game
+                                board = self.game.board
+                                dragger = self.game.dragger
+                    if game.is_autoplay_paused():
+                        _aborted = True
+                        break
                     pygame.time.delay(15)
+                if _aborted:
+                    continue  # don't take the AI's turn this iteration
                 _ctrl.take_turn(game)
                 continue  # re-render the resulting position
 

--- a/tests/test_boulder_captures_friendly_pawn.py
+++ b/tests/test_boulder_captures_friendly_pawn.py
@@ -1,0 +1,179 @@
+"""Tests for the rulebook clarification: the boulder may capture
+pawns of EITHER colour, including the moving player's own pawn.
+
+User asked: should the boulder be able to capture pawns that are
+the same colour as the player to move?
+
+Engine inspection (src/board.py boulder_moves) shows the current
+behaviour: the only filter on the boulder's capture is
+`isinstance(target.piece, Pawn)` — NO colour check. So a same-
+colour pawn IS capturable.
+
+Rationale (to be documented in both rulebooks):
+- The boulder is NEUTRAL (color = 'none'). It is owned by neither
+  side. The standard "no same-colour capture" rule applies to
+  OWNED pieces capturing pieces of their owner's colour; a neutral
+  piece has no owner and so has no "same colour" to violate.
+- The "boulder is treated as friendly by both sides for most
+  purposes" clause governs how OTHER pieces treat the boulder
+  (e.g. invuln support, manipulation eligibility); it does NOT
+  restrict the boulder's own capture rules.
+- The boulder's own capture rule says it "may capture pawns only"
+  — that's the entire restriction. No colour qualifier.
+
+Strategic note: capturing your own pawn via boulder is rarely
+useful (it removes your own material) but is occasionally a
+positional tool — clear a key square, dispose of a pawn the
+opponent could otherwise manipulate, etc. The rule simply allows
+it; it does not require the player to make use of it.
+
+These tests verify the engine matches the documented rule.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+# Use mocked-pygame for the engine-level tests (the engine doesn't
+# need a display). The conftest fixture loads the stub.
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_pygame_if_needed():
+    if 'pygame' not in sys.modules:
+        # Minimal stub so board.py / piece.py imports work headlessly.
+        import types
+        pg = types.ModuleType('pygame')
+        sys.modules['pygame'] = pg
+
+
+# ---- helper: clear board, place pieces by hand ----------------------------
+
+def _make_clean_board():
+    """Construct a Board, then empty every square so we can plant a
+    minimal test position. Returns the Board."""
+    from board import Board
+    b = Board()
+    for r in range(8):
+        for c in range(8):
+            b.squares[r][c].piece = None
+    b.boulder = None
+    return b
+
+
+def _place(b, r, c, piece):
+    b.squares[r][c].piece = piece
+
+
+def _legal_dests(b, piece, r, c):
+    """Compute the legal destinations for `piece` at (r, c) using the
+    boulder's mover. Returns a set of (row, col) tuples."""
+    piece.clear_moves()
+    b.boulder_moves(piece, r, c)
+    return {(m.final.row, m.final.col) for m in piece.moves}
+
+
+# ---- the central question --------------------------------------------------
+
+def test_boulder_can_capture_white_pawn_when_white_to_move():
+    """Rulebook clarification: boulder captures any pawn regardless
+    of colour. White-to-move + white pawn adjacent to boulder —
+    boulder may capture it."""
+    from piece import Boulder, Pawn
+    b = _make_clean_board()
+    boulder = Boulder()
+    boulder.first_move = False  # past the first-move constraint
+    boulder.on_intersection = False
+    boulder.cooldown = 0
+    _place(b, 4, 4, boulder)  # boulder at d5
+    # White pawn at d4 (one square south of boulder).
+    white_pawn = Pawn('white')
+    _place(b, 5, 4, white_pawn)
+    dests = _legal_dests(b, boulder, 4, 4)
+    assert (5, 4) in dests, (
+        f"boulder at (4,4) should be able to capture WHITE pawn at "
+        f"(5,4); legal dests were {dests}")
+
+
+def test_boulder_can_capture_black_pawn_when_white_to_move():
+    """Symmetric sanity: capturing an enemy pawn is also allowed
+    (the rulebook never prohibited this)."""
+    from piece import Boulder, Pawn
+    b = _make_clean_board()
+    boulder = Boulder()
+    boulder.first_move = False
+    boulder.on_intersection = False
+    boulder.cooldown = 0
+    _place(b, 4, 4, boulder)
+    black_pawn = Pawn('black')
+    _place(b, 5, 4, black_pawn)
+    dests = _legal_dests(b, boulder, 4, 4)
+    assert (5, 4) in dests, (
+        f"boulder should be able to capture BLACK pawn; got dests "
+        f"{dests}")
+
+
+def test_boulder_cannot_capture_non_pawn_regardless_of_colour():
+    """The rule restricts capture to pawns. A friendly knight in the
+    boulder's adjacency must NOT be a legal capture destination —
+    the boulder's "captures pawns only" rule blocks the move."""
+    from piece import Boulder, Knight
+    b = _make_clean_board()
+    boulder = Boulder()
+    boulder.first_move = False
+    boulder.on_intersection = False
+    boulder.cooldown = 0
+    _place(b, 4, 4, boulder)
+    knight = Knight('white')
+    _place(b, 5, 4, knight)
+    dests = _legal_dests(b, boulder, 4, 4)
+    assert (5, 4) not in dests
+
+
+def test_boulder_capture_of_friendly_pawn_uses_pawn_capture_branch():
+    """The same-colour capture-pawn case should be treated identically
+    to the enemy-pawn capture case — both go through the boulder's
+    "is_pawn_capture" branch. This guards against future refactors
+    that might add a colour gate."""
+    from piece import Boulder, Pawn
+    b = _make_clean_board()
+    boulder = Boulder()
+    boulder.first_move = False
+    boulder.on_intersection = False
+    boulder.cooldown = 0
+    _place(b, 4, 4, boulder)
+    # White pawn directly east of boulder.
+    white_pawn = Pawn('white')
+    _place(b, 4, 5, white_pawn)
+    # Black pawn directly west of boulder.
+    black_pawn = Pawn('black')
+    _place(b, 4, 3, black_pawn)
+    dests = _legal_dests(b, boulder, 4, 4)
+    assert (4, 5) in dests, "boulder should capture white pawn east"
+    assert (4, 3) in dests, "boulder should capture black pawn west"
+
+
+def test_boulder_returning_to_capture_friendly_pawn_via_no_return_exception():
+    """The no-return-memory rule has an exception for captures. Both
+    enemy AND friendly pawn captures should trigger the exception
+    (the rule keys on 'is this a pawn capture', not 'is this an
+    enemy pawn capture')."""
+    from piece import Boulder, Pawn
+    b = _make_clean_board()
+    boulder = Boulder()
+    boulder.first_move = False
+    boulder.on_intersection = False
+    boulder.cooldown = 0
+    boulder.last_square = (4, 5)  # boulder's most recent square
+    _place(b, 4, 4, boulder)
+    # White pawn at the no-return square — boulder should still be
+    # able to RETURN there (since capture overrides the no-return rule
+    # per the rulebook's "Exception — captures" clause).
+    white_pawn = Pawn('white')
+    _place(b, 4, 5, white_pawn)
+    dests = _legal_dests(b, boulder, 4, 4)
+    assert (4, 5) in dests, (
+        f"boulder should be able to capture-return to (4,5) holding "
+        f"a WHITE pawn — capture exception applies to either "
+        f"colour. Got dests: {dests}")

--- a/tests/test_cvc_keys_and_undo_gating.py
+++ b/tests/test_cvc_keys_and_undo_gating.py
@@ -1,0 +1,256 @@
+"""Tests for the CvC key-dispatch behavior + the new undo/redo
+gating rule.
+
+User report (2026-05-30): in CvC mode, no key presses worked. Root
+cause: main.py's autoplay-wait loop (the 600 ms pre-move pause)
+only handled `pygame.QUIT` and silently dropped all KEYDOWN events.
+
+Fix in main.py wires `Game.handle_keydown(event.key)` into the
+wait loop too. This file does NOT directly exercise the main.py
+loop (that's a long-running event loop); it tests the Game-side
+key dispatch under the conditions main.py is asking it about
+(CvC mode, no menu open) and trusts the small main.py wiring to
+deliver the events.
+
+Plus the new spec on undo/redo:
+> "Disable undo/redo during computer vs computer mode and only
+> enable it during the pause screen, mode menu, or reset
+> confirmation screen."
+
+So in CvC + no paused state, U / Y are NO-OPs. In CvC + any
+paused state (pgn dialog / mode menu / reset confirm), U / Y
+work normally. HvH / HvAI behaviour is UNCHANGED — undo/redo
+always work.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import random
+import pytest
+
+from game import Game
+from ai_controller import AIController
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+
+
+def _advance_cvc(g, n):
+    for _ in range(n):
+        if g.winner is not None:
+            return
+        ctrl = g.current_ai_controller()
+        if ctrl is None:
+            return
+        ctrl.take_turn(g)
+
+
+# ===========================================================================
+# Section 1 — non-undo keys (T / F / M / P / R) work during CvC
+# ===========================================================================
+
+def test_t_changes_theme_during_cvc():
+    """View prefs always work — even during CvC autoplay."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    assert g.is_autoplay_paused() is False  # baseline: CvC is active
+    initial = g.config.idx
+    g.handle_keydown(pygame.K_t)
+    assert g.config.idx != initial
+
+
+def test_f_flips_board_during_cvc():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    initial = g.flipped
+    g.handle_keydown(pygame.K_f)
+    assert g.flipped != initial
+
+
+def test_m_opens_mode_menu_during_cvc():
+    """M during CvC must open the mode menu (pausing autoplay) — the
+    user-reported bug was 'all keys disabled', and M is critical for
+    switching out of CvC."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    g.handle_keydown(pygame.K_m)
+    assert g.mode_menu is not None
+    # And autoplay is now paused.
+    assert g.is_autoplay_paused() is True
+
+
+def test_p_opens_pgn_dialog_during_cvc():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    g.handle_keydown(pygame.K_p)
+    assert g.pgn_dialog_open is True
+    assert g.is_autoplay_paused() is True
+
+
+def test_r_opens_reset_confirm_during_cvc():
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    g.handle_keydown(pygame.K_r)
+    assert g.reset_confirm_pending is True
+    assert g.is_autoplay_paused() is True
+
+
+# ===========================================================================
+# Section 2 — NEW undo/redo gating: blocked in CvC unless paused state open
+# ===========================================================================
+
+def test_undo_blocked_in_cvc_with_no_paused_state():
+    """NEW (2026-05-30 user spec): in CvC + no menu/dialog/confirm,
+    U is a NO-OP — does NOT undo and does NOT open the pgn dialog
+    (the previous design auto-opened the dialog; that's reverted)."""
+    random.seed(401)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 3)
+    assert g.board.turn_number == 3
+    assert g.is_autoplay_paused() is False  # no menu open
+    g.handle_keydown(pygame.K_u)
+    # Nothing changed.
+    assert g.board.turn_number == 3
+    assert g.pgn_dialog_open is False  # did NOT auto-open
+
+
+def test_redo_blocked_in_cvc_with_no_paused_state():
+    random.seed(403)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 4)
+    g.undo()
+    assert g.board.turn_number == 3
+    g.handle_keydown(pygame.K_y)
+    # Y is NOT intercepted as 'yes' (no reset confirm pending), but
+    # it ALSO doesn't redo because CvC + no paused state.
+    assert g.board.turn_number == 3
+    assert g.pgn_dialog_open is False
+
+
+def test_undo_works_in_cvc_when_pgn_dialog_open():
+    """Paused state → undo allowed."""
+    random.seed(407)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 3)
+    g.open_pgn_dialog()
+    assert g.is_autoplay_paused() is True
+    g.handle_keydown(pygame.K_u)
+    assert g.board.turn_number == 2
+
+
+def test_undo_works_in_cvc_when_mode_menu_open():
+    random.seed(409)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 3)
+    g.open_mode_menu()
+    g.handle_keydown(pygame.K_u)
+    assert g.board.turn_number == 2
+
+
+def test_undo_works_in_cvc_when_reset_confirm_pending():
+    """Reset confirm is also a paused state — undo allowed.
+    Note: U is NOT in the reset-confirm intercept's whitelist, so it
+    falls through to normal dispatch, which now permits undo because
+    a paused state is open."""
+    random.seed(411)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 3)
+    g.reset_confirm_pending = True
+    g.handle_keydown(pygame.K_u)
+    assert g.board.turn_number == 2
+    assert g.reset_confirm_pending is True  # reset survives
+
+
+def test_redo_works_in_cvc_when_pgn_dialog_open():
+    random.seed(413)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 4)
+    g.undo()
+    g.open_pgn_dialog()
+    g.handle_keydown(pygame.K_y)
+    assert g.board.turn_number == 4
+
+
+# ===========================================================================
+# Section 3 — HvH and HvAI undo/redo UNCHANGED
+# ===========================================================================
+
+def _advance_hvh(g, n):
+    for _ in range(n):
+        if g.winner is not None:
+            return
+        AIController(g.next_player).take_turn(g)
+
+
+def test_undo_works_in_hvh_no_paused_state():
+    """HvH: U undoes immediately, no CvC gating applies."""
+    random.seed(421)
+    g = Game()  # HvH default
+    _advance_hvh(g, 3)
+    g.handle_keydown(pygame.K_u)
+    assert g.board.turn_number == 2
+
+
+def test_undo_works_in_hvai_no_paused_state():
+    random.seed(423)
+    g = Game()
+    g.apply_mode_selection(opponent='random')  # HvAI; AI = black
+    _advance_hvh(g, 4)
+    g.handle_keydown(pygame.K_u)
+    # HvAI undo skips back to the previous USER turn.
+    assert g.next_player == 'white'  # still user's turn after undo
+    assert g.board.turn_number < 4
+
+
+# ===========================================================================
+# Section 4 — pgn dialog does NOT auto-open on U/Y in CvC anymore
+# ===========================================================================
+
+def test_u_in_cvc_no_paused_state_does_not_auto_open_dialog():
+    """Previous (now-reverted) behaviour: U in CvC auto-opened the
+    PGN dialog. New behaviour: U is suppressed — the user must
+    EXPLICITLY open a paused state first."""
+    random.seed(431)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 2)
+    g.handle_keydown(pygame.K_u)
+    assert g.pgn_dialog_open is False
+    # board state unchanged
+    assert g.board.turn_number == 2
+
+
+def test_y_in_cvc_no_paused_state_does_not_auto_open_dialog():
+    random.seed(433)
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    _advance_cvc(g, 3)
+    g.undo()  # need redo stack populated... but undo is normally
+              # blocked in CvC — bypass via direct call (testing the
+              # KEYDOWN path here, not the can_undo guard)
+    g.handle_keydown(pygame.K_y)
+    assert g.pgn_dialog_open is False

--- a/tests/test_game_keydown_dispatch.py
+++ b/tests/test_game_keydown_dispatch.py
@@ -223,9 +223,10 @@ def test_y_redoes_in_hvh_no_dialog_open():
     assert g.pgn_dialog_open is False
 
 
-def test_u_in_cvc_opens_dialog_then_undoes():
-    """In CvC, pressing U must auto-open the dialog so the autoplay
-    halts cleanly (per user spec)."""
+def test_u_in_cvc_no_paused_state_is_noop():
+    """REVERTED 2026-05-30: U in CvC without a paused state is now
+    a NO-OP. The previous "auto-open the dialog" behaviour required
+    the user to explicitly open a paused state first."""
     random.seed(107)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -233,24 +234,26 @@ def test_u_in_cvc_opens_dialog_then_undoes():
         g.current_ai_controller().take_turn(g)
     assert g.board.turn_number == 3
     g.handle_keydown(pygame.K_u)
-    assert g.pgn_dialog_open is True
-    assert g.board.turn_number == 2
+    assert g.pgn_dialog_open is False  # NOT auto-opened
+    assert g.board.turn_number == 3   # NOT undone
 
 
-def test_y_in_cvc_opens_dialog_then_redoes():
+def test_y_in_cvc_no_paused_state_is_noop():
     random.seed(109)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     for _ in range(4):
         g.current_ai_controller().take_turn(g)
-    g.undo()
+    g.undo()  # via direct call — testing the keydown gate, not
+              # can_undo guard
     g.handle_keydown(pygame.K_y)
-    assert g.pgn_dialog_open is True
-    assert g.board.turn_number == 4
+    assert g.pgn_dialog_open is False
+    # board state unchanged (Y did not redo).
+    assert g.board.turn_number == 3
 
 
-def test_u_in_cvc_does_not_reopen_dialog_when_already_open():
-    """Second U press shouldn't toggle the dialog — it's already open."""
+def test_u_in_cvc_with_dialog_open_undoes_normally():
+    """When a paused state IS open in CvC, U works."""
     random.seed(113)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -258,7 +261,7 @@ def test_u_in_cvc_does_not_reopen_dialog_when_already_open():
         g.current_ai_controller().take_turn(g)
     g.open_pgn_dialog()
     g.handle_keydown(pygame.K_u)
-    assert g.pgn_dialog_open is True  # still open (not toggled off)
+    assert g.pgn_dialog_open is True  # still open
     assert g.board.turn_number == 2
 
 


### PR DESCRIPTION
## Summary
- **Fix CvC key dispatch** (user reported "all keys disabled"): main.py's autoplay-wait loop was silently dropping KEYDOWN events. Now dispatches via Game.handle_keydown and breaks the wait if a paused state opens.
- **Revert undo/redo auto-open** (user spec change): in CvC + no paused state, U/Y are now no-ops. Undo/redo work in CvC ONLY when a paused state is open (pgn dialog / mode menu / reset confirm). HvH and HvAI unchanged.
- **Boulder rule clarification**: the boulder may capture pawns of EITHER colour, including the moving player's own pawns. The engine already implements this; both rulebooks updated to make it explicit. Reasoning: the boulder is neutral, so the "no same-colour capture" rule doesn't apply.

## Test plan
- [x] 15 new tests in `test_cvc_keys_and_undo_gating.py` — every key in CvC, undo/redo gating across the 3 paused states, HvH/HvAI regression — all pass
- [x] 5 new tests in `test_boulder_captures_friendly_pawn.py` — boulder captures same-colour pawn, opposite-colour pawn, cannot capture non-pawn, both-colour from same position, capture-return via no-return exception — all pass (engine already correct)
- [x] Older `test_game_keydown_dispatch.py` U-auto-opens-dialog tests flipped to U-is-noop — pass
- [x] Total focused suite: 298 / 15 files / all pass
- [ ] Manual: launch main.py, switch to CvC; verify T/F/M/P/R/U/Y all work as expected during autoplay; verify U/Y do nothing in CvC without a paused state; press P, then U — verifies undo works inside the paused dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)