### PR TITLE
Allow undo/redo from the CvC win screen; halt autoplay while stepping

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -484,6 +484,16 @@ class Game:
         # overlay is rendered by show_reset_confirm; main.py treats it like
         # any other open menu (no interactions while up).
         self.reset_confirm_pending = False
+        # CvC autoplay halt (2026-07-20 win-screen undo fix). Set when
+        # the user undoes/redoes from the WIN SCREEN in CvC mode: the
+        # first undo clears the winner, and without this flag autoplay
+        # would instantly replay over the undone position (and the
+        # pause-screen undo gating would re-close). While True,
+        # is_autoplay_paused() holds the AIs and keeps U/Y enabled so
+        # the user can step through the finished game. Esc (bottom of
+        # the cascade) resumes autoplay; mode changes, reset, and
+        # loading a game clear it.
+        self.cvc_autoplay_halted = False
         # Pause / PGN-FEN dialog. Opened via 'P', or implicitly when
         # undo/redo is pressed during CvC autoplay (the user-spec'd
         # "paused screen for undo/redo that doesn't interfere with CvC
@@ -1428,7 +1438,8 @@ class Game:
 
     def _handle_escape(self):
         """Esc cascade. Closes ONE thing per press, in priority order:
-        jump-capture > mode menu > pgn dialog > reset confirm > no-op."""
+        jump-capture > mode menu > pgn dialog > reset confirm >
+        CvC autoplay-halt resume > no-op."""
         if self.jump_capture_targets is not None:
             self.cancel_jump_capture()
             return
@@ -1440,6 +1451,10 @@ class Game:
             return
         if self.reset_confirm_pending:
             self.reset_confirm_pending = False
+            return
+        if self.cvc_autoplay_halted:
+            # Resume CvC autoplay after win-screen undo stepping.
+            self.cvc_autoplay_halted = False
             return
 
     def _handle_mode_menu_toggle(self):
@@ -1471,17 +1486,30 @@ class Game:
         reset confirm). The previous "auto-open the dialog on U"
         behaviour is reverted — the user must explicitly open a
         paused state first. In HvH / HvAI undo always works.
+
+        Win-screen exception (2026-07-20): when a winner is set, the
+        game is over and no autoplay is running, so the gating does
+        not apply — U works directly on the win screen (live or a
+        loaded finished save). The undo clears the winner, so the
+        first one also sets `cvc_autoplay_halted` to keep the AIs
+        from replaying over the undone position and to keep U/Y
+        enabled for further stepping. Esc resumes autoplay.
         """
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            return  # CvC + no paused state -> U is a no-op
+            if self.winner is None:
+                return  # CvC mid-game + no paused state -> U is a no-op
+            self.cvc_autoplay_halted = True
         self.undo()
 
     def _handle_redo_key(self):
-        """Y as redo: same CvC gating as undo above."""
+        """Y as redo: same CvC gating + win-screen exception as undo
+        above."""
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            return
+            if self.winner is None:
+                return
+            self.cvc_autoplay_halted = True
         self.redo()
 
     # ---- serialization / save-load --------------------------------------
@@ -1648,6 +1676,7 @@ class Game:
         self.mode_menu = None
         self.mode_menu_rects = []
         self.reset_confirm_pending = False
+        self.cvc_autoplay_halted = False
         if self.dragger is not None:
             self.dragger.dragging = False
             self.dragger.piece = None
@@ -1783,6 +1812,10 @@ class Game:
                     f"Unknown black_player: {black_player!r}; "
                     f"valid: {sorted(valid_players)}")
             self.black_player = black_player
+        # A mode change is an explicit "play on" instruction — clear any
+        # win-screen undo halt so the new configuration isn't silently
+        # blocked from moving.
+        self.cvc_autoplay_halted = False
         self._refresh_ai()
 
     def _refresh_ai(self):
