### PR TITLE
Fix 19 stale-API failures in test_manipulation_variants

### DIFF
--- a/tests/test_manipulation_variants.py
+++ b/tests/test_manipulation_variants.py
@@ -422,13 +422,12 @@ class TestFreezeManipulation(unittest.TestCase):
                 return
 
             turn = random.choice(turns)
-            jc = None
-            pc = None
-            if turn.jump_capture_targets:
-                jc = random.choice(list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                pc = random.choice(turn.promotion_options)
-            engine.execute_turn(turn, jc, pc)
+            # Since the PR #86 engine refactor every Turn is FULLY
+            # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+            # and promotion sub-choice as its own Turn, so a uniform
+            # random choice over `turns` already samples every sub-choice
+            # combination, and execute_turn takes no sub-choice args.
+            engine.execute_turn(turn)
 
         self.skipTest("Could not find manipulable transformed queen")
 
@@ -776,13 +775,12 @@ class TestFreezeInvulnerableManipulation(unittest.TestCase):
                 return
 
             turn = random.choice(turns)
-            jc = None
-            pc = None
-            if turn.jump_capture_targets:
-                jc = random.choice(list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                pc = random.choice(turn.promotion_options)
-            engine.execute_turn(turn, jc, pc)
+            # Since the PR #86 engine refactor every Turn is FULLY
+            # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+            # and promotion sub-choice as its own Turn, so a uniform
+            # random choice over `turns` already samples every sub-choice
+            # combination, and execute_turn takes no sub-choice args.
+            engine.execute_turn(turn)
 
         self.skipTest("Could not find manipulable transformed queen")
 
@@ -1188,13 +1186,12 @@ class TestFreezeNoRepeatManipulation(unittest.TestCase):
                 return
 
             turn = random.choice(turns)
-            jc = None
-            pc = None
-            if turn.jump_capture_targets:
-                jc = random.choice(list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                pc = random.choice(turn.promotion_options)
-            engine.execute_turn(turn, jc, pc)
+            # Since the PR #86 engine refactor every Turn is FULLY
+            # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+            # and promotion sub-choice as its own Turn, so a uniform
+            # random choice over `turns` already samples every sub-choice
+            # combination, and execute_turn takes no sub-choice args.
+            engine.execute_turn(turn)
 
         self.skipTest("Could not find manipulable transformed queen")
 
@@ -1375,13 +1372,12 @@ class TestManipulationRestrictionsAllVariants(unittest.TestCase):
             turn = random.choice(turns)
             if turn.turn_type == 'manipulation':
                 manipulation_count += 1
-            jc = None
-            pc = None
-            if turn.jump_capture_targets:
-                jc = random.choice(list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                pc = random.choice(turn.promotion_options)
-            engine.execute_turn(turn, jc, pc)
+            # Since the PR #86 engine refactor every Turn is FULLY
+            # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+            # and promotion sub-choice as its own Turn, so a uniform
+            # random choice over `turns` already samples every sub-choice
+            # combination, and execute_turn takes no sub-choice args.
+            engine.execute_turn(turn)
 
         # Should have had some manipulations in 200 turns
         # (not guaranteed, but likely with seed 42)
@@ -1429,13 +1425,12 @@ class TestFullGameAllVariants(unittest.TestCase):
             turn = random.choice(turns)
             if turn.turn_type == 'manipulation':
                 manipulations += 1
-            jc = None
-            pc = None
-            if turn.jump_capture_targets:
-                jc = random.choice(list(turn.jump_capture_targets) + [None])
-            if turn.promotion_options:
-                pc = random.choice(turn.promotion_options)
-            engine.execute_turn(turn, jc, pc)
+            # Since the PR #86 engine refactor every Turn is FULLY
+            # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+            # and promotion sub-choice as its own Turn, so a uniform
+            # random choice over `turns` already samples every sub-choice
+            # combination, and execute_turn takes no sub-choice args.
+            engine.execute_turn(turn)
             turns_played += 1
 
         return {
@@ -1558,13 +1553,12 @@ class TestGameRecordVariants(unittest.TestCase):
                 if not turns:
                     break
                 turn = random.choice(turns)
-                jc = None
-                pc = None
-                if turn.jump_capture_targets:
-                    jc = random.choice(list(turn.jump_capture_targets) + [None])
-                if turn.promotion_options:
-                    pc = random.choice(turn.promotion_options)
-                engine.execute_turn(turn, jc, pc)
+                # Since the PR #86 engine refactor every Turn is FULLY
+                # SPECIFIED: get_all_legal_turns enumerates each jump-capture
+                # and promotion sub-choice as its own Turn, so a uniform
+                # random choice over `turns` already samples every sub-choice
+                # combination, and execute_turn takes no sub-choice args.
+                engine.execute_turn(turn)
 
             record = engine.get_game_record()
             record_dict = record.to_dict()


### PR DESCRIPTION
## Summary
All 19 failures shared one root cause: six copies of a pre-PR-#86 random-playout block referencing `turn.jump_capture_targets` / `turn.promotion_options` and calling 3-arg `execute_turn`. Since the fully-specified-Turn refactor, every sub-choice combination is its own Turn and `execute_turn(turn)` takes no args — so each block reduces to a plain `engine.execute_turn(turn)`.

Test-only change (no `src/` edits). Same staleness family as PR #117.

## Test plan
- [x] `tests/test_manipulation_variants.py` alone with `--cache-clear`: **106 passed, 3 skipped, 0 failed** (was 19 failed / 90 passed; skips are pre-existing legitimate fallbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)