### PR TITLE
R3 rulebook explanation; GGP steps 3+4+5 validated; step 5 GDL bug fix

### DIFF
--- a/docs/RULEBOOK_v2_elaborated.md
+++ b/docs/RULEBOOK_v2_elaborated.md
@@ -214,6 +214,22 @@ The manipulation action counts as a turn and a player may only perform the actio
 
 The queen may only perform the manipulation action when in base form.
 
+#### **Why R3 forbids king / boulder / enemy base-form queen manipulation**
+
+Each exclusion in R3 plugs a distinct exploit. R3 is a one-clause rule rather than three separate qualified rules because the simpler form is easier to remember and just as airtight.
+
+**Enemy king.** Three independent exploit classes are blocked:
+
+1. *Forced immediate win.* The win condition is capturing both royals (king + royal queen). If the queen could manipulate the king, the manipulator picks the destination — and any destination on an enemy-attacked square is an instant-win pick. Even adding a "safe-square only" filter (parallel to bishop teleport-safety) doesn't plug the remaining two exploits below.
+2. *Forced friendly capture.* The v2 king is the only piece that may capture friendlies and the boulder. This is meant to be a *voluntary* tool — the king's owner decides when to sacrifice their own material. If the queen could manipulate the king, the manipulator could pick a destination holding a friendly piece of the king's owner. The king "moves as its owner would" and captures that friendly piece — handing free material to the manipulator.
+3. *Forced boulder capture.* Same shape: the manipulator picks the boulder's square; the king moves there and captures the boulder. The neutral piece is removed at no cost to the manipulator's side.
+
+Plugging all three would require a multi-part rule: "queen may manipulate the king only if (a) destination is enemy-safe AND (b) not holding a friendly piece AND (c) not the boulder." The blanket form "queen may not manipulate the king" is one short clause that achieves the same coverage.
+
+**Boulder.** The boulder is neutral — owned by neither side. Allowing the queen to manipulate it would let one side relocate a neutral piece purely for their own benefit, against the design intent that the boulder belongs to neither player. The neutral status also means "who owns it" is meaningless, so the standard manipulation rule's notion of "queen moves the enemy's piece" doesn't even apply cleanly.
+
+**Enemy base-form queen.** The opposing base-form queen is itself a manipulator. Allowing queens to manipulate queens would create chainable mutual-manipulation hell: A manipulates B's queen onto a square useful for A; B's queen on its next turn manipulates A's queen in retaliation; etc. The restriction keeps each queen's actions firmly in its owner's control. Note that *transformed* enemy queens (queen-as-rook, queen-as-bishop, queen-as-knight) ARE manipulable — the exclusion applies only to *base-form* queens. A transformed queen moves and captures as the chosen piece, so the manipulator is manipulating a "rook" or "knight" for that turn, not a manipulator.
+
 ---
 
 ### **Transformation Action**

--- a/docs/gdl/integrated.gdl
+++ b/docs/gdl/integrated.gdl
@@ -225,7 +225,6 @@
 (<= (enemy_can_reach ?mover ?tf ?tr) (opponent ?mover ?atk) (true (cell ?ef ?er ?atk ?piece)) (distinct ?piece bishop) (can_capture_to ?atk ?piece ?ef ?er ?tf ?tr))
 (<= (enemy_can_reach ?mover ?tf ?tr) (opponent ?mover ?atk) (true (cell ?ef ?er ?atk ?piece)) (distinct ?piece bishop) (can_move_to_only ?atk ?piece ?ef ?er ?tf ?tr))
 (<= (enemy_can_reach ?mover ?tf ?tr) (opponent ?mover ?atk) (jump_capturable_by_knight ?atk ?tf ?tr))
-(<= (legal ?player (move bishop ?ff ?fr ?tf ?tr)) (true (control ?player)) (true (cell ?ff ?fr ?player bishop)) (true (cell ?tf ?tr ?dummy_color ?dummy_piece)))
 (<= (file ?f) (file_adj ?f ?other))
 (<= (file h))
 (<= (rank ?r) (rank_adj ?r ?other))

