### PR TITLE
Bump Easy + Medium difficulty caps to 500 (match Hard)

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -417,13 +417,16 @@ class Game:
         # the exact target iteration; otherwise the option is disabled in
         # the mode menu.
         #
-        # 2026-06-01 bump: training reached iter 139/500 and the
-        # network plays substantially stronger than at earlier caps.
-        # User raised Easy → 200, Medium → 300, Hard remains 500.
-        # All three still capped (auto-track up to their respective
-        # caps as new checkpoints land).
-        'easy':   {'target': 200, 'mode': 'capped'},
-        'medium': {'target': 300, 'mode': 'capped'},
+        # 2026-06-02 bump: at iter 200+ the network is STILL too
+        # easy in user testing. Bumping Easy + Medium to 500 (same
+        # as Hard) so all three auto-track the latest available
+        # checkpoint. This effectively collapses the three modes
+        # into one until a different difficulty knob (action-
+        # selection temperature, explicit blunder rate) is added —
+        # iteration depth alone has stopped being a meaningful
+        # difficulty discriminator at this training depth.
+        'easy':   {'target': 500, 'mode': 'capped'},
+        'medium': {'target': 500, 'mode': 'capped'},
         'hard':   {'target': 500, 'mode': 'capped'},
     }
 

--- a/tests/test_mode_selection.py
+++ b/tests/test_mode_selection.py
@@ -93,8 +93,8 @@ def test_ai_difficulty_targets_configured():
     assert Game._AI_DIFFICULTY['easy']['mode'] == 'capped'
     assert Game._AI_DIFFICULTY['medium']['mode'] == 'capped'
     assert Game._AI_DIFFICULTY['hard']['mode'] == 'capped'
-    assert Game._AI_DIFFICULTY['easy']['target'] == 200
-    assert Game._AI_DIFFICULTY['medium']['target'] == 300
+    assert Game._AI_DIFFICULTY['easy']['target'] == 500
+    assert Game._AI_DIFFICULTY['medium']['target'] == 500
     assert Game._AI_DIFFICULTY['hard']['target'] == 500
 
 


### PR DESCRIPTION
## Summary
User: "iter 200 is still too easy". All three difficulty modes now cap at 500 (still 'capped' mode = auto-track latest available checkpoint).

This collapses all three modes into one effective checkpoint for now. Iteration depth has stopped being a meaningful difficulty discriminator at this training depth. Next step (deferred) is a different difficulty knob — action-selection temperature, explicit blunder rate, or MCTS lookahead budget.

## Test plan
- [x] test_mode_selection.py updated and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)