### PR TITLE
GGP Game class + difficulty bumps + 6000x resolver speedup

### DIFF
--- a/docs/design-notes/session_handoff_2026-05-27.md
+++ b/docs/design-notes/session_handoff_2026-05-27.md
@@ -713,3 +713,39 @@ Tests in `tests/test_render_frame_helper.py` (9 tests): helper exists, renders f
 
 ### Branch
 `claude/cvc-view-pref-no-pause` (this branch).
+
+## UPDATE (2026-05-31 — GGP Game class + difficulty bumps + resolver speedup)
+
+### Training progress: iter 76/500 complete, iter 77 in cycle
+W=39 B=61 (small imbalance), avg_len 265 turns (longer than recent — random-policy-like at start of resume due to ε=0.865), loss 0.0067 (much lower than the unconverged iter-68 0.0484 — buffer is fully loaded now).
+
+### Difficulty bumps (per user)
+- Easy: target=100, mode='capped' (auto-tracks)
+- Medium: target=150, mode='capped' (NEW — was exact-75)
+- Hard: target=500, mode='capped' (NEW — was exact-100; tracks latest until iter 500 lands)
+- All 3 are now `capped` so each auto-updates as training advances. Iter depth alone isn't a fine knob; once training matures, switching to temperature / blunder rate is the right next step.
+
+### GGP Game class — STATE MACHINE landed
+- `src/ggp/game.py` exports `GGPGame`, `RandomGGPPlayer`, `play_game`.
+- `GGPGame`:
+  - `.from_file(path)` / `__init__(gdl_text)` — load
+  - `.state` — Python set of fact terms representing the current state's `(true ?fact)` content
+  - `.roles` — list of role names
+  - `.legal_moves(player)` — query `(legal ?p ?move)` against state
+  - `.step({role: move})` — add `(does ?p ?move)` facts, query `(next ?fact)`, replace state
+  - `.is_terminal()` / `.goal(player)` — query `terminal` / `(goal ?p ?n)`
+- `RandomGGPPlayer(role, seed=None)` — seedable uniform-random legal-move chooser
+- `play_game(game, players, max_steps=200)` — drives a game to terminal or step cap; returns `{role: goal}`
+
+### Resolver SPEEDUP (50s → 8ms = 6000×)
+First end-to-end test of `legal_moves` was 50 seconds. Root cause: cycle detection used `_freeze` which includes variable names, so symmetric rule `(<= (file_adj ?x ?y) (file_adj ?y ?x))` recursed via renamed `?_v1`, `?_v2`, etc. → each rename looked like a "new" goal → no cycle detected → ~200 redundant proofs per query.
+
+Fix: new `_cycle_key(term)` collapses ALL variables to a single `'?'` placeholder. Same predicate + same ground args now compare equal regardless of variable position naming. Cycle correctly detected → exits immediately on re-entry → proof count drops from ~200 per file_adj call to 1.
+
+### Tests for GGP Game class
+`tests/test_ggp_game_class.py` (18 tests, all pass): load from file/text, roles, initial state has 4 cells + control white, legal_moves white=10 black=noop, step advances state, does facts don't persist, post-step legal_moves flip, terminal/goal at hand-constructed end state, RandomGGPPlayer deterministic under seed, play_game runs to terminal or cap.
+
+### Total focused test count: 449 across 28 files (449 pass), full suite runs in 31s.
+
+### Branch
+`claude/ggp-game-class-difficulty-bumps` (this branch).

--- a/src/game.py
+++ b/src/game.py
@@ -417,17 +417,17 @@ class Game:
         # the exact target iteration; otherwise the option is disabled in
         # the mode menu.
         #
-        # Easy cap raised 50 -> 75 -> 100 (2026-05-30): at iter 64 the
-        # network was still blundering more than random in user testing.
-        # Cap pushed all the way to 100 so Easy auto-tracks whatever the
-        # strongest available checkpoint is — once iter 100 lands, all
-        # three difficulties resolve to the same checkpoint. Re-tune via
-        # a different mechanism (temperature / explicit blunder rate)
-        # once the network is genuinely strong; iteration depth alone
-        # isn't a fine enough difficulty knob.
+        # 2026-05-31 spec change: with training resumed to iter 500, all
+        # three difficulties are now CAPPED (auto-track up to their cap).
+        # Easy → 100, Medium → 150, Hard → 500 (tracks the latest
+        # available checkpoint until training reaches 500).
+        #
+        # Iter depth alone is not a fine difficulty knob — once the
+        # network is genuinely strong, switching to temperature / blunder
+        # rate is the right next step.
         'easy':   {'target': 100, 'mode': 'capped'},