--- a/docs/gdl/step5_add_bishop.gdl
+++ b/docs/gdl/step5_add_bishop.gdl
@@ -383,13 +383,10 @@
 ; Encoded via a "cells" iteration: enumerate every board cell, ask
 ; if it's a legal teleport destination.
 
-(<= (legal ?player (move bishop ?ff ?fr ?tf ?tr))
-    (true (control ?player))
-    (true (cell ?ff ?fr ?player bishop))
-    (true (cell ?tf ?tr ?dummy_color ?dummy_piece))    ; helper
-    ; (above clause never matches — bishop teleports to EMPTY squares,
-    ; so we use a different approach: enumerate via files + ranks.)
-    )
+; (Bishop teleport legal rule is below — earlier draft of this
+; file had a botched scaffold rule here that allowed ANY occupied
+; cell as a destination; removed 2026-05-31 when end-to-end
+; testing via the GGP exposed it as legal-move-set incorrect.)
 
 ; Real bishop teleport rule: enumerate destinations via (file, rank)
 ; pairs. We use file/rank enumeration helpers.

--- a/tests/test_ggp_step3_engine.py
+++ b/tests/test_ggp_step3_engine.py
@@ -1,0 +1,154 @@
+"""End-to-end: step-3 GDL (kings + queens + pawns + rooks) into
+the GGP.
+
+Step 3 board: 2 kings + 2 queens + 4 rooks + 16 pawns = 24 cells.
+First multi-segment move in the series (rook 2-segment via
+sweep_path + perpendicular).
+
+Expected legal moves for white at init:
+- 8 pawns × 1 forward each (sideways blocked by friendly pawns)
+- 2 rooks at c1 and f1, each with 1 legal length-zero move:
+  c1 → d1 (east, since b1 has friend queen, c2 has friend pawn)
+  f1 → e1 (west, since g1 has friend king, f2 has friend pawn)
+  Length-≥1 moves blocked because every perpendicular destination
+  is a friend square (d2, e2, b2 are friend pawns).
+- 1 king at g1: only g1 → h1 (other neighbours friend).
+- 1 queen at b1: only b1 → a1 (other neighbours friend).
+
+Total: 8 + 2 + 1 + 1 = 12 legal moves for white.
+
+This is the FIRST end-to-end multi-segment validation. Exercises
+the resolver's handling of:
+- The `sweep_path` recursive rule (base case + recursive case)
+- `(not (occupied ?))` inside a body
+- `perpendicular ?dir1 ?dir2` enumeration
+- Multiple matching rules with same predicate (`legal` rook
+  length-zero + length-≥1)
+- `(not (friend_at ?))` destination check that filters
+  segment-≥1 moves where the sweep destination is friend-occupied
+"""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from ggp.game import GGPGame, RandomGGPPlayer, play_game
+
+
+STEP3 = os.path.join(
+    os.path.dirname(__file__), '..', 'docs', 'gdl', 'step3_add_rook.gdl')
+
+
+def test_step3_loads_into_ggp():
+    g = GGPGame.from_file(STEP3)
+    assert g is not None
+
+
+def test_step3_initial_state_has_24_cells():
+    """2 kings + 2 queens + 4 rooks + 16 pawns = 24."""
+    g = GGPGame.from_file(STEP3)
+    cells = [f for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell']
+    assert len(cells) == 24
+
+
+def test_step3_rooks_at_rulebook_squares():
+    """White rooks at c1, f1; black rooks at c8, f8 (rotational
+    symmetric back rank per RULEBOOK_v2.md)."""
+    g = GGPGame.from_file(STEP3)
+    cells = {(f[1], f[2]): (f[3], f[4])
+             for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell'}
+    assert cells.get(('c', '1')) == ('white', 'rook')
+    assert cells.get(('f', '1')) == ('white', 'rook')
+    assert cells.get(('c', '8')) == ('black', 'rook')
+    assert cells.get(('f', '8')) == ('black', 'rook')
+
+
+def test_step3_white_has_12_legal_moves_at_init():
+    g = GGPGame.from_file(STEP3)
+    moves = g.legal_moves('white')
+    assert len(moves) == 12, (
+        f'expected 12 legal white moves; got {len(moves)}: {moves}')
+
+
+def test_step3_white_rook_c1_to_d1_legal():
+    """The one legal rook move from c1: east 1 square (length-
+    zero segment 2)."""
+    g = GGPGame.from_file(STEP3)
+    moves = g.legal_moves('white')
+    assert ('move', 'rook', 'c', '1', 'd', '1') in moves
+
+
+def test_step3_white_rook_c1_to_d2_blocked():
+    """Length-≥1 c1 → d1 → north to d2: blocked because d2 has
+    friend pawn."""
+    g = GGPGame.from_file(STEP3)
+    moves = g.legal_moves('white')
+    assert ('move', 'rook', 'c', '1', 'd', '2') not in moves
+
+
+def test_step3_white_rook_f1_to_e1_legal():
+    g = GGPGame.from_file(STEP3)
+    moves = g.legal_moves('white')
+    assert ('move', 'rook', 'f', '1', 'e', '1') in moves
+
+
+def test_step3_black_plays_noop_at_init():
+    g = GGPGame.from_file(STEP3)
+    assert g.legal_moves('black') == ['noop']
+
+
+def test_step3_step_applies_rook_move():
+    """Apply WR c1 → d1, verify state."""
+    g = GGPGame.from_file(STEP3)
+    g.step({
+        'white': ('move', 'rook', 'c', '1', 'd', '1'),
+        'black': 'noop',
+    })
+    cells = {(f[1], f[2]): (f[3], f[4])
+             for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell'}
+    assert cells.get(('d', '1')) == ('white', 'rook')
+    assert ('c', '1') not in cells
+
+
+def test_step3_after_pawn_advance_rook_can_use_segment_2():
+    """After white advances d2 → d3, rook at c1 can now do
+    c1 → d1 east + perpendicular north sweep_path to d2 (which
+    is now empty)."""
+    g = GGPGame.from_file(STEP3)
+    # White d2 → d3 (clears d2).
+    g.step({
+        'white': ('move', 'pawn', 'd', '2', 'd', '3'),
+        'black': 'noop',
+    })
+    # Now it's black's turn — they play noop equivalent.
+    g.step({
+        'white': 'noop',
+        'black': ('move', 'pawn', 'a', '7', 'a', '6'),
+    })
+    # White's turn again. Rook c1 → d2 (via c1→d1 east + north
+    # sweep to d2): d2 is empty now.
+    moves = g.legal_moves('white')
+    rook_moves = [m for m in moves
+                  if isinstance(m, tuple) and len(m) >= 2
+                  and m[1] == 'rook']
+    assert ('move', 'rook', 'c', '1', 'd', '2') in moves, (
+        f'after d2 cleared, rook c1 should reach d2 via '
+        f'segment-≥1; got rook moves: {rook_moves}')
+
+
+def test_step3_random_self_play_runs_without_error():
+    import random
+    random.seed(303)
+    g = GGPGame.from_file(STEP3)
+    players = {
+        'white': RandomGGPPlayer('white', seed=1),
+        'black': RandomGGPPlayer('black', seed=2),
+    }
+    result = play_game(g, players, max_steps=15)
+    assert 'white' in result
+    assert 'black' in result

--- a/tests/test_ggp_step4_engine.py
+++ b/tests/test_ggp_step4_engine.py
@@ -1,0 +1,138 @@
+"""End-to-end: step-4 GDL (+ knight radius-2) into the GGP.
+
+Step 4 board: 2 kings + 2 queens + 4 rooks + 4 knights + 16 pawns =
+28 cells. Adds the knight's chebyshev-≤2-but-not-1 16-square
+movement pattern (no jump-capture / no invuln yet — those are
+step 8).
+
+Expected white legal moves at init:
+- 8 pawns × 1 forward
+- 0 rooks (rook moves to d1/e1 blocked by friend knights now at
+  d1/e1; b1/c2/f2 still friend; other directions friend or off)
+- 10 knights (2 × 5 each: 1 forward 2-orthogonal + 2 diagonal +
+  2 L-shape via file_delta_1)
+- 1 queen + 1 king (same as step 3)
+
+Total = 20.
+
+This is the first end-to-end test of the resolver's handling of
+many disjoint rules (4 knight_step families, each branching on
+file/rank deltas), and the FIRST test where ROOKS are FULLY
+BLOCKED by new step-4 pieces — a useful "did my step change the
+behavior of an existing rule" regression check.
+"""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from ggp.game import GGPGame, RandomGGPPlayer, play_game
+
+
+STEP4 = os.path.join(
+    os.path.dirname(__file__), '..', 'docs', 'gdl', 'step4_add_knight.gdl')
+
+
+def test_step4_loads_into_ggp():
+    g = GGPGame.from_file(STEP4)
+    assert g is not None
+
+
+def test_step4_initial_state_has_28_cells():
+    g = GGPGame.from_file(STEP4)
+    cells = [f for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell']
+    assert len(cells) == 28
+
+
+def test_step4_knights_at_rulebook_squares():
+    """White knights at d1, e1; black knights at d8, e8."""
+    g = GGPGame.from_file(STEP4)
+    cells = {(f[1], f[2]): (f[3], f[4])
+             for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell'}
+    assert cells.get(('d', '1')) == ('white', 'knight')
+    assert cells.get(('e', '1')) == ('white', 'knight')
+    assert cells.get(('d', '8')) == ('black', 'knight')
+    assert cells.get(('e', '8')) == ('black', 'knight')
+
+
+def test_step4_white_has_20_legal_moves_at_init():
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    assert len(moves) == 20, (
+        f'expected 20 legal white moves; got {len(moves)}: {moves}')
+
+
+def test_step4_knight_d1_can_reach_d3():
+    """d1 → d3 is the 2-orthogonal (file_d, rank_delta_2) family."""
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    assert ('move', 'knight', 'd', '1', 'd', '3') in moves
+
+
+def test_step4_knight_d1_can_reach_b3():
+    """d1 → b3 is the 2-diagonal family."""
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    assert ('move', 'knight', 'd', '1', 'b', '3') in moves
+
+
+def test_step4_knight_d1_can_reach_c3():
+    """d1 → c3 is the L-shape (file_delta_1 c, rank_delta_2) family."""
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    assert ('move', 'knight', 'd', '1', 'c', '3') in moves
+
+
+def test_step4_knight_d1_cannot_reach_b1():
+    """d1 → b1 is 2-orthogonal same-rank, but b1 has friend queen."""
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    assert ('move', 'knight', 'd', '1', 'b', '1') not in moves
+
+
+def test_step4_rooks_have_no_legal_moves_at_init():
+    """With knights at d1/e1, rooks at c1/f1 have NO legal moves
+    (their previously-legal length-zero destinations are now
+    friend-occupied)."""
+    g = GGPGame.from_file(STEP4)
+    moves = g.legal_moves('white')
+    rook_moves = [m for m in moves
+                  if isinstance(m, tuple) and len(m) >= 2
+                  and m[1] == 'rook']
+    assert rook_moves == [], (
+        f'expected zero rook moves at init; got {rook_moves}')
+
+
+def test_step4_after_d_pawn_advance_knight_can_use_d3():
+    """After white d2 → d3, the knight at d1 can no longer reach
+    d3 (now friend-occupied). But d2 should be reachable by
+    knight d3-jump? No — knight moves chebyshev-2, not 1. So
+    d1 can still reach b3, f3, c3, e3."""
+    g = GGPGame.from_file(STEP4)
+    g.step({
+        'white': ('move', 'pawn', 'd', '2', 'd', '3'),
+        'black': 'noop',
+    })
+    g.step({
+        'white': 'noop',
+        'black': ('move', 'pawn', 'a', '7', 'a', '6'),
+    })
+    moves = g.legal_moves('white')
+    # d1 → d3 now blocked (d3 has friend pawn).
+    assert ('move', 'knight', 'd', '1', 'd', '3') not in moves
+    # b3, f3, c3, e3 still reachable.
+    assert ('move', 'knight', 'd', '1', 'b', '3') in moves
+
+
+def test_step4_random_self_play_runs_without_error():
+    g = GGPGame.from_file(STEP4)
+    players = {
+        'white': RandomGGPPlayer('white', seed=4),
+        'black': RandomGGPPlayer('black', seed=14),
+    }
+    result = play_game(g, players, max_steps=10)
+    assert 'white' in result

--- a/tests/test_ggp_step5_engine.py
+++ b/tests/test_ggp_step5_engine.py
@@ -1,0 +1,128 @@
+"""End-to-end: step-5 GDL (+ bishop teleport) into the GGP.
+
+Step 5 board: 2 kings + 2 queens + 4 rooks + 4 knights + 4 bishops +
+16 pawns = 32 cells. Bishops at a1, h1, a8, h8 (rulebook-correct
+corners per RULEBOOK_v2.md).
+
+Bishop adds TELEPORT MOVEMENT — to any empty square that isn't
+moved-to or captured-by any non-bishop enemy (with knight
+jump-capture included; enemy bishops excluded per the destination-
+vs-source rationale).
+
+Step 5 white legal-move counts (manual analysis):
+- 8 pawns × 1 forward
+- 0 rooks (still blocked by knights/pawns)
+- 10 knights (same 5 each as step 4)
+- 0 king (g1 surrounded by friends: f1=rook, h1=bishop, f2/g2/h2=pawn)
+- 0 queen (b1 surrounded by friends)
+- 48 bishop teleports (24 per bishop — each reaches empty +
+  not-enemy-attacked squares; some destinations excluded by enemy
+  pawn capture-to threat, enemy knight jump-capture, etc.)
+
+Total: 66.
+
+These tests exercise the resolver's handling of:
+- file + rank enumeration via the helper predicates
+- The enemy_can_reach predicate (queries every non-bishop enemy's
+  can_capture_to or can_move_to_only)
+- The jump_capturable_by_knight enumeration
+- The bishop's own-square exclusion via `(or (distinct ?ff ?tf)
+  (distinct ?fr ?tr))`
+"""
+
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from ggp.game import GGPGame, RandomGGPPlayer, play_game
+
+
+STEP5 = os.path.join(
+    os.path.dirname(__file__), '..', 'docs', 'gdl', 'step5_add_bishop.gdl')
+
+
+def test_step5_loads_into_ggp():
+    g = GGPGame.from_file(STEP5)
+    assert g is not None
+
+
+def test_step5_initial_state_has_32_cells():
+    g = GGPGame.from_file(STEP5)
+    cells = [f for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell']
+    assert len(cells) == 32
+
+
+def test_step5_bishops_at_rulebook_corners():
+    g = GGPGame.from_file(STEP5)
+    cells = {(f[1], f[2]): (f[3], f[4])
+             for f in g.state
+             if isinstance(f, tuple) and f[0] == 'cell'}
+    assert cells.get(('a', '1')) == ('white', 'bishop')
+    assert cells.get(('h', '1')) == ('white', 'bishop')
+    assert cells.get(('a', '8')) == ('black', 'bishop')
+    assert cells.get(('h', '8')) == ('black', 'bishop')
+
+
+def test_step5_white_has_66_legal_moves_at_init():
+    """The GGP returns exactly 66 legal white moves. 8 pawns + 10
+    knights + 48 bishop teleports. King + queen + rooks all blocked
+    by surrounding friends at init."""
+    g = GGPGame.from_file(STEP5)
+    moves = g.legal_moves('white')
+    assert len(moves) == 66, (
+        f'expected 66 legal white moves; got {len(moves)}')
+
+
+def test_step5_bishop_a1_has_many_teleports():
+    """The white bishop at a1 has many legitimate teleport
+    destinations (empty squares not reachable by any non-bishop
+    enemy)."""
+    g = GGPGame.from_file(STEP5)
+    moves = g.legal_moves('white')
+    bishop_a1 = [m for m in moves
+                 if isinstance(m, tuple) and len(m) >= 4
+                 and m[1] == 'bishop' and m[2] == 'a' and m[3] == '1']
+    assert len(bishop_a1) >= 20, (
+        f'bishop a1 should have many teleports; got {len(bishop_a1)}')
+
+
+def test_step5_bishop_cannot_teleport_to_friend_square():
+    """Bishop a1 → a2 is illegal — a2 has a friend pawn."""
+    g = GGPGame.from_file(STEP5)
+    moves = g.legal_moves('white')
+    assert ('move', 'bishop', 'a', '1', 'a', '2') not in moves
+
+
+def test_step5_bishop_cannot_teleport_to_own_square():
+    """Bishop a1 → a1 is a no-op and explicitly excluded by the
+    `(or (distinct ?ff ?tf) (distinct ?fr ?tr))` body conjunct."""
+    g = GGPGame.from_file(STEP5)
+    moves = g.legal_moves('white')
+    assert ('move', 'bishop', 'a', '1', 'a', '1') not in moves
+
+
+def test_step5_bishop_cannot_teleport_to_enemy_pawn_capture_square():
+    """A square that a black pawn could capture-to (forward-left or
+    forward-right from rank 7). For black: forward = rank 7 → 6.
+    So a black pawn at b7 can capture to a6, c6 — those are NOT
+    safe for white bishop teleport. Verify a bishop teleport to
+    such a square is excluded."""
+    g = GGPGame.from_file(STEP5)
+    moves = g.legal_moves('white')
+    # Black pawn at b7 can capture to a6 (forward-diagonal-left).
+    # White bishop teleport to a6 should be illegal.
+    assert ('move', 'bishop', 'a', '1', 'a', '6') not in moves
+    assert ('move', 'bishop', 'a', '1', 'c', '6') not in moves
+
+
+def test_step5_random_self_play_runs_without_error():
+    g = GGPGame.from_file(STEP5)
+    players = {
+        'white': RandomGGPPlayer('white', seed=5),
+        'black': RandomGGPPlayer('black', seed=55),
+    }
+    result = play_game(g, players, max_steps=5)
+    assert 'white' in result


### PR DESCRIPTION
## Summary
- **R3 rationale in elaborated rulebook**: per side-chat paste, added a "Why R3 forbids king / boulder / enemy base-form queen manipulation" subsection covering the 3 king-exploit classes (forced win / forced friendly capture / forced boulder capture), the boulder neutrality argument, and the queen chainable-manipulation argument.
- **GGP steps 3, 4, 5 validated end-to-end**: 11 + 11 + 9 = 31 new tests. Each step loads its GDL into the GGP, asserts exact legal-move count from initial position, spot-checks specific moves are legal / illegal, runs random self-play.
- **Step 5 GDL bug fix**: end-to-end testing exposed a leftover scaffold rule in `step5_add_bishop.gdl` that allowed ANY occupied cell as a bishop teleport destination (bishop could "teleport" to its own square, a friend pawn, an enemy piece). Deleted; rebuilt integrated.gdl. This is exactly the value the GGP provides — structural tests pass syntactically-valid-but-wrong rules; semantic testing catches them.

## Test plan
- [x] 31 new GGP step-3/4/5 tests — all pass
- [x] Total focused suite: 500 / 36 files / all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)