### PR TITLE
Fix stale manipulation-repetition test: seed the hash the simulation computes

### DIFF
--- a/docs/design-notes/MEMORY.md
+++ b/docs/design-notes/MEMORY.md
@@ -42,7 +42,7 @@ Then `git log --oneline -20` for recent design context (commit bodies contain ra
 
 - [Helper semantics: `has_enemy_piece` vs `has_capturable_enemy_piece`](project_helper_semantics.md) — broad-vs-narrow Square helpers; using the wrong one has caused several bugs.
 - [V2 knight redesign](project_v2_knight_redesign.md) — radius-2 movement, jump-capture, invulnerability with adjacent-enemy condition.
-- [State hash design](project_state_hash_design.md) — repetition is positional + invulnerability only; deliberately excludes last-move history.
+- [State hash design](project_state_hash_design.md) — hash = full legal-move-determining state (2026-05-26 redesign, PRs #77–#79): positions + queen markers + manipulation freeze + invulnerability + derived `moved_last_turn`/`reactive_armed` flags; literal last-move coords excluded. NOT "positional only" — do not re-revert.
 - [Piece strategic dynamics](project_piece_strategic_dynamics.md) — **READ FIRST for any tiny-endgame analysis.** Bishop is an ACTIVE piece (global teleport + pin power). Queens lock down via mutual bishop pin. Queens escape via bishop-form teleport when opponent's coverage < 64. Action stalling avoids reactive capture.
 - [Tiny endgame analysis methodology](project_tiny_endgame_analysis_methodology.md) — **READ FIRST for any tiny-endgame analysis.** Operational stall definition (assume repetition rule absent). Required analysis steps. Anti-pattern checklist of mistakes to avoid.
 - [Tiny endgame status](project_tiny_endgame_status.md) — current rulebook version + proposed variants (cancel-queens, Pattern A/B/C) under active discussion. Includes corrected strategic facts (K+Q vs K+R+R+N is drift-prone).

--- a/docs/key-rule-differences.md
+++ b/docs/key-rule-differences.md
@@ -186,8 +186,25 @@ A neutral piece, not present in standard chess.
 ### Repetition rule
 
 - A board state cannot occur 3 times during the game.
-- **State hash includes**: piece positions, boulder state (position + cooldown + no-return last-square memory), queen markers (is_royal / is_transformed / current form), whose turn, and currently-invulnerable pieces.
-- **State hash does NOT include**: last-move history. Repetition is a purely positional rule.
+- **Governing principle (2026-05-26 redesign):** the state captures everything
+  that determines the legal-move set at the current position, EXCEPT the
+  repetition rule's own state-history counts and the tiny endgame rule's
+  distance counts (game-level tracking, not properties of the position).
+- **State hash includes**: piece positions/types/colors; queen markers
+  (is_royal / is_transformed / current form); per-piece **manipulation
+  freeze** (`moved_by_queen`, Restriction 1); currently-invulnerable
+  pieces; two DERIVED last-move flags — `moved_last_turn` (this piece
+  moved on the immediately preceding turn AND an enemy base-form queen has
+  LoS to it [Restriction 2] OR an enemy knight is at chebyshev-1
+  [jump-capture eligible]) and `reactive_armed` (bishops/queens-as-bishop
+  only: enemy of the moved piece AND unblocked diagonal LoS to the move's
+  INITIAL square); boulder state (position + cooldown + no-return memory,
+  the memory included only when it actually restricts a legal boulder
+  move); and whose turn it is.
+- **State hash does NOT include**: the literal `last_move` coordinates
+  (last-move relevance is captured entirely by the derived flags above —
+  same flags ⇒ same legal moves ⇒ same hash), the repetition rule's own
+  counts, or the tiny endgame distance counts.
 - If all legal turns produce a 3rd repetition, the player loses.
 
 ### Tiny Endgame Rule
@@ -283,10 +300,10 @@ These are mistakes I (Claude) have made repeatedly. Re-read this list before any
 - ❌ **Knights move in L-shape only (8 destinations).** No — radius-2 pattern, 16 destinations.
 - ❌ **Pawn promotion is always to a base-form queen.** No — promoting player can pick any queen form (base or transformed rook/bishop/knight, with the standard transformation capture-availability constraint).
 - ❌ **Invulnerability blocks reactive captures mid-move (interrupting the opponent's turn).** No — reactive captures fire on the bishop's NEXT turn. The opponent's turn is never interrupted; reactive captures are deferred to the bishop's own turn.
-- ❌ **Last-move tracking is in the state hash.** No — removed. State hash is positional + invulnerability only.
+- ❌ **The repetition state hash is "positional + invulnerability only".** Stale — that was the 2026-05-13 design. Since the 2026-05-26 redesign (PRs #77–#79) the hash is the full legal-move-determining state: it also includes the manipulation freeze flag (`moved_by_queen`) and the derived last-move flags `moved_last_turn` / `reactive_armed`. Do not re-revert to the positional-only framing.
 - ❌ **The "manipulated piece moved on preceding turn" restriction applies even after intervening actions.** No — only SPATIAL moves on the immediately preceding turn count. A transformation in between clears the restriction.
 - ❌ **The king's special capture overrides invulnerability.** No — invulnerability is universal protection; even friendly or enemy kings cannot capture invulnerable pieces.
-- ❌ **The repetition rule's state includes which piece just moved.** No (after the 2026-05-13 redesign) — only positional + invulnerability.
+- ❌ **The repetition rule's state includes the literal last-move squares.** No — the literal `last_move.initial` / `last_move.final` coordinates are never hashed. But last-move RELEVANCE is hashed via the derived flags (`moved_last_turn`, `reactive_armed`): two states differing only in a way no rule consults hash identically; two states where a rule is armed differently hash differently.
 - ❌ **A manipulated knight that jumps gets invulnerability that protects it on the opponent's turn.** No — manipulated knight invulnerability is cleared at the start of the knight player's own next turn, before any opportunity to use it.
 - ❌ **A knight jumping over ANY piece + adjacent enemy at landing grants invulnerability.** No — the jumped piece must be **friendly or the boulder**. Jumping over an enemy never grants invulnerability (closes the perpetual-invuln-via-enemy-territory-leap loophole). This was the rule prior to the refinement but no longer.
 - ❌ **`has_capturable_enemy_piece` is the right helper for engagement checks.** No — that filters invulnerable enemies. Use `has_enemy_piece` for presence/engagement/threat/blocker checks.

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -4165,13 +4165,30 @@ class TestRepetitionRule(unittest.TestCase):
 
         # Compute the state that would result from black rook moving e4→e3
         # via manipulation, then record it twice to simulate two previous
-        # occurrences
+        # occurrences. The seeded hash must mirror EVERYTHING
+        # would_cause_repetition simulates for a manipulation move
+        # (PRs #103/#104): the move itself, the Restriction-1 freeze
+        # (moved_by_queen=True on the manipulated piece), and board.move's
+        # last_move/last_move_turn_number update + Game.next_turn's
+        # turn_number increment — the latter drive the hash's derived
+        # moved_last_turn flag (True here: the white base-form queen on e1
+        # has file LoS to e3).
+        manip_move = Move(Square(*sq("e4")), Square(*sq("e3")))
         board.squares[sq("e4")[0]][sq("e4")[1]].piece = None
         place(board, "e3", black_rook)
-        # Simulate boulder decrement (no boulder = no-op)
+        black_rook.moved_by_queen = True
+        board.last_move = manip_move
+        board.last_move_turn_number = board.turn_number
+        board.turn_number += 1
+        # Simulate boulder decrement (no boulder = no-op) and end_turn's
+        # clear_invulnerable_for_color('black') (nothing invulnerable = no-op)
         state_after = board.get_state_hash('black')
         board.state_history[state_after] = 2
         # Restore
+        board.turn_number -= 1
+        board.last_move = None
+        board.last_move_turn_number = None
+        black_rook.moved_by_queen = False
         board.squares[sq("e3")[0]][sq("e3")[1]].piece = None
         place(board, "e4", black_rook)
 


### PR DESCRIPTION
Closes #122.

## Problem

`TestRepetitionRule::test_manipulation_move_blocked_by_repetition` fails on main. It seeds `state_history` with a hash computed by only moving the rook e4→e3 — stale relative to the PR #103/#104 fixes, which make `would_cause_repetition` also simulate:

- `moved_by_queen=True` on the manipulated piece (Restriction 1 freeze, PR #103), and
- the `last_move` / `last_move_turn_number` / `turn_number` updates (PR #104), which flip the hash's derived `moved_last_turn` flag to True here (white base-form queen on e1 has file LoS to e3).

Two mismatched hash fields → the simulated hash never matches the seeded one → the filter never fires.

## Fix

- **`tests/test_piece_movement.py`**: the test now mirrors the full simulation when seeding the twice-seen state (apply move, set the freeze flag, set last-move bookkeeping and bump `turn_number`, hash for `'black'`; boulder-decrement and clear-invulnerability steps are no-ops in this position), then restores everything. Assertion unchanged: e3 must be filtered as a third repetition; the other 27 manipulation destinations survive.
- **`docs/key-rule-differences.md`**: the Repetition section + two Common Misconceptions bullets still described the 2026-05-13 "purely positional + invulnerability" hash. Synced with `RULEBOOK_v2.md`'s 2026-05-26 legal-move-determining-state design (PRs #77–#79) — the same staleness family that produced this test failure.
- **`docs/design-notes/MEMORY.md`**: fixed the same stale state-hash summary line in the memory-mirror index.

## Testing

`.venv/bin/python -m pytest tests/test_piece_movement.py --cache-clear` → **349 passed** (file run alone per the mocked-pygame test-ordering caveat in CLAUDE.md).

Note: no merge conflict with #121/`claude/fix-transform-highlight` work — it touches `TestQueen` (~line 1187); this PR touches `TestRepetitionRule` (~line 4165).

🤖 Generated with [Claude Code](https://claude.com/claude-code)