-        'medium': {'target': 75,  'mode': 'exact'},
-        'hard':   {'target': 100, 'mode': 'exact'},
+        'medium': {'target': 150, 'mode': 'capped'},
+        'hard':   {'target': 500, 'mode': 'capped'},
     }
 
     def __init__(self, knight_mode=Board.KNIGHT_MODE_V2):

--- a/src/ggp/game.py
+++ b/src/ggp/game.py
@@ -1,0 +1,182 @@
+"""GGPGame — state-machine wrapper around the KB + Resolver.
+
+Exposes a clean Game-driving API:
+
+    g = GGPGame.from_file('step1_kings_queens.gdl')
+    print(g.roles)                            # ['black', 'white']
+    print(g.legal_moves('white'))             # 10 legal moves
+    g.step({'white': move, 'black': 'noop'})  # apply turn
+    print(g.is_terminal())                    # False / True
+    print(g.goal('white'))                    # 0..100
+
+How it works internally:
+
+1. The GDL file is parsed into a "rules KB" — all the (<= ...)
+   rules + permanent facts (roles, file_adj, etc.).
+2. The initial state is computed by querying (init ?fact) against
+   the rules KB; the answers form the initial set of (true ...)
+   facts. We store these as plain ?fact terms in `self.state`
+   (a Python set).
+3. legal_moves(player) builds a temporary KB that combines the
+   rules KB with the current state's facts (each wrapped in
+   `(true ...)`) and queries (legal <player> ?move).
+4. step(moves) adds (does <player> <move>) facts to a temporary
+   KB and queries (next ?fact) to derive the next state. The
+   answer set replaces self.state. The does facts are not
+   persisted.
+5. is_terminal() / goal(player) work the same way — temporary
+   KB + query.
+
+Per-query KB construction is O(rule_count) and could be expensive
+on the larger steps (6-11). For step 1 (kings + queens) it's
+acceptably fast (a few seconds per legal-moves query). Future
+optimization: cache the rule prefix once and only re-bind the
+state facts.
+
+Also includes:
+    RandomGGPPlayer(role, seed=None)  — picks a uniform-random
+        legal move; seedable for reproducibility.
+    play_game(game, players, max_steps=200)  — alternates
+        legal-move + step + check-terminal until terminal or
+        step cap. Returns {role: goal} dict.
+"""
+
+import random as _random
+
+from .parser import parse, is_variable
+from .kb import KnowledgeBase
+from .resolver import Resolver
+
+
+class GGPGame:
+    """A Game driven by a GDL ruleset."""
+
+    def __init__(self, gdl_text):
+        """Build from a raw GDL text string. Use
+        `GGPGame.from_file(path)` to load from a file."""
+        self._rules_kb = KnowledgeBase()
+        for form in parse(gdl_text):
+            self._rules_kb.add_clause(form)
+        self.state = self._initial_state()
+        self.roles = self._compute_roles()
+
+    @classmethod
+    def from_file(cls, path):
+        with open(path) as f:
+            return cls(f.read())
+
+    # ---- initial state computation -------------------------------------
+
+    def _initial_state(self):
+        """Query (init ?fact) against the rules KB to compute the
+        initial set of state facts. Returns a set of fact terms."""
+        r = Resolver(self._rules_kb)
+        return {b['?fact'] for b in r.query(('init', '?fact'))}
+
+    def _compute_roles(self):
+        kb = self._state_kb()
+        r = Resolver(kb)
+        return sorted(b['?r'] for b in r.query(('role', '?r')))
+
+    # ---- temporary KB building -----------------------------------------
+
+    def _state_kb(self, extra_facts=None):
+        """Build a transient KB that combines:
+          - all permanent rules + permanent facts from the rules KB
+            (excluding init facts — those were consumed to build
+            the initial state)
+          - the current state's facts, each wrapped in (true ...)
+          - any extra_facts the caller provides (typically does
+            facts for next-state derivation)
+        """
+        kb = KnowledgeBase()
+        # Copy rules + permanent facts (skip init).
+        for pred in self._rules_kb.all_predicates():
+            for head, body in self._rules_kb.rules_for(pred):
+                kb._add_rule(head, body)
+            for fact in self._rules_kb.facts_for(pred):
+                if isinstance(fact, tuple) and fact and fact[0] == 'init':
+                    continue
+                kb._add_fact(fact)
+        # Lift current state into (true ...) facts.
+        for fact in self.state:
+            kb._add_fact(('true', fact))
+        # Extras (e.g. does ...).
+        if extra_facts:
+            for f in extra_facts:
+                kb._add_fact(f)
+        return kb
+
+    # ---- public state-machine API --------------------------------------
+
+    def legal_moves(self, player):
+        """Return a list of legal move terms for `player` in the
+        current state. Empty list if the player is unknown or has
+        no legal moves."""
+        kb = self._state_kb()
+        r = Resolver(kb)
+        return [b['?move'] for b in r.query(('legal', player, '?move'))]
+
+    def step(self, moves):
+        """Advance the game by one turn. `moves` is a dict
+        {role: move_term}. The next state is computed by
+        querying (next ?fact) against a KB containing (does ...)
+        facts for each player's move."""
+        does_facts = [('does', role, move)
+                      for role, move in moves.items()]
+        kb = self._state_kb(does_facts)
+        r = Resolver(kb)
+        self.state = {b['?fact'] for b in r.query(('next', '?fact'))}
+
+    def is_terminal(self):
+        """True iff the current state satisfies `terminal`."""
+        kb = self._state_kb()
+        r = Resolver(kb)
+        return any(True for _ in r.query('terminal'))
+
+    def goal(self, player):
+        """Return the player's current goal value (0..100). Returns
+        0 if no goal rule succeeds (per GDL convention, goal is
+        only meaningful at terminal states)."""
+        kb = self._state_kb()
+        r = Resolver(kb)
+        for b in r.query(('goal', player, '?n')):
+            try:
+                return int(b['?n'])
+            except (ValueError, TypeError):
+                continue
+        return 0
+
+
+# ---- Players -------------------------------------------------------------
+
+class RandomGGPPlayer:
+    """Picks a uniform-random legal move for its role. Seedable."""
+
+    def __init__(self, role, seed=None):
+        self.role = role
+        self._rng = _random.Random(seed)
+
+    def choose(self, game):
+        moves = game.legal_moves(self.role)
+        if not moves:
+            return None
+        return self._rng.choice(moves)
+
+
+def play_game(game, players, max_steps=200):
+    """Drive `game` with `players` (dict {role: player}) until
+    terminal or `max_steps` elapse. Returns the final
+    {role: goal_int} dict — 0s if not terminal at the end."""
+    for _ in range(max_steps):
+        if game.is_terminal():
+            break
+        moves = {}
+        for role, p in players.items():
+            choice = p.choose(game)
+            if choice is None:
+                # No legal moves for this role — game can't proceed.
+                return {role: game.goal(role) for role in players}
+            moves[role] = choice
+        game.step(moves)
+    return {role: game.goal(role) for role in players}

