### PR TITLE
4 user fixes (boulder rule, win layering, reset Y/redo, CvC view lag) + GDL step 6

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -42,7 +42,7 @@ A turn includes legal boulder moves (either player may move the boulder).
 
 - **First move:** the boulder's first move must be to one of the four central squares (d4, d5, e4, e5). White may not move the boulder on their first turn.
 - **Subsequent moves:** like a king (one square in any direction).
-- **Capture rules:** the boulder may capture pawns of either colour; only a king may capture the boulder.
+- **Capture rules:** the boulder may only capture pawns (of either colour) — no other piece is capturable by the boulder; only a king may capture the boulder.
 - **Neutral status:** the boulder is treated as a friendly piece by both sides for most purposes.
 - **Central intersection:** when on the central intersection, the boulder blocks diagonal lines only — not files or ranks.
 - **Cooldown:** after the boulder moves, both players must make one turn before the boulder may move again.

--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -576,3 +576,43 @@ Tests: `tests/test_gdl_step5.py` (13 structural assertions). All pass.
 
 ### Branch
 `claude/gdl-step5-bishop-rulebook-tidy` (this branch).
+
+## UPDATE (2026-05-30, near midnight — 4 user issues + GDL step 6)
+
+### Training progress: iter 68/75 still. Iter 69 in cycle.
+
+### 4 user issues fixed
+1. **Boulder concise rule** — added "only" so restriction to pawns is unambiguous: "the boulder may **only** capture pawns (of either colour) — no other piece is capturable by the boulder; only a king may capture the boulder."
+2. **Win screen layering + click gate**:
+   - Render order in main.py reorganised: `show_winner` now runs BEFORE `show_mode_menu` / `show_pgn_dialog` / `show_reset_confirm` so the menus paint on top of the winner overlay (was the opposite — winner covered the menus).
+   - Mode-menu and pgn-dialog click handlers moved ABOVE the `if game.winner: continue` gate so users can still navigate menus after a game ends.
+3. **Reset-confirm Y vs Y conflict** — DROPPED Y as a confirm key. Only Enter confirms. Y always means redo now. Updated the on-screen prompt to "Press Enter to reset. Press N or Esc to cancel."
+4. **Theme/flip lag in CvC** — `Game.handle_keydown` now returns `view_changed` flag (True if theme or flip changed). The autoplay-wait loop in main.py breaks on `view_changed` too, so T/F press re-renders immediately instead of waiting up to 600 ms.
+
+Implementation refactor: `Game.handle_keydown` is now a thin wrapper around `_handle_keydown_impl` so the view_pref state capture can wrap the dispatch cleanly without modifying every return path.
+
+Tests in `tests/test_winscreen_resetconfirm_cvclag_boulder_rule.py` (18 new): boulder rule wording strictness (the word "only" must appear in the boulder-captures CLAUSE, not just "only a king"); winner-overlay layering (mode menu, pgn dialog, reset confirm all paint OVER winner); reset-confirm Y now redoes (not confirms); reset-confirm Enter still confirms; show_reset_confirm message no longer mentions Y; view_changed flag returned correctly by handle_keydown for T/F/U/M/P/unknown keys, and across all 3 paused states.
+
+Older tests updated: `test_reset_confirm_y_confirms_reset` → `test_reset_confirm_y_no_longer_confirms_reset`; similar for `test_reset_confirm_y_still_confirms` → `test_reset_confirm_enter_still_confirms`.
+
+### GDL step 6 — BOULDER (the first neutral piece)
+`docs/gdl/step6_add_boulder.gdl` (~330 lines). Key constructs:
+- `(boulder_at intersection)` init fact + sentinel — boulder starts on the central intersection (not on a square).
+- `(boulder_first_move)` flag — clears after first move; controls the d4/d5/e4/e5 first-destination restriction.
+- `(boulder_cooldown N)` — 0 = movable, set to 2 after a move, decrements each turn.
+- `(boulder_last ?f ?r)` — no-return memory; non-capture moves to this square are blocked, but capturing a pawn there IS allowed (the capture exception).
+- `(turn_number ?n)` — supports the "white may not move boulder on turn 1" guard.
+- `boulder_first_dest` enumerates d4/d5/e4/e5.
+- 3 legal-rule families: first move from intersection / subsequent non-capture / subsequent capture-pawn (either colour).
+- State transitions handle origin clearing, destination placement, cooldown decrement, first_move flag clear, last_square set.
+
+Tests: `tests/test_gdl_step6.py` (13 structural assertions). All pass.
+
+### Fragment series progress: 6 of 11 steps complete
+- ✓ Steps 1-6 done
+- → Step 7: queen actions (manipulation + transformation) — HARDEST mechanical step. Manipulation has cross-turn constraints (R1: manipulated piece can't make a spatial move on its next own turn; R2: queen can't manipulate a piece that made a spatial move on the immediately preceding turn). Plus multi-form queen with transformation as a non-spatial action.
+
+### Total focused test count: 360 across 18 files (360 pass).
+
+### Branch
+`claude/fixes-tests-then-gdl-steps` (this branch).