@@ -1972,8 +2005,12 @@ class Game:
         """True iff CvC autoplay should hold off. Same as
         is_any_menu_open in current scope, but exposed as a separate
         predicate so callers reading "is autoplay paused?" don't have
-        to think about whether menus block autoplay (they always do)."""
-        return self.is_any_menu_open()
+        to think about whether menus block autoplay (they always do).
+
+        Additionally honors `cvc_autoplay_halted` (win-screen undo:
+        after undoing a finished CvC game, the AIs must not instantly
+        replay over the undone position; Esc resumes)."""
+        return self.is_any_menu_open() or self.cvc_autoplay_halted
 
     def show_reset_confirm(self, surface):
         """Render the reset-game confirmation overlay if pending."""

--- a/tests/test_winscreen_undo.py
+++ b/tests/test_winscreen_undo.py
@@ -1,0 +1,184 @@
+"""Tests for undo/redo from the win screen in CvC mode
+(user report 2026-07-20: "I have a previously saved game but now I
+cannot undo from the win screen").
+
+ROOT CAUSE: the CvC undo/redo gating (2026-05-30 spec: undo only
+during the pause screen, mode menu, or reset confirm) did not treat
+the win screen as a paused state — `_handle_undo_key` dropped U
+whenever mode == computer_vs_computer with no menu open, even after
+the game had ended (live win screen AND loaded finished saves).
+
+FIX: when a winner is set, the game is over and no autoplay is
+running, so U/Y are allowed. The first such undo sets
+`cvc_autoplay_halted`, which `is_autoplay_paused()` honors — so
+(a) CvC autoplay does not instantly replay over the undone position
+once the winner is cleared, and (b) subsequent U/Y presses keep
+working while stepping through the finished game. Esc (bottom of
+the cascade) resumes autoplay; mode changes, reset, and loading a
+game clear the flag. Mid-game CvC gating is unchanged.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import pytest
+
+from game import Game
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+
+
+def _cvc_game_over(n_turns=4):
+    """CvC game with a few real turns of history and a declared
+    winner (as main.py declares one after a decisive capture)."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    for _ in range(n_turns):
+        assert g.current_ai_controller().take_turn(g)
+    g.winner = 'white'
+    return g
+
+
+# ---- the reported bug ----------------------------------------------------
+
+def test_undo_from_cvc_win_screen():
+    g = _cvc_game_over()
+    depth = len(g._history)
+    result = g.handle_keydown(pygame.K_u)
+    assert result['consumed']
+    assert g.winner is None, (
+        'U on the CvC win screen must undo (the game is over — the '
+        'pause-screen gating must not apply)')
+    assert len(g._history) < depth
+    # Autoplay is halted so the AIs don't instantly replay over the
+    # undone position.
+    assert g.cvc_autoplay_halted is True
+    assert g.is_autoplay_paused() is True
+
+
+def test_undo_from_loaded_cvc_save_win_screen():
+    """The user's exact scenario: load a finished CvC save, press U."""
+    src = _cvc_game_over()
+    text = src.serialize_to_text()
+    g = Game()
+    assert g.load_from_text(text) is True
+    assert g.mode == 'computer_vs_computer' and g.winner == 'white'
+    assert g.cvc_autoplay_halted is False   # load resets UI state
+    depth = len(g._history)
+    g.handle_keydown(pygame.K_u)
+    assert g.winner is None
+    assert len(g._history) < depth
+
+
+def test_subsequent_undo_redo_keep_working_while_halted():
+    """After the first win-screen undo clears the winner, the halt
+    flag keeps the gate open for further stepping."""
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    assert g.winner is None
+    depth = len(g._history)
+    g.handle_keydown(pygame.K_u)            # step further back
+    assert len(g._history) < depth
+    g.handle_keydown(pygame.K_y)            # and redo forward again
+    assert len(g._history) == depth
+
+
+# ---- autoplay resume / flag lifecycle ------------------------------------
+
+def test_escape_resumes_cvc_autoplay():
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    assert g.is_autoplay_paused() is True
+    g._handle_escape()
+    assert g.cvc_autoplay_halted is False
+    assert g.is_autoplay_paused() is False
+
+
+def test_escape_closes_menus_before_resuming_autoplay():
+    """Esc cascade: one thing per press — an open paused screen
+    closes first; the halt clears on the NEXT press."""
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    g.open_pgn_dialog()
+    g._handle_escape()
+    assert g.pgn_dialog_open is False
+    assert g.cvc_autoplay_halted is True
+    g._handle_escape()
+    assert g.cvc_autoplay_halted is False
+
+
+def test_mode_change_clears_halt():
+    """Switching a side to human must clear the halt so HvAI/HvH
+    autoplay is not silently blocked by a stale flag."""
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    assert g.cvc_autoplay_halted is True
+    g.apply_mode_selection(white_player='human')
+    assert g.cvc_autoplay_halted is False
+
+
+def test_load_clears_halt():
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    assert g.cvc_autoplay_halted is True
+    text = _cvc_game_over().serialize_to_text()
+    assert g.load_from_text(text) is True
+    assert g.cvc_autoplay_halted is False
+
+
+def test_reset_clears_halt():
+    g = _cvc_game_over()
+    g.handle_keydown(pygame.K_u)
+    assert g.cvc_autoplay_halted is True
+    g.reset()
+    assert g.cvc_autoplay_halted is False
+
+
+# ---- the original mid-game gating is preserved ---------------------------
+
+def test_midgame_cvc_undo_still_gated():
+    """2026-05-30 spec unchanged: during live CvC play (no winner,
+    no paused screen), U remains a no-op."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    for _ in range(2):
+        assert g.current_ai_controller().take_turn(g)
+    depth = len(g._history)
+    g.handle_keydown(pygame.K_u)
+    assert len(g._history) == depth
+    assert g.cvc_autoplay_halted is False
+
+
+def test_hvh_win_screen_undo_unaffected():
+    g = Game()
+    ai = Game()
+    ai.apply_mode_selection(white_player='random', black_player='random')
+    for _ in range(2):
+        assert ai.current_ai_controller().take_turn(ai)
+    ai.winner = 'white'
+    text = ai.serialize_to_text()
+    assert g.load_from_text(text) is True
+    g.apply_mode_selection(white_player='human', black_player='human')
+    depth = len(g._history)
+    g.handle_keydown(pygame.K_u)
+    assert g.winner is None
+    assert len(g._history) < depth


### PR DESCRIPTION
Closes #126. User report: a previously saved (computer-vs-computer) game shows its win screen after loading, but pressing U does nothing.

**Root cause:** the CvC undo/redo gating (2026-05-30 spec: undo only during pause screens) didn't treat the win screen as a paused state — `_handle_undo_key`/`_handle_redo_key` dropped U/Y in CvC with no menu open, even after the game had ended. Reproduced on both a live CvC win screen and a loaded finished CvC save; HvH/HvAI saves were unaffected.

**Fix:** a bare gate exception wouldn't suffice — the first undo clears the winner, so autoplay would replay over the undone position ~600 ms later and the gate would re-close for the next U/Y. So:

- U/Y with a winner set in CvC now performs the undo/redo and sets a new `cvc_autoplay_halted` flag.
- `is_autoplay_paused()` honors the flag: the AIs hold (main.py already consults this predicate — no main.py changes) and U/Y stay enabled for stepping through the finished game.
- Esc resumes autoplay (new bottom entry in the escape cascade, after reset-confirm — open paused screens still close first, one thing per press).
- The halt is UI state: cleared by mode changes, loads, and reset; never serialized. Mid-game CvC gating is unchanged.

**Tests** (written first, red → green): `tests/test_winscreen_undo.py` (10 tests) covering the reported loaded-save scenario, live win-screen undo, continued stepping, Esc resume + cascade priority, flag lifecycle, and preserved mid-game gating. Regression suites: keydown dispatch, cvc keys/gating, cvc mode, undo/redo, winscreen, pause/pgn, mode selection, reset confirm, save compression (266 passed), `test_piece_movement.py` alone (349 passed), all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)