--- a/src/ggp/resolver.py
+++ b/src/ggp/resolver.py
@@ -110,6 +110,22 @@ def _freeze(term):
     return term
 
 
+def _cycle_key(term):
+    """Hash key for cycle detection. Collapses ALL variables to a
+    single placeholder '?' so that `(file_adj g ?x)` and
+    `(file_adj g ?y)` (after rule-variable renaming) compare as
+    the SAME goal — they ask the same question regardless of
+    which variable name carries the answer. Without this, the
+    symmetric `(file_adj ?x ?y) :- (file_adj ?y ?x)` rule recurses
+    indefinitely via different renamings, exploding proof count
+    to ~200× per query."""
+    if is_variable(term):
+        return '?'
+    if isinstance(term, tuple):
+        return tuple(_cycle_key(c) for c in term)
+    return term
+
+
 def _collect_variables(term):
     """Walk a term and yield each unique variable name."""
     seen = set()
@@ -160,14 +176,25 @@ class Resolver:
             seen.add(key)
             yield clean
 
-    def _query(self, goal, subst=None, depth=0):
+    def _query(self, goal, subst=None, depth=0, in_progress=None):
         """Internal: yields raw substitutions (may contain renamed
         internal variables in the values). Callers in resolver.py
         chain into this directly; external callers should use
         the public `query` method which cleans up bindings.
+
+        `in_progress` is a set of currently-being-solved goals
+        (ground form) used to short-circuit cycles. Without this,
+        symmetric rules like `(<= (file_adj ?x ?y) (file_adj ?y ?x))`
+        recursively re-derive the same fact O(depth_limit) times,
+        producing massive duplication and ~50s per legal-move query
+        on step 1. With cycle detection a query that re-enters the
+        same goal during its own derivation just returns no
+        additional proofs from the recursive branch.
         """
         if subst is None:
             subst = {}