--- a/docs/gdl/step6_add_boulder.gdl
+++ b/docs/gdl/step6_add_boulder.gdl
@@ -1,0 +1,463 @@
+; ============================================================================
+; Step 6 GDL-I fragment: + the BOULDER.
+;
+; Builds on step5_add_bishop.gdl. Adds the boulder — the first NEUTRAL
+; piece in the fragment series (no owner). Adds:
+;
+;   - 1 boulder, starting on the central intersection (not on any
+;     single square — encoded with the sentinel 'intersection' in a
+;     `(boulder_at ...)` fact)
+;   - First-move constraint: the boulder's first move must be to one
+;     of d4 / d5 / e4 / e5. White may NOT move the boulder on their
+;     first turn (turn 1).
+;   - Subsequent moves: king-like 1 square in any direction.
+;   - Capture: pawns ONLY (either colour). Only the king captures
+;     the boulder.
+;   - Cooldown: between boulder moves, both players must each have
+;     made one turn. Encoded as `(boulder_cooldown N)` that decrements
+;     on every turn until 0; boulder may move only when cooldown is 0.
+;   - No-return memory: the boulder may not RETURN (via non-capture)
+;     to its immediately previous square. Encoded as `(boulder_last
+;     <sq>)`. Capture exception: returning to last_square IS allowed
+;     if there's a pawn there to capture.
+;   - Treated as friendly by both sides for blocking-passage etc.
+;     (not all of those semantics matter until later steps).
+;   - Central-intersection blocking: when on the intersection, the
+;     boulder blocks diagonals only (not files/ranks). This affects
+;     bishop diagonal LoS (step 5) and rook 2-segment paths — but in
+;     this step the boulder is the only neutral piece, so we just
+;     encode that the intersection IS blockable for diagonal
+;     reactive captures (deferred to step 9).
+;
+; What we DO NOT yet do in step 6:
+;   - Queen manipulation / transformation (step 7)
+;   - Knight jump-capture + invuln (step 8)
+;   - Bishop reactive capture (step 9)
+;   - Repetition rule (step 10) — but the boulder's cooldown and
+;     last_square WILL be part of the repetition state hash there.
+;   - Tiny endgame rule (step 11)
+; ============================================================================
+
+; ---- Roles --------------------------------------------------------------
+(role white)
+(role black)
+
+; ---- Initial state ------------------------------------------------------
+
+; Pieces (same as step 5).
+(init (cell a 1 white bishop))
+(init (cell g 1 white king))
+(init (cell b 1 white queen))
+(init (cell c 1 white rook))
+(init (cell d 1 white knight))
+(init (cell e 1 white knight))
+(init (cell f 1 white rook))
+(init (cell h 1 white bishop))
+(init (cell a 8 black bishop))
+(init (cell g 8 black queen))
+(init (cell b 8 black king))
+(init (cell c 8 black rook))
+(init (cell d 8 black knight))
+(init (cell e 8 black knight))
+(init (cell f 8 black rook))
+(init (cell h 8 black bishop))
+(init (cell a 2 white pawn))
+(init (cell b 2 white pawn))
+(init (cell c 2 white pawn))
+(init (cell d 2 white pawn))
+(init (cell e 2 white pawn))
+(init (cell f 2 white pawn))
+(init (cell g 2 white pawn))
+(init (cell h 2 white pawn))
+(init (cell a 7 black pawn))
+(init (cell b 7 black pawn))
+(init (cell c 7 black pawn))
+(init (cell d 7 black pawn))
+(init (cell e 7 black pawn))
+(init (cell f 7 black pawn))
+(init (cell g 7 black pawn))
+(init (cell h 7 black pawn))
+
+; Boulder: starts on the central intersection (not on a square).
+(init (boulder_at intersection))
+; First-move flag: TRUE until the boulder first leaves the
+; intersection. While first_move is TRUE the boulder may ONLY move
+; to one of d4, d5, e4, e5 (the four central squares around the
+; intersection), AND white may NOT move it on their first turn (the
+; turn-1 check is handled by a separate guard below).
+(init (boulder_first_move))
+; Cooldown: 0 = movable; >0 = on cooldown. Decremented every turn
+; the boulder is NOT moved; set after a boulder move.
+(init (boulder_cooldown 0))
+; Last-square memory: unset at the start (boulder hasn't moved yet).
+; Once set, the boulder cannot RETURN to that square via a
+; non-capturing move. Capture exception: returning to capture a pawn
+; there IS allowed.
+; (No (boulder_last X Y) fact at init — the memory is "empty" by
+; the absence of the fact.)
+
+(init (control white))
+; A simple turn-number facility for the "white may not move boulder
+; on turn 1" guard. Increments in `next`.
+(init (turn_number 1))
+
+; ---- Adjacency / step / piece helpers (carried over) -------------------
+; (Same as step 5; included for self-containedness.)
+
+(<= (opponent white black))
+(<= (opponent black white))
+
+(<= (file_adj a b)) (<= (file_adj b c)) (<= (file_adj c d))
+(<= (file_adj d e)) (<= (file_adj e f)) (<= (file_adj f g))
+(<= (file_adj g h))
+(<= (file_adj ?x ?y) (file_adj ?y ?x))
+
+(<= (rank_adj 1 2)) (<= (rank_adj 2 3)) (<= (rank_adj 3 4))
+(<= (rank_adj 4 5)) (<= (rank_adj 5 6)) (<= (rank_adj 6 7))
+(<= (rank_adj 7 8))
+(<= (rank_adj ?x ?y) (rank_adj ?y ?x))
+
+(<= (same_file ?x ?x))
+(<= (same_rank ?x ?x))
+
+(<= (king_step ?ff ?fr ?tf ?tr)
+    (file_adj ?ff ?tf)
+    (or (rank_adj ?fr ?tr) (same_rank ?fr ?tr)))
+(<= (king_step ?ff ?fr ?tf ?tr)
+    (same_file ?ff ?tf)
+    (rank_adj ?fr ?tr))
+
+(<= (occupied ?f ?r) (true (cell ?f ?r ?c ?p)))
+(<= (empty ?f ?r) (not (occupied ?f ?r)))
+(<= (enemy_at ?mover ?f ?r)
+    (true (cell ?f ?r ?other ?p))
+    (opponent ?mover ?other))
+(<= (friend_at ?mover ?f ?r)
+    (true (cell ?f ?r ?mover ?p)))
+
+; pawn_forward + last_rank (step 2).
+(<= (pawn_forward white 1 2)) (<= (pawn_forward white 2 3))
+(<= (pawn_forward white 3 4)) (<= (pawn_forward white 4 5))
+(<= (pawn_forward white 5 6)) (<= (pawn_forward white 6 7))
+(<= (pawn_forward white 7 8))
+(<= (pawn_forward black 8 7)) (<= (pawn_forward black 7 6))
+(<= (pawn_forward black 6 5)) (<= (pawn_forward black 5 4))
+(<= (pawn_forward black 4 3)) (<= (pawn_forward black 3 2))
+(<= (pawn_forward black 2 1))
+(<= (last_rank white 8)) (<= (last_rank black 1))
+
+; rook_step + perpendicular + sweep_path (step 3).
+(<= (rook_step ?ff 1 ?ff 2 n)) (<= (rook_step ?ff 2 ?ff 3 n))
+(<= (rook_step ?ff 3 ?ff 4 n)) (<= (rook_step ?ff 4 ?ff 5 n))
+(<= (rook_step ?ff 5 ?ff 6 n)) (<= (rook_step ?ff 6 ?ff 7 n))
+(<= (rook_step ?ff 7 ?ff 8 n))
+(<= (rook_step ?ff 8 ?ff 7 s)) (<= (rook_step ?ff 7 ?ff 6 s))
+(<= (rook_step ?ff 6 ?ff 5 s)) (<= (rook_step ?ff 5 ?ff 4 s))
+(<= (rook_step ?ff 4 ?ff 3 s)) (<= (rook_step ?ff 3 ?ff 2 s))
+(<= (rook_step ?ff 2 ?ff 1 s))
+(<= (rook_step a ?r b ?r e)) (<= (rook_step b ?r c ?r e))
+(<= (rook_step c ?r d ?r e)) (<= (rook_step d ?r e ?r e))
+(<= (rook_step e ?r f ?r e)) (<= (rook_step f ?r g ?r e))
+(<= (rook_step g ?r h ?r e))
+(<= (rook_step h ?r g ?r w)) (<= (rook_step g ?r f ?r w))
+(<= (rook_step f ?r e ?r w)) (<= (rook_step e ?r d ?r w))
+(<= (rook_step d ?r c ?r w)) (<= (rook_step c ?r b ?r w))
+(<= (rook_step b ?r a ?r w))
+(<= (perpendicular n e)) (<= (perpendicular n w))
+(<= (perpendicular s e)) (<= (perpendicular s w))
+(<= (perpendicular e n)) (<= (perpendicular e s))
+(<= (perpendicular w n)) (<= (perpendicular w s))
+(<= (sweep_path ?ff ?fr ?tf ?tr ?dir)
+    (rook_step ?ff ?fr ?tf ?tr ?dir))
+(<= (sweep_path ?ff ?fr ?tf ?tr ?dir)
+    (rook_step ?ff ?fr ?mf ?mr ?dir)
+    (not (occupied ?mf ?mr))
+    (sweep_path ?mf ?mr ?tf ?tr ?dir))
+
+; knight_step (step 4).
+(<= (file_delta_1 a b)) (<= (file_delta_1 b a)) (<= (file_delta_1 b c)) (<= (file_delta_1 c b))
+(<= (file_delta_1 c d)) (<= (file_delta_1 d c)) (<= (file_delta_1 d e)) (<= (file_delta_1 e d))
+(<= (file_delta_1 e f)) (<= (file_delta_1 f e)) (<= (file_delta_1 f g)) (<= (file_delta_1 g f))
+(<= (file_delta_1 g h)) (<= (file_delta_1 h g))
+(<= (file_delta_2 a c)) (<= (file_delta_2 c a)) (<= (file_delta_2 b d)) (<= (file_delta_2 d b))
+(<= (file_delta_2 c e)) (<= (file_delta_2 e c)) (<= (file_delta_2 d f)) (<= (file_delta_2 f d))
+(<= (file_delta_2 e g)) (<= (file_delta_2 g e)) (<= (file_delta_2 f h)) (<= (file_delta_2 h f))
+(<= (rank_delta_1 1 2)) (<= (rank_delta_1 2 1)) (<= (rank_delta_1 2 3)) (<= (rank_delta_1 3 2))
+(<= (rank_delta_1 3 4)) (<= (rank_delta_1 4 3)) (<= (rank_delta_1 4 5)) (<= (rank_delta_1 5 4))
+(<= (rank_delta_1 5 6)) (<= (rank_delta_1 6 5)) (<= (rank_delta_1 6 7)) (<= (rank_delta_1 7 6))
+(<= (rank_delta_1 7 8)) (<= (rank_delta_1 8 7))
+(<= (rank_delta_2 1 3)) (<= (rank_delta_2 3 1)) (<= (rank_delta_2 2 4)) (<= (rank_delta_2 4 2))
+(<= (rank_delta_2 3 5)) (<= (rank_delta_2 5 3)) (<= (rank_delta_2 4 6)) (<= (rank_delta_2 6 4))
+(<= (rank_delta_2 5 7)) (<= (rank_delta_2 7 5)) (<= (rank_delta_2 6 8)) (<= (rank_delta_2 8 6))
+(<= (knight_step ?ff ?fr ?tf ?fr) (file_delta_2 ?ff ?tf))
+(<= (knight_step ?ff ?fr ?ff ?tr) (rank_delta_2 ?fr ?tr))
+(<= (knight_step ?ff ?fr ?tf ?tr) (file_delta_2 ?ff ?tf) (rank_delta_2 ?fr ?tr))
+(<= (knight_step ?ff ?fr ?tf ?tr) (file_delta_2 ?ff ?tf) (rank_delta_1 ?fr ?tr))
+(<= (knight_step ?ff ?fr ?tf ?tr) (file_delta_1 ?ff ?tf) (rank_delta_2 ?fr ?tr))
+
+; bishop helpers (step 5) — can_capture_to / can_move_to_only /
+; enemy_can_reach. Encoded for the bishop's teleport safety check.
+
+(<= (can_capture_to ?atk pawn ?ff ?fr ?ff ?tr)
+    (pawn_forward ?atk ?fr ?tr))
+(<= (can_capture_to ?atk pawn ?ff ?fr ?tf ?tr)
+    (pawn_forward ?atk ?fr ?tr)
+    (file_adj ?ff ?tf))
+(<= (can_capture_to ?atk king ?ff ?fr ?tf ?tr)
+    (king_step ?ff ?fr ?tf ?tr))
+(<= (can_capture_to ?atk queen ?ff ?fr ?tf ?tr)
+    (king_step ?ff ?fr ?tf ?tr))
+(<= (can_capture_to ?atk rook ?ff ?fr ?mf ?mr)
+    (rook_step ?ff ?fr ?mf ?mr ?dir1))
+(<= (can_capture_to ?atk rook ?ff ?fr ?tf ?tr)
+    (rook_step ?ff ?fr ?mf ?mr ?dir1)
+    (perpendicular ?dir1 ?dir2)
+    (sweep_path ?mf ?mr ?tf ?tr ?dir2))
+(<= (can_capture_to ?atk knight ?ff ?fr ?tf ?tr)
+    (knight_step ?ff ?fr ?tf ?tr))
+(<= (jump_capturable_by_knight ?atk ?tf ?tr)
+    (true (cell ?nf ?nr ?atk knight))
+    (king_step ?nf ?nr ?tf ?tr))
+(<= (can_move_to_only ?atk pawn ?ff ?fr ?tf ?fr)
+    (file_adj ?ff ?tf))
+
+(<= (enemy_can_reach ?mover ?tf ?tr)
+    (opponent ?mover ?atk)
+    (true (cell ?ef ?er ?atk ?piece))
+    (distinct ?piece bishop)
+    (can_capture_to ?atk ?piece ?ef ?er ?tf ?tr))
+(<= (enemy_can_reach ?mover ?tf ?tr)
+    (opponent ?mover ?atk)
+    (true (cell ?ef ?er ?atk ?piece))
+    (distinct ?piece bishop)
+    (can_move_to_only ?atk ?piece ?ef ?er ?tf ?tr))
+(<= (enemy_can_reach ?mover ?tf ?tr)
+    (opponent ?mover ?atk)
+    (jump_capturable_by_knight ?atk ?tf ?tr))
+
+; file / rank enumeration (used by bishop teleport).
+(<= (file ?f) (file_adj ?f ?other))
+(<= (file h))
+(<= (rank ?r) (rank_adj ?r ?other))
+(<= (rank 8))
+
+; ---- Boulder-specific helpers -------------------------------------------
+
+; Central squares the boulder may FIRST move to (one of d4, d5, e4,
+; e5).
+(<= (boulder_first_dest d 4))
+(<= (boulder_first_dest d 5))
+(<= (boulder_first_dest e 4))
+(<= (boulder_first_dest e 5))
+
+; A pawn at (?f, ?r) — any colour.
+(<= (pawn_at ?f ?r)
+    (true (cell ?f ?r ?c pawn)))
+
+; ---- Boulder legal moves ------------------------------------------------
+;
+; FIRST move (boulder on intersection, no cooldown, white can't on
+; turn 1):
+(<= (legal ?player (move boulder intersection ?tf ?tr))
+    (true (control ?player))
+    (true (boulder_at intersection))
+    (true (boulder_first_move))
+    (true (boulder_cooldown 0))
+    (boulder_first_dest ?tf ?tr)
+    (empty ?tf ?tr)
+    ; White may not move boulder on turn 1.
+    (not (and_white_and_turn_1 ?player)))
+; Helper for the turn-1 guard.
+(<= (and_white_and_turn_1 white)
+    (true (turn_number 1)))
+
+; SUBSEQUENT non-capture moves (boulder is at some square, king-step
+; to an empty square that ISN'T the last_square):
+(<= (legal ?player (move boulder ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr none boulder))
+    (true (boulder_cooldown 0))
+    (king_step ?ff ?fr ?tf ?tr)
+    (empty ?tf ?tr)
+    (not (true (boulder_last ?tf ?tr))))
+
+; CAPTURE-RETURN exception: boulder may capture a pawn at
+; last_square even though no-return would normally prevent it.
+(<= (legal ?player (move boulder ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr none boulder))
+    (true (boulder_cooldown 0))
+    (king_step ?ff ?fr ?tf ?tr)
+    (pawn_at ?tf ?tr))   ; capture — both colour pawns allowed
+
+; ---- Legal moves for other pieces (carry over from step 5) -------------
+
+(<= (legal ?player (move ?piece ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player ?piece))
+    (or (= ?piece king) (= ?piece queen))
+    (king_step ?ff ?fr ?tf ?tr)
+    (not (friend_at ?player ?tf ?tr)))
+
+(<= (legal ?player (move pawn ?ff ?fr ?ff ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player pawn))
+    (pawn_forward ?player ?fr ?tr)
+    (not (occupied ?ff ?tr)))
+(<= (legal ?player (move pawn ?ff ?fr ?tf ?fr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player pawn))
+    (file_adj ?ff ?tf)
+    (not (occupied ?tf ?fr)))
+(<= (legal ?player (move pawn ?ff ?fr ?ff ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player pawn))
+    (pawn_forward ?player ?fr ?tr)
+    (enemy_at ?player ?ff ?tr))
+(<= (legal ?player (move pawn ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player pawn))
+    (pawn_forward ?player ?fr ?tr)
+    (file_adj ?ff ?tf)
+    (enemy_at ?player ?tf ?tr))
+
+(<= (legal ?player (move rook ?ff ?fr ?mf ?mr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player rook))
+    (rook_step ?ff ?fr ?mf ?mr ?dir1)
+    (not (friend_at ?player ?mf ?mr)))
+(<= (legal ?player (move rook ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player rook))
+    (rook_step ?ff ?fr ?mf ?mr ?dir1)
+    (not (friend_at ?player ?mf ?mr))
+    (perpendicular ?dir1 ?dir2)
+    (sweep_path ?mf ?mr ?tf ?tr ?dir2))
+
+(<= (legal ?player (move knight ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player knight))
+    (knight_step ?ff ?fr ?tf ?tr)
+    (not (friend_at ?player ?tf ?tr)))
+
+(<= (legal ?player (move bishop ?ff ?fr ?tf ?tr))
+    (true (control ?player))
+    (true (cell ?ff ?fr ?player bishop))
+    (file ?tf)
+    (rank ?tr)
+    (or (distinct ?ff ?tf) (distinct ?fr ?tr))
+    (empty ?tf ?tr)
+    (not (enemy_can_reach ?player ?tf ?tr)))
+
+(<= (legal ?player noop)
+    (true (control ?other))
+    (opponent ?other ?player))
+
+; ---- State transitions -------------------------------------------------
+
+; Standard piece moves (frame axiom + arrives at destination), as
+; before.
+(<= (next (cell ?f ?r ?c ?p))
+    (true (cell ?f ?r ?c ?p))
+    (does ?mover (move ?piece ?ff ?fr ?tf ?tr))
+    (distinct ?piece boulder)
+    (or (distinct ?f ?ff) (distinct ?r ?fr))
+    (or (distinct ?f ?tf) (distinct ?r ?tr)))
+
+(<= (next (cell ?tf ?tr ?mover queen))
+    (does ?mover (move pawn ?ff ?fr ?tf ?tr))
+    (last_rank ?mover ?tr))
+
+(<= (next (cell ?tf ?tr ?mover ?piece))
+    (does ?mover (move ?piece ?ff ?fr ?tf ?tr))
+    (distinct ?piece boulder)
+    (or (distinct ?piece pawn) (not (last_rank ?mover ?tr))))
+
+; ---- Boulder state transitions -----------------------------------------
+;
+; When the boulder moves: clear its origin, place at destination,
+; set cooldown to 2 (each player makes one turn before boulder can
+; move again — counting the current player's "made their turn"
+; plus the opponent's), set last_square to origin.
+
+; Origin clears (only when boulder MOVES — the source cell becomes
+; empty). For the first move (from intersection) there's no origin
+; cell to clear.
+(<= (next (cell ?f ?r none boulder))     ; persist non-affected boulder cells
+    (true (cell ?f ?r none boulder))
+    (does ?mover (move ?piece ?ff ?fr ?tf ?tr))
+    (distinct ?piece boulder))
+
+; Boulder ARRIVES at new square (handles both first move and
+; subsequent moves).
+(<= (next (cell ?tf ?tr none boulder))
+    (does ?mover (move boulder ?ff ?fr ?tf ?tr)))
+
+; Boulder LEAVES intersection: when first move happens, no
+; (boulder_at intersection) in next state.
+; (We omit the (next (boulder_at intersection)) rule — by absence
+; it's gone. But we also need to NOT add it for subsequent moves.
+; Since we only add it via init and never re-add it in next, this
+; is automatic.)
+
+; boulder_first_move: persists if no boulder move happened; cleared
+; if it did.
+(<= (next (boulder_first_move))
+    (true (boulder_first_move))
+    (not (boulder_moved_this_turn)))
+(<= (boulder_moved_this_turn)
+    (does ?mover (move boulder ?ff ?fr ?tf ?tr)))
+
+; boulder_last: set to ?ff,?fr when the boulder moves from
+; (?ff,?fr) — only for non-first-move (first move has origin
+; 'intersection').
+(<= (next (boulder_last ?ff ?fr))
+    (does ?mover (move boulder ?ff ?fr ?tf ?tr))
+    (distinct ?ff intersection))
+; persist last_square when boulder did NOT move this turn
+(<= (next (boulder_last ?f ?r))
+    (true (boulder_last ?f ?r))
+    (not (boulder_moved_this_turn)))
+
+; cooldown: set to 2 after a boulder move; decrement otherwise.
+(<= (next (boulder_cooldown 2))
+    (boulder_moved_this_turn))
+(<= (next (boulder_cooldown 1))
+    (true (boulder_cooldown 2))
+    (not (boulder_moved_this_turn)))
+(<= (next (boulder_cooldown 0))
+    (true (boulder_cooldown 1))
+    (not (boulder_moved_this_turn)))
+(<= (next (boulder_cooldown 0))
+    (true (boulder_cooldown 0))
+    (not (boulder_moved_this_turn)))
+
+; turn_number: increments every turn.
+(<= (next (turn_number ?next))
+    (true (turn_number ?n))
+    (succ ?n ?next))
+; succ relation up to a reasonable game length.
+(<= (succ 1 2)) (<= (succ 2 3)) (<= (succ 3 4)) (<= (succ 4 5))
+(<= (succ 5 6)) (<= (succ 6 7)) (<= (succ 7 8)) (<= (succ 8 9))
+(<= (succ 9 10))
+
+; control passes to opponent.
+(<= (next (control ?next))
+    (true (control ?mover))
+    (opponent ?mover ?next))
+
+; ---- Terminal & goals --------------------------------------------------
+
+(<= (alive ?player ?piece)
+    (true (cell ?f ?r ?player ?piece)))
+(<= (dead ?player ?piece)
+    (not (alive ?player ?piece)))
+(<= (lost ?player)
+    (dead ?player king)
+    (dead ?player queen))
+(<= terminal (lost white))
+(<= terminal (lost black))
+(<= (goal white 100) (lost black))
+(<= (goal black 100) (lost white))
+(<= (goal white 0)   (lost white))
+(<= (goal black 0)   (lost black))

--- a/docs/goal4_gdl_ggp_planning.md
+++ b/docs/goal4_gdl_ggp_planning.md
@@ -534,3 +534,47 @@ boulder (cooldown + no-return memory + neutral-piece blocking
 semantics). The boulder is the first NEUTRAL piece in GDL — a
 non-trivial new wrinkle (most GDL-I games have only player-owned
 pieces).
+
+---
+
+## UPDATE — 2026-05-30 (very-very late): Step 6 landed (boulder)
+
+`docs/gdl/step6_add_boulder.gdl` (~330 lines including comments).
+Adds the BOULDER — the first neutral piece in the fragment series.
+
+Key new constructs:
+- `(boulder_at intersection)` init fact — boulder begins on the
+  central intersection (not on any single square).
+- `(boulder_first_move)` flag — TRUE until the boulder's first move.
+- `(boulder_cooldown N)` counter — 0 = movable, 2 set after a move,
+  decrements each turn (own + opponent).
+- `(boulder_last ?f ?r)` memory — the boulder's previous square;
+  no-return restriction blocks non-capture re-entry.
+- `(turn_number ?n)` counter — supports the "white may not move
+  boulder on turn 1" guard.
+- `boulder_first_dest` predicate — the 4 central squares (d4, d5,
+  e4, e5) the boulder may first move to from the intersection.
+- 4 legal-rule families for boulder moves:
+  * FIRST move from intersection to a central square (subject to
+    cooldown + first_move flag + turn-1 guard).
+  * SUBSEQUENT non-capture king-step to an empty non-last square.
+  * SUBSEQUENT capture-pawn move (last-square exception covered
+    by the capture branch).
+- State transitions: boulder arrives at destination cell, origin
+  cleared, cooldown set to 2 then decremented, last_square set,
+  first_move flag cleared.
+
+Boulder captures pawns of EITHER colour — encoded with no colour
+check on the pawn (matches the rulebook clarification).
+
+Tests: `tests/test_gdl_step6.py` (13 structural assertions). All
+pass.
+
+This brings the fragment series to **6 of 11** steps. Next step:
+queen actions (manipulation + transformation) — step 7 is the
+hardest mechanical step in the variant because manipulation has
+cross-turn constraints (R1: manipulated piece may not make a
+spatial move on its next own turn; R2: queen may not manipulate a
+piece that made a spatial move on the immediately preceding turn).
+Plus the multi-form queen (base / rook / bishop / knight) with
+transformation as a non-spatial action.

--- a/src/game.py
+++ b/src/game.py
@@ -1288,7 +1288,23 @@ class Game:
     # ---- centralised KEYDOWN dispatch ----------------------------------
 
     def handle_keydown(self, key):
-        """Dispatch a single pygame KEYDOWN. Returns a dict:
+        """Public wrapper: dispatch the key + report whether a view
+        pref (theme / flip) changed as a side-effect. The view_changed
+        flag is consumed by main.py's CvC autoplay-wait loop so it
+        can re-render immediately instead of waiting the full 600 ms
+        before the next frame (the user reported T / F being laggy
+        in CvC). All other dispatch logic lives in
+        _handle_keydown_impl."""
+        _pre_theme = self.config.idx
+        _pre_flipped = self.flipped
+        result = self._handle_keydown_impl(key)
+        result['view_changed'] = (
+            self.config.idx != _pre_theme
+            or self.flipped != _pre_flipped)
+        return result
+
+    def _handle_keydown_impl(self, key):
+        """Inner KEYDOWN dispatch. Returns a dict:
 
             {
               'consumed':       True if the key matched a handler,
@@ -1323,18 +1339,29 @@ class Game:
         — this method only mutates Game state and returns the result
         flags.
         """
-        result = {'consumed': False, 'reset_happened': False}
+        # Capture view-pref state BEFORE dispatch so we can detect
+        # changes after — used to set `view_changed` in the result,
+        # which the autoplay wait loop in main.py reads to abort its
+        # 600 ms pause and re-render immediately on T / F press.
+        _pre_theme = self.config.idx
+        _pre_flipped = self.flipped
+        result = {
+            'consumed': False, 'reset_happened': False,
+            'view_changed': False,
+        }
 
         # ------ reset-confirm intercept (narrow: only Y / N / R) -------
         # Y/Enter and N are exclusively reset-confirm answers while the
-        # confirm is pending (Y would otherwise mean "redo" — that's
-        # the only key collision). R also re-toggles (per spec). All
-        # OTHER keys fall through to the unified dispatch below; T/F
-        # still work as view prefs, U/Y(redo) still work (but Y is
-        # eaten as "yes" above before reaching the redo handler),
-        # M/P open their screens which auto-cancel the reset.
+        # confirm is pending. Per the 2026-05-30 evening user feedback,
+        # 'Y' is NO LONGER a confirm key — it collided with Y-as-redo,
+        # making redo unusable while the confirm was open. ONLY Enter
+        # confirms now; Y always means redo. R toggles the confirm off
+        # (per spec). All other keys (T/F/U/Y/M/P/...) fall through to
+        # the unified dispatch below; T/F still work as view prefs,
+        # U undoes / Y redoes, M/P open their screens which
+        # auto-cancel the reset.
         if self.reset_confirm_pending:
-            if key in (pygame.K_y, pygame.K_RETURN):
+            if key == pygame.K_RETURN:
                 self.reset_confirm_pending = False
                 self.reset()
                 result['consumed'] = True
@@ -1931,7 +1958,7 @@ class Game:
         body_font = pygame.font.SysFont('arial', 20)
         title = title_font.render('Reset the game?', True, (255, 255, 255))
         body = body_font.render(
-            'Press Y or Enter to reset.   Press N or Esc to cancel.',
+            'Press Enter to reset.   Press N or Esc to cancel.',
             True, (220, 220, 220))
         surface.blit(title, title.get_rect(center=(w // 2, h // 2 - 30)))
         surface.blit(body, body.get_rect(center=(w // 2, h // 2 + 20)))

--- a/src/main.py
+++ b/src/main.py
@@ -123,9 +123,13 @@ class Main:
             game.show_hover(screen)
             game.show_transform_menu(screen)
             game.show_promotion_menu(screen)
+            # Render order (bottom to top): winner overlay FIRST so the
+            # paused-screen overlays paint over it — otherwise the winner
+            # text covers the menu / dialog / confirm options. Reset-confirm
+            # remains the absolute top (it's a tight modal decision).
+            game.show_winner(screen)
             game.show_mode_menu(screen)
             game.show_pgn_dialog(screen)
-            game.show_winner(screen)
             game.show_reset_confirm(screen)
             board.update_lines_of_sight()
             board.update_threat_squares()
@@ -172,6 +176,7 @@ class Main:
                 # user's request).
                 start = pygame.time.get_ticks()
                 _aborted = False
+                _view_changed = False
                 while pygame.time.get_ticks() - start < 600:
                     for event in pygame.event.get():
                         if event.type == pygame.QUIT:
@@ -183,12 +188,22 @@ class Main:
                                 game = self.game
                                 board = self.game.board
                                 dragger = self.game.dragger
+                            # NEW: theme / flip changes need an
+                            # immediate re-render (user reported ~600ms
+                            # lag for T / F during CvC). Break out of
+                            # the wait so the next iteration redraws.
+                            if result.get('view_changed'):
+                                _view_changed = True
                     if game.is_autoplay_paused():
                         _aborted = True
+                        break
+                    if _view_changed:
                         break
                     pygame.time.delay(15)
                 if _aborted:
                     continue  # don't take the AI's turn this iteration
+                if _view_changed:
+                    continue  # re-render with the new view pref first
                 _ctrl.take_turn(game)
                 continue  # re-render the resulting position
 
@@ -244,10 +259,6 @@ class Main:
                         # to piece drag while the dialog is up.
                         continue
 
-                    # Block all interactions when game is over
-                    if game.winner:
-                        continue
-
                     # Handle mode-selector menu clicks (left-click on option).
                     # Each menu_rects entry is (rect, side, player_key)
                     # where side is 'white' or 'black'. Clicking a button
@@ -255,6 +266,12 @@ class Main:
                     # (live-settings model) so the user can also configure
                     # the other side — supporting HvH / HvAI / CvC
                     # transparently. Close via M / Esc (KEYDOWN handler).
+                    #
+                    # Mode-menu clicks are ALLOWED even when game.winner
+                    # is set — the user may want to change modes after a
+                    # game ends (e.g., switch back to HvH and reset).
+                    # This branch sits above the winner gate for that
+                    # reason.
                     if game.mode_menu and event.button == 1:
                         mx, my = event.pos
                         for rect, side, player_key in game.mode_menu_rects:
@@ -266,6 +283,12 @@ class Main:
                                     game.apply_mode_selection(
                                         black_player=player_key)
                                 break
+                        continue
+
+                    # Block all OTHER interactions when game is over.
+                    # (Mode-menu and pgn-dialog clicks above are
+                    # whitelisted — they don't mutate board state.)
+                    if game.winner:
                         continue
 
                     # Handle transform menu clicks (left-click on menu option)

--- a/tests/test_game_keydown_dispatch.py
+++ b/tests/test_game_keydown_dispatch.py
@@ -283,15 +283,20 @@ def test_r_works_from_paused_state():
 
 # ---- reset-confirm intercept: Y / Enter / N / Esc / R / T / F ------------
 
-def test_reset_confirm_y_confirms_reset():
+def test_reset_confirm_y_no_longer_confirms_reset():
+    """2026-05-30 evening user spec change: Y is no longer a confirm
+    key (it collided with Y-as-redo). Only Enter confirms."""
     random.seed(127)
     g = Game()
     _advance(g, 2)
     g.reset_confirm_pending = True
     result = g.handle_keydown(pygame.K_y)
-    assert result.get('reset_happened') is True
-    assert g.reset_confirm_pending is False
-    assert g.board.turn_number == 0
+    assert result.get('reset_happened') is False
+    # Reset confirm STILL pending — Y did not confirm.
+    assert g.reset_confirm_pending is True
+    # Y as redo would have tried to redo but redo stack is empty
+    # at this point — so board state unchanged.
+    assert g.board.turn_number == 2
 
 
 def test_reset_confirm_enter_confirms_reset():

--- a/tests/test_gdl_step6.py
+++ b/tests/test_gdl_step6.py
@@ -1,0 +1,229 @@
+"""Structural tests for the Goal-4 GDL step-6 fragment
+(`docs/gdl/step6_add_boulder.gdl`).
+
+Step 6 adds the boulder to step 5's
+kings+queens+pawns+rooks+knights+bishops base. The boulder is the
+first NEUTRAL piece in the fragment series — owned by neither
+player — and brings several rule wrinkles:
+
+  - First move: from the central intersection to one of d4, d5,
+    e4, e5. White may NOT move the boulder on their first turn.
+  - Subsequent moves: king-like (1 square in any direction).
+  - Capture: pawns ONLY (either colour). Only the king captures
+    the boulder.
+  - Cooldown: between boulder moves, both players must each have
+    made one turn — encoded as a per-turn counter that
+    decrements toward zero.
+  - No-return memory: the boulder may not return via a NON-
+    CAPTURING move to its immediately previous square (capture
+    exception applies).
+  - Treated as friendly by both sides for most purposes (blocks
+    no one).
+
+For step 6 we encode the boulder's MOVEMENT + CAPTURE + COOLDOWN +
+NO-RETURN MEMORY. The repetition rule (step 10) will reference the
+boulder's state in the state hash; queen actions (step 7) reference
+the boulder for the boulder-not-manipulable rule.
+
+Structural invariants tested:
+
+  - Step-5 invariants still hold (roles + initial pieces).
+  - Boulder appears in init at the central intersection (encoded
+    as a sentinel value like 'int').
+  - Boulder cooldown counter starts at 0 (movable).
+  - Boulder last-square memory starts unset.
+  - At least one legal rule mentions 'boulder'.
+  - The first-move constraint is encoded (textual reference to
+    'first_move' / 'd4' / 'e5' / similar).
+  - The cooldown is encoded in `next` clauses.
+  - The no-return memory is encoded.
+"""
+
+import os
+import pytest
+
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+from test_gdl_step1 import _tokenize, _parse_all, _strip_comments
+
+
+GDL_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'docs', 'gdl',
+    'step6_add_boulder.gdl')
+
+
+@pytest.fixture(scope='module')
+def parsed():
+    assert os.path.exists(GDL_PATH), f"step-6 GDL missing at {GDL_PATH}"
+    with open(GDL_PATH) as f:
+        text = f.read()
+    return _parse_all(_tokenize(_strip_comments(text)))
+
+
+# ---- step-5 invariants still hold ----------------------------------------
+
+def test_step6_parses(parsed):
+    assert len(parsed) > 0
+
+
+def test_step6_both_roles_declared(parsed):
+    roles = {f[1] for f in parsed
+             if isinstance(f, tuple) and len(f) == 2 and f[0] == 'role'}
+    assert roles == {'white', 'black'}
+
+
+def test_step6_white_moves_first(parsed):
+    has_init = any(
+        isinstance(f, tuple) and len(f) == 2 and f[0] == 'init'
+        and f[1] == ('control', 'white')
+        for f in parsed)
+    assert has_init
+
+
+def test_step6_has_terminal_and_goal(parsed):
+    has_terminal = False
+    has_goal = False
+    for f in parsed:
+        if isinstance(f, tuple) and len(f) >= 2 and f[0] == '<=':
+            head = f[1]
+            if head == 'terminal' or (
+                    isinstance(head, tuple) and head and
+                    head[0] == 'terminal'):
+                has_terminal = True
+            if isinstance(head, tuple) and head and head[0] == 'goal':
+                has_goal = True
+    assert has_terminal and has_goal
+
+
+# ---- boulder initial state ------------------------------------------------
+
+def _init_facts(parsed):
+    return [f[1] for f in parsed
+            if isinstance(f, tuple) and len(f) == 2 and f[0] == 'init']
+
+
+def test_step6_boulder_starts_on_intersection(parsed):
+    """The boulder starts on the central intersection (not on any
+    single square). Encoded with a sentinel like 'int' or a special
+    fact such as `(boulder_at intersection)` or
+    `(cell intersection none boulder)`."""
+    inits = _init_facts(parsed)
+    flat = [' '.join(_flatten(f)) for f in inits]
+    # Look for ANY init fact mentioning both 'boulder' and an
+    # intersection sentinel (commonly 'int' or 'intersection').
+    relevant = [s for s in flat
+                if 'boulder' in s and ('int' in s or 'center' in s)]
+    assert relevant, (
+        f"no init fact establishes the boulder at the central "
+        f"intersection; init facts: {flat}")
+
+
+def test_step6_boulder_cooldown_starts_at_zero(parsed):
+    """Boulder is movable from the start (cooldown 0). White may NOT
+    move it on their first turn (that's the first-move constraint —
+    separate from cooldown)."""
+    inits = _init_facts(parsed)
+    flat = [' '.join(_flatten(f)) for f in inits]
+    relevant = [s for s in flat
+                if 'cooldown' in s.lower() or 'cd' in s.split()]
+    # Either: there's an explicit (boulder_cooldown 0) init OR cooldown
+    # is implicitly zero (no init fact). Both are acceptable. We just
+    # check the source DOES mention cooldown somewhere.
+    with open(GDL_PATH) as f:
+        text = f.read().lower()
+    assert 'cooldown' in text, "step-6 GDL must encode boulder cooldown"
+
+
+def test_step6_all_step5_pieces_still_present(parsed):
+    # _init_facts already returns the inner fact tuples (the thing
+    # after 'init'), so each `f` is e.g. ('cell', 'a', '1', 'white',
+    # 'bishop'). Filter for cell facts and index directly.
+    cells = [f for f in _init_facts(parsed)
+             if isinstance(f, tuple) and f[0] == 'cell']
+    pieces = {(c[1], c[2]): (c[3], c[4]) for c in cells if len(c) == 5}
+    # spot-check
+    assert pieces.get(('g', '1')) == ('white', 'king')
+    assert pieces.get(('a', '1')) == ('white', 'bishop')
+    assert pieces.get(('d', '1')) == ('white', 'knight')
+    assert pieces.get(('a', '2')) == ('white', 'pawn')
+
+
+# ---- boulder-specific rules ----------------------------------------------
+
+def _flatten(form):
+    if isinstance(form, str):
+        yield form
+    elif isinstance(form, tuple):
+        for item in form:
+            yield from _flatten(item)
+
+
+def test_step6_has_boulder_legal_rule(parsed):
+    """At least one legal rule references 'boulder'."""
+    for f in parsed:
+        if (isinstance(f, tuple) and len(f) >= 2 and f[0] == '<='
+                and isinstance(f[1], tuple) and f[1] and f[1][0] == 'legal'):
+            atoms = list(_flatten(f[1]))
+            if 'boulder' in atoms:
+                return
+    raise AssertionError("no legal rule mentions 'boulder'")
+
+
+def test_step6_first_move_constraint_encoded():
+    """White cannot move the boulder on turn 1; the boulder's first
+    move must be to one of d4 / d5 / e4 / e5. Source must reference
+    either the first-move flag / one of those squares / both."""
+    with open(GDL_PATH) as f:
+        text = f.read().lower()
+    has_first_move_text = (
+        'first_move' in text or 'first move' in text
+        or ('d 4' in text or 'd 5' in text or 'e 4' in text or 'e 5' in text))
+    assert has_first_move_text, (
+        "step-6 GDL must encode the boulder's first-move constraint "
+        "(first move from intersection to d4/d5/e4/e5)")
+
+
+def test_step6_cooldown_handling_in_next():
+    """The cooldown is decremented per turn — must appear in some
+    `next` clause."""
+    with open(GDL_PATH) as f:
+        text = f.read()
+    # crude check: 'cooldown' appears in a `next` clause
+    next_clauses = [s for s in text.split('(<= (next ')
+                    if 'cooldown' in s.split('(<= ')[0]]
+    assert next_clauses, (
+        "boulder cooldown must be updated in a `next` clause")
+
+
+def test_step6_no_return_memory_encoded():
+    """The boulder may not return (via non-capturing move) to its
+    last square. Source must encode last_square or no_return."""
+    with open(GDL_PATH) as f:
+        text = f.read().lower()
+    assert ('last_square' in text or 'no_return' in text
+            or 'no-return' in text or 'previous_square' in text), (
+        "step-6 GDL must encode the no-return memory")
+
+
+def test_step6_boulder_captures_pawn_only_encoded():
+    """The boulder captures pawns only — source must restrict the
+    boulder's capture targets to pawns."""
+    with open(GDL_PATH) as f:
+        text = f.read()
+    # Look for a rule mentioning both 'boulder' and 'pawn' in a
+    # capture/legal context.
+    assert 'pawn' in text and 'boulder' in text, (
+        "step-6 GDL must reference pawn + boulder for the pawn-only "
+        "capture rule")
+
+
+def test_step6_no_queen_actions_yet():
+    """Queen actions (manipulation, transformation) are step 7."""
+    with open(GDL_PATH) as f:
+        text = f.read().lower()
+    code_only = '\n'.join(
+        ln.split(';')[0] for ln in text.split('\n'))
+    assert 'manipulat' not in code_only, (
+        "step 6 must NOT encode queen manipulation (step 7)")
+    assert 'transform' not in code_only, (
+        "step 6 must NOT encode queen transformation (step 7)")

--- a/tests/test_load_fen_centered_dialog_unified_keys.py
+++ b/tests/test_load_fen_centered_dialog_unified_keys.py
@@ -454,10 +454,12 @@ def test_reset_confirm_f_still_flips_board():
     assert g.reset_confirm_pending is True
 
 
-def test_reset_confirm_y_still_confirms():
+def test_reset_confirm_enter_still_confirms():
+    """2026-05-30 evening: Y dropped as confirm key. Only Enter
+    confirms now."""
     g = Game()
     g.reset_confirm_pending = True
-    result = g.handle_keydown(pygame.K_y)
+    result = g.handle_keydown(pygame.K_RETURN)
     assert result['reset_happened'] is True
     assert g.reset_confirm_pending is False
 

--- a/tests/test_winscreen_resetconfirm_cvclag_boulder_rule.py
+++ b/tests/test_winscreen_resetconfirm_cvclag_boulder_rule.py
@@ -1,0 +1,304 @@
+"""Tests for the four user-reported issues (2026-05-30 evening):
+
+1. The concise rulebook line for the boulder should make clear the
+   boulder ONLY captures pawns (not other pieces). Add the word
+   'only' somewhere.
+
+2. When a winner is decided, the win text overlays the mode menu /
+   pause dialog / reset confirm screen — making them unreadable.
+   AND mode menu clicks are blocked by the winner gate in main.py
+   so the user can't reset their mode after a win.
+
+   Fix:
+     - Render the winner overlay BEFORE the paused-screen overlays
+       so the menus paint on top.
+     - Move the mode menu / pgn dialog click handlers ABOVE the
+       winner gate in main.py so they fire even when winner is set.
+
+3. The reset-confirm screen intercepts 'Y' as 'yes confirm reset',
+   which clashes with 'Y' as redo. So redo is unusable while the
+   confirm is open.
+
+   Fix: drop 'Y' as a confirm key — use Enter only. Y remains the
+   redo key in all states (the reset-confirm intercept just doesn't
+   touch it). Update the on-screen prompt text accordingly.
+
+4. Theme / flip changes in CvC mode are laggy — the user presses T
+   or F and waits ~600 ms (the autoplay wait) before seeing the
+   change.
+
+   Fix: extend `Game.handle_keydown`'s result dict with
+   `'view_changed': bool` (true when theme or flip changed). The
+   autoplay wait loop in main.py breaks out as soon as a view pref
+   changes, re-rendering immediately.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import random
+import pytest
+
+from game import Game
+from ai_controller import AIController
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+
+
+# ===========================================================================
+# Issue 1 — boulder rule says "only" pawns
+# ===========================================================================
+
+def test_concise_rulebook_boulder_says_only_pawns():
+    """The concise rulebook line must make clear the boulder can
+    capture ONLY pawns — not other pieces. The word 'only' must
+    appear in the PART of the line that describes what the boulder
+    captures (not just in 'only a king may capture the boulder')."""
+    path = os.path.join(
+        os.path.dirname(__file__), '..', 'RULEBOOK_v2.md')
+    with open(path) as f:
+        text = f.read()
+    matching = [ln for ln in text.split('\n')
+                if 'Capture rules' in ln and 'boulder' in ln.lower()]
+    assert matching, "could not find the boulder Capture rules line"
+    line = matching[0]
+    # The line typically has two clauses separated by ';':
+    #   "the boulder may [only] capture pawns ...; only a king may
+    #    capture the boulder."
+    # Split on ';' and check that the FIRST clause (the boulder's-
+    # captures part) contains 'only' so the restriction is unambiguous
+    # — not just the "only a king" clause in the second half.
+    first_clause = line.split(';')[0].lower()
+    assert 'only' in first_clause, (
+        f"the BOULDER-captures clause must contain 'only' to make "
+        f"clear the boulder cannot capture non-pawns; got first "
+        f"clause: {first_clause!r}")
+
+
+# ===========================================================================
+# Issue 2 — winner screen + paused screens
+# ===========================================================================
+
+def test_show_winner_paints_at_center():
+    """Sanity: the winner overlay does paint visible content at the
+    center of the surface when winner is set."""
+    g = Game()
+    g.winner = 'white'
+    surface = pygame.Surface((800, 800))
+    surface.fill((10, 20, 30))
+    g.show_winner(surface)
+    assert surface.get_at((400, 400))[:3] != (10, 20, 30), (
+        "winner overlay should paint visible content at center")
+
+
+def test_mode_menu_paints_over_winner_when_both_active():
+    """When winner is set AND mode menu is open, the menu must render
+    ABOVE the winner — otherwise the winner text covers the menu
+    options and the user can't read them."""
+    g = Game()
+    g.winner = 'white'
+    g.open_mode_menu()
+    surface = pygame.Surface((800, 800))
+    surface.fill((10, 20, 30))
+    # Render in the order main.py uses (winner first, menu after).
+    g.show_winner(surface)
+    g.show_mode_menu(surface)
+    # The mode menu populates click rects; sample inside the FIRST
+    # rect's center and verify the pixel is the button color, NOT
+    # the winner-overlay color. If the menu paints first and winner
+    # paints over it, the menu rect's center would be obscured.
+    assert g.mode_menu_rects, "mode menu drew no click rects"
+    rect, _side, _key = g.mode_menu_rects[0]
+    px = surface.get_at(rect.center)[:3]
+    # The button color is bluish (60,60,60) for inactive and
+    # (80,140,200) for the currently-selected. The winner overlay
+    # is dark. Reject EXACT match with the original background, but
+    # we mainly want a NON-black pixel — i.e., the menu is on top.
+    # Soft check: button center pixel must have at least one channel
+    # >= 50 (indicating a colored button is visible, not pure dim
+    # backdrop).
+    assert max(px) >= 50, (
+        f"menu button center pixel {px} too dark — winner overlay "
+        f"is likely painting on top of the menu")
+
+
+def test_pgn_dialog_paints_over_winner_when_both_active():
+    g = Game()
+    g.winner = 'black'
+    g.open_pgn_dialog()
+    surface = pygame.Surface((800, 800))
+    surface.fill((10, 20, 30))
+    g.show_winner(surface)
+    g.show_pgn_dialog(surface)
+    # Centered dialog covers the center — check the center pixel.
+    px = surface.get_at((400, 400))[:3]
+    # The dialog panel has rgba (28, 28, 32, 210); even with
+    # semi-transparency it brightens dark-overlaid pixels above
+    # pure-zero. The key check: the dialog DREW something at the
+    # center (panel bg, button, text), which means it ran after
+    # the winner. Soft check: center is not pure black.
+    assert px != (0, 0, 0), (
+        "PGN dialog should render its panel over the winner overlay")
+
+
+def test_reset_confirm_paints_over_winner_when_both_active():
+    g = Game()
+    g.winner = 'white'
+    g.reset_confirm_pending = True
+    surface = pygame.Surface((800, 800))
+    surface.fill((10, 20, 30))
+    g.show_winner(surface)
+    g.show_reset_confirm(surface)
+    # The reset-confirm overlay has its own dark backdrop + text;
+    # at the center we expect the confirm overlay's text, not the
+    # winner overlay's text. Soft: just check the render happened
+    # (center pixel changed from original bg).
+    assert surface.get_at((400, 400))[:3] != (10, 20, 30)
+
+
+# ===========================================================================
+# Issue 3 — Y is now redo only; Enter is confirm
+# ===========================================================================
+
+def test_reset_confirm_y_no_longer_confirms_reset():
+    """NEW (2026-05-30 evening): Y is no longer accepted as a confirm
+    key in the reset-confirm intercept. Only Enter confirms. Y now
+    falls through and acts as redo (subject to other gating)."""
+    random.seed(601)
+    g = Game()
+    # Drive a few turns then undo so redo stack is populated.
+    for _ in range(3):
+        AIController(g.next_player).take_turn(g)
+    g.undo()  # turn 3 -> 2
+    assert g.board.turn_number == 2
+    assert g.can_redo() is True
+    # Open reset confirm.
+    g.reset_confirm_pending = True
+    # Press Y. Previously this would have confirmed reset (back to
+    # turn 0). Now it should REDO (turn 2 -> 3) and leave reset
+    # confirm UNTOUCHED.
+    result = g.handle_keydown(pygame.K_y)
+    assert result['reset_happened'] is False
+    assert g.reset_confirm_pending is True  # confirm still pending
+    assert g.board.turn_number == 3  # redo happened
+
+
+def test_reset_confirm_enter_still_confirms():
+    """Enter (return) is still the confirm key."""
+    g = Game()
+    g.reset_confirm_pending = True
+    result = g.handle_keydown(pygame.K_RETURN)
+    assert result['reset_happened'] is True
+    assert g.reset_confirm_pending is False
+
+
+def test_reset_confirm_n_still_cancels():
+    g = Game()
+    g.reset_confirm_pending = True
+    g.handle_keydown(pygame.K_n)
+    assert g.reset_confirm_pending is False
+
+
+def test_reset_confirm_r_still_toggles_off():
+    g = Game()
+    g.reset_confirm_pending = True
+    g.handle_keydown(pygame.K_r)
+    assert g.reset_confirm_pending is False
+
+
+def test_show_reset_confirm_message_no_longer_mentions_y():
+    """The on-screen prompt must NOT tell the user to press Y to
+    confirm (now misleading)."""
+    g = Game()
+    g.reset_confirm_pending = True
+    surface = pygame.Surface((800, 600))
+    g.show_reset_confirm(surface)
+    # We can't easily extract the rendered text from pixels. Instead,
+    # check the source code: the prompt string must not say "Y" as a
+    # confirm key.
+    import inspect
+    src = inspect.getsource(Game.show_reset_confirm)
+    # The message used to be "Press Y or Enter to reset". After the
+    # fix it should say "Enter" (not "Y") for confirm.
+    # Look for "Press Y" — that's the OLD wording that must be gone.
+    assert 'Press Y' not in src, (
+        "show_reset_confirm still tells the user to press Y — that "
+        "wording should be updated since Y is no longer a confirm key")
+
+
+# ===========================================================================
+# Issue 4 — view_changed flag for fast theme/flip in CvC
+# ===========================================================================
+
+def test_handle_keydown_returns_view_changed_false_for_non_view_keys():
+    g = Game()
+    result = g.handle_keydown(pygame.K_u)
+    assert 'view_changed' in result
+    assert result['view_changed'] is False
+
+
+def test_handle_keydown_returns_view_changed_true_when_theme_changes():
+    g = Game()
+    result = g.handle_keydown(pygame.K_t)
+    assert result['view_changed'] is True
+
+
+def test_handle_keydown_returns_view_changed_true_when_flip_changes():
+    g = Game()
+    result = g.handle_keydown(pygame.K_f)
+    assert result['view_changed'] is True
+
+
+def test_handle_keydown_view_changed_during_reset_confirm():
+    """T pressed during reset confirm still triggers view_changed=True
+    so the CvC autoplay wait can re-render the new theme immediately."""
+    g = Game()
+    g.reset_confirm_pending = True
+    result = g.handle_keydown(pygame.K_t)
+    assert result['view_changed'] is True
+
+
+def test_handle_keydown_view_changed_during_mode_menu():
+    g = Game()
+    g.open_mode_menu()
+    result = g.handle_keydown(pygame.K_f)
+    assert result['view_changed'] is True
+
+
+def test_handle_keydown_view_changed_for_p_is_false():
+    """Opening the PGN dialog isn't a view pref change — view_changed
+    must be False. (P opens a paused state, which is its own abort
+    signal in the wait loop.)"""
+    g = Game()
+    result = g.handle_keydown(pygame.K_p)
+    assert result['view_changed'] is False
+
+
+def test_handle_keydown_view_changed_for_m_is_false():
+    g = Game()
+    result = g.handle_keydown(pygame.K_m)
+    assert result['view_changed'] is False
+
+
+def test_handle_keydown_view_changed_for_unknown_key_is_false():
+    g = Game()
+    result = g.handle_keydown(pygame.K_a)
+    assert result['view_changed'] is False


### PR DESCRIPTION
## Summary
- **Boulder rule**: added 'only' to make pawn-only restriction unambiguous.
- **Win-screen layering + click gate**: render winner FIRST so paused-screens paint over it; allow mode-menu and pgn-dialog clicks through the winner gate.
- **Reset-confirm Y conflict**: dropped Y as confirm key. Only Enter confirms. Y always means redo.
- **CvC view lag**: handle_keydown returns view_changed flag; autoplay wait loop breaks immediately on T/F.
- **GDL step 6 (boulder)**: first neutral piece; first-move/cooldown/no-return memory/turn-number facility; captures pawns of either colour.

## Test plan
- [x] 18 new tests in `test_winscreen_resetconfirm_cvclag_boulder_rule.py`
- [x] 13 new tests in `test_gdl_step6.py`
- [x] Older Y-confirms-reset tests flipped to new spec
- [x] Total focused suite: 360 / 18 files / all pass
- [ ] Manual: end a game (let one side win), open mode menu — verify clicks switch modes; press R after a win, verify confirm overlay reads "Enter to reset" (not "Y or Enter"); start CvC, press T / F, verify theme/flip changes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)