+        if in_progress is None:
+            in_progress = set()
         # Resolve any already-bound variables.
         goal = _substitute(goal, subst)
 
@@ -183,17 +210,19 @@ class Resolver:
             if op == 'not':
                 # Negation-as-failure.
                 inner = goal[1]
-                solutions = self._query(inner, subst, depth + 1)
+                solutions = self._query(
+                    inner, subst, depth + 1, in_progress)
                 if next(solutions, None) is None:
                     yield subst
                 return
             if op == 'or':
                 for alt in goal[1:]:
-                    yield from self._query(alt, subst, depth + 1)
+                    yield from self._query(
+                        alt, subst, depth + 1, in_progress)
                 return
             if op == 'and':
                 yield from self._query_conjunction(
-                    list(goal[1:]), subst, depth + 1)
+                    list(goal[1:]), subst, depth + 1, in_progress)
                 return
             if op == 'distinct':
                 a = _walk(goal[1], subst)
@@ -207,6 +236,18 @@ class Resolver:
                 if new_subst is not None:
                     yield new_subst
                 return
+
+        # Cycle guard: if we're already in the middle of solving
+        # this exact (substituted) goal, bail. This stops symmetric
+        # rules like (file_adj ?x ?y) :- (file_adj ?y ?x) from
+        # recursing indefinitely (cut by depth limit -> dedup), which
+        # was generating ~200 duplicate proofs per file_adj call.
+        # With the guard, file_adj(a,b) re-entering via the symmetric
+        # rule short-circuits at the second call.
+        goal_key = _cycle_key(goal)
+        if goal_key in in_progress:
+            return
+        new_in_progress = in_progress | {goal_key}
 
         # Otherwise: query against the KB.
         pred = goal[0] if isinstance(goal, tuple) and goal else goal
@@ -226,14 +267,19 @@ class Resolver:
             if new_subst is None:
                 continue
             yield from self._query_conjunction(
-                renamed_body, new_subst, depth + 1)
+                renamed_body, new_subst, depth + 1, new_in_progress)
 
-    def _query_conjunction(self, goals, subst, depth):
+    def _query_conjunction(self, goals, subst, depth,
+                           in_progress=None):
         """Solve a sequence of goals as a conjunction. Each
-        binding extends the substitution."""
+        binding extends the substitution. Threads in_progress
+        through so cycle detection survives across conjuncts."""
+        if in_progress is None:
+            in_progress = set()
         if not goals:
             yield subst
             return
         head, *rest = goals
-        for new_subst in self._query(head, subst, depth):
-            yield from self._query_conjunction(rest, new_subst, depth)
+        for new_subst in self._query(head, subst, depth, in_progress):
+            yield from self._query_conjunction(
+                rest, new_subst, depth, in_progress)

--- a/tests/test_ggp_game_class.py
+++ b/tests/test_ggp_game_class.py
@@ -1,0 +1,210 @@
+"""Tests for `src/ggp/game.py` — the GGP Game class that wraps
+KB + resolver and exposes a clean state-machine API:
+
+    g = GGPGame.from_file('step1_kings_queens.gdl')
+    g.legal_moves('white')   -> list of move terms
+    g.step({'white': move, 'black': 'noop'})   -> mutates state
+    g.is_terminal()          -> bool
+    g.goal('white')          -> int  (0-100 per GDL convention)
+    g.roles                  -> ['white', 'black']
+
+Plus a `RandomGGPPlayer` and a `play_game` helper for end-to-end
+self-play validation.
+"""
+
+import os
+import sys
+import random
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from ggp.game import GGPGame, RandomGGPPlayer, play_game
+
+
+GDL_DIR = os.path.join(os.path.dirname(__file__), '..', 'docs', 'gdl')
+STEP1 = os.path.join(GDL_DIR, 'step1_kings_queens.gdl')
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+# ---- construction --------------------------------------------------------
+
+def test_ggp_game_loads_from_file():
+    g = GGPGame.from_file(STEP1)
+    assert g is not None
+
+
+def test_ggp_game_loads_from_text():
+    text = _read(STEP1)
+    g = GGPGame(text)
+    assert g is not None
+
+
+def test_ggp_game_exposes_roles():
+    g = GGPGame.from_file(STEP1)
+    assert sorted(g.roles) == ['black', 'white']
+
+
+# ---- initial state -------------------------------------------------------
+
+def test_ggp_game_initial_state_has_4_cells():
+    g = GGPGame.from_file(STEP1)
+    cells = [f for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell']
+    assert len(cells) == 4
+
+
+def test_ggp_game_initial_state_has_control_white():
+    g = GGPGame.from_file(STEP1)
+    assert ('control', 'white') in g.state
+
+
+# ---- legal moves ---------------------------------------------------------
+
+def test_ggp_game_legal_moves_white_at_init():
+    g = GGPGame.from_file(STEP1)
+    moves = g.legal_moves('white')
+    assert len(moves) == 10, (
+        f'expected 10 legal moves for white at init; got '
+        f'{len(moves)}: {moves}')
+
+
+def test_ggp_game_legal_moves_black_at_init_is_noop():
+    g = GGPGame.from_file(STEP1)
+    moves = g.legal_moves('black')
+    assert moves == ['noop']
+
+
+def test_ggp_game_legal_moves_for_unknown_role_is_empty():
+    g = GGPGame.from_file(STEP1)
+    assert g.legal_moves('green') == []
+
+
+# ---- step (state progression) -------------------------------------------
+
+def test_ggp_game_step_advances_state():
+    g = GGPGame.from_file(STEP1)
+    # White king g1 -> f1.
+    move = ('move', 'king', 'g', '1', 'f', '1')
+    g.step({'white': move, 'black': 'noop'})
+    # After the move:
+    #   - cell at g1 should be empty (no fact)
+    #   - cell at f1 should hold white king
+    #   - control should be black
+    cells = {(f[1], f[2]): (f[3], f[4])
+             for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell'}
+    assert cells.get(('f', '1')) == ('white', 'king'), (
+        f'white king should be at f1 after move; got cells {cells}')
+    assert ('g', '1') not in cells, (
+        f'g1 should be empty after move; got cells {cells}')
+    assert ('control', 'black') in g.state, (
+        f'control should pass to black; state has {g.state}')
+
+
+def test_ggp_game_step_does_not_create_does_facts():
+    """After step, the (does ...) facts used for next-state derivation
+    should NOT persist into the next state."""
+    g = GGPGame.from_file(STEP1)
+    move = ('move', 'king', 'g', '1', 'f', '1')
+    g.step({'white': move, 'black': 'noop'})
+    does_facts = [f for f in g.state
+                  if isinstance(f, tuple) and f[0] == 'does']
+    assert does_facts == []
+
+
+def test_ggp_game_step_makes_other_side_legal_to_move():
+    g = GGPGame.from_file(STEP1)
+    move = ('move', 'king', 'g', '1', 'f', '1')
+    g.step({'white': move, 'black': 'noop'})
+    # Now it's black's turn.
+    black_moves = g.legal_moves('black')
+    # Black has its own king + queen now able to make 10 king-step
+    # moves (or close — let's just verify > 1).
+    assert len(black_moves) >= 5, (
+        f'expected ≥5 black moves after white moved; got '
+        f'{len(black_moves)}: {black_moves}')
+    # And white now plays noop.
+    white_moves = g.legal_moves('white')
+    assert white_moves == ['noop']
+
+
+# ---- terminal + goal ----------------------------------------------------
+
+def test_ggp_game_not_terminal_at_init():
+    g = GGPGame.from_file(STEP1)
+    assert g.is_terminal() is False
+
+
+def test_ggp_game_terminal_when_one_side_loses_all_royals():
+    """Hand-construct a near-terminal state: only black has a piece."""
+    g = GGPGame.from_file(STEP1)
+    # Force white's king + queen off the board (state mutation).
+    g.state = {
+        ('cell', 'b', '8', 'black', 'king'),
+        ('cell', 'g', '8', 'black', 'queen'),
+        ('control', 'white'),
+    }
+    # No white royals → white has lost → game terminal.
+    assert g.is_terminal() is True
+    assert g.goal('black') == 100
+    assert g.goal('white') == 0
+
+
+def test_ggp_game_goal_zero_when_neither_side_has_won():
+    g = GGPGame.from_file(STEP1)
+    # Both alive — no goal yet (per GDL: goal only defined when
+    # terminal; we return 0 by convention before then).
+    assert g.goal('white') == 0
+    assert g.goal('black') == 0
+
+
+# ---- RandomGGPPlayer + play_game ----------------------------------------
+
+def test_random_player_picks_a_legal_move():
+    g = GGPGame.from_file(STEP1)
+    p = RandomGGPPlayer('white', seed=42)
+    move = p.choose(g)
+    legal = g.legal_moves('white')
+    assert move in legal
+
+
+def test_random_player_deterministic_under_seed():
+    g = GGPGame.from_file(STEP1)
+    p1 = RandomGGPPlayer('white', seed=1234)
+    p2 = RandomGGPPlayer('white', seed=1234)
+    assert p1.choose(g) == p2.choose(g)
+
+
+def test_play_game_runs_until_terminal_or_step_cap():
+    """End-to-end: play step-1 with random players for both sides.
+    Should either reach terminal (one side captured the other's
+    royals) within the step cap, OR cleanly exit at the cap."""
+    g = GGPGame.from_file(STEP1)
+    players = {
+        'white': RandomGGPPlayer('white', seed=1),
+        'black': RandomGGPPlayer('black', seed=2),
+    }
+    result = play_game(g, players, max_steps=200)
+    # result is {role: int_goal_or_zero}
+    assert 'white' in result
+    assert 'black' in result
+    assert isinstance(result['white'], int)
+    assert isinstance(result['black'], int)
+
+
+def test_play_game_returns_zeros_if_not_terminal():
+    """If the game doesn't terminate within max_steps, both goals
+    should be 0 (no winner)."""
+    g = GGPGame.from_file(STEP1)
+    players = {
+        'white': RandomGGPPlayer('white', seed=99),
+        'black': RandomGGPPlayer('black', seed=100),
+    }
+    result = play_game(g, players, max_steps=2)   # tiny cap
+    # 2 steps almost certainly won't terminate.
+    assert result == {'white': 0, 'black': 0} or g.is_terminal()

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -87,11 +87,15 @@ def test_ai_difficulty_targets_configured():
         cfg = Game._AI_DIFFICULTY[key]
         assert isinstance(cfg['target'], int)
         assert cfg['mode'] in ('capped', 'exact')
-    # Easy is 'capped' (auto-tracks latest up to its cap); Medium/Hard are
-    # 'exact' (gated until their exact checkpoint exists).
+    # 2026-05-31: all three difficulties now 'capped' (auto-tracks
+    # latest checkpoint up to each cap). Targets: Easy=100, Medium=150,
+    # Hard=500.
     assert Game._AI_DIFFICULTY['easy']['mode'] == 'capped'
-    assert Game._AI_DIFFICULTY['medium']['mode'] == 'exact'
-    assert Game._AI_DIFFICULTY['hard']['mode'] == 'exact'
+    assert Game._AI_DIFFICULTY['medium']['mode'] == 'capped'
+    assert Game._AI_DIFFICULTY['hard']['mode'] == 'capped'
+    assert Game._AI_DIFFICULTY['easy']['target'] == 100
+    assert Game._AI_DIFFICULTY['medium']['target'] == 150
+    assert Game._AI_DIFFICULTY['hard']['target'] == 500
 
 
 def test_ai_checkpoint_available_for_non_ai_keys():


### PR DESCRIPTION
## Summary
- **GGP Game class** (`src/ggp/game.py`): `GGPGame` state-machine wrapper exposing `legal_moves` / `step` / `is_terminal` / `goal` / `roles`. Plus `RandomGGPPlayer` and `play_game` helper. Validated end-to-end on step 1.
- **Resolver speedup: 50s → 8ms per query (6000×)**. Root cause: cycle detection used variable-preserving hash, so the symmetric `file_adj` rule recursed via fresh renames and generated ~200 redundant proofs per call. Fixed with `_cycle_key` that collapses variables to a single placeholder.
- **Difficulty bumps** per user: Easy capped at 100, Medium capped at 150, Hard capped at 500. All three now `capped` mode (auto-track latest checkpoint).

## Test plan
- [x] 18 new tests for `GGPGame` + `RandomGGPPlayer` + `play_game` — all pass
- [x] Resolver speedup validated by manual profile (50.7s → 0.008s for `legal_moves` on step 1)
- [x] Total focused suite: 449 / 28 files / all pass / runs in 31s
- [ ] Manual: launch main.py, verify Easy mode picks the strongest checkpoint ≤ 100; Medium picks the strongest ≤ 150; Hard picks the strongest available

🤖 Generated with [Claude Code](https://claude.com/claude-code)