### PR TITLE
Extend the CvC autoplay hold to mid-game undo/redo (Esc resumes)

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -484,15 +484,15 @@ class Game:
         # overlay is rendered by show_reset_confirm; main.py treats it like
         # any other open menu (no interactions while up).
         self.reset_confirm_pending = False
-        # CvC autoplay halt (2026-07-20 win-screen undo fix). Set when
-        # the user undoes/redoes from the WIN SCREEN in CvC mode: the
-        # first undo clears the winner, and without this flag autoplay
-        # would instantly replay over the undone position (and the
+        # CvC autoplay halt (2026-07-20). Set when the user undoes/
+        # redoes in CvC mode with no paused screen open — mid-game or
+        # on the win screen: without this flag autoplay would
+        # instantly replay over the undone position (and the
         # pause-screen undo gating would re-close). While True,
         # is_autoplay_paused() holds the AIs and keeps U/Y enabled so
-        # the user can step through the finished game. Esc (bottom of
-        # the cascade) resumes autoplay; mode changes, reset, and
-        # loading a game clear it.
+        # the user can step through the game. Esc (bottom of the
+        # cascade) resumes autoplay; mode changes, reset, and loading
+        # a game clear it.
         self.cvc_autoplay_halted = False
         # Pause / PGN-FEN dialog. Opened via 'P', or implicitly when
         # undo/redo is pressed during CvC autoplay (the user-spec'd
@@ -1502,34 +1502,27 @@ class Game:
     def _handle_undo_key(self):
         """U: undo.
 
-        2026-05-30 user spec change: in CvC mode, undo is DISABLED
-        unless a paused state is open (pgn dialog, mode menu, or
-        reset confirm). The previous "auto-open the dialog on U"
-        behaviour is reverted — the user must explicitly open a
-        paused state first. In HvH / HvAI undo always works.
-
-        Win-screen exception (2026-07-20): when a winner is set, the
-        game is over and no autoplay is running, so the gating does
-        not apply — U works directly on the win screen (live or a
-        loaded finished save). The undo clears the winner, so the
-        first one also sets `cvc_autoplay_halted` to keep the AIs
-        from replaying over the undone position and to keep U/Y
-        enabled for further stepping. Esc resumes autoplay.
+        Spec revision 2026-07-20 (supersedes the 2026-05-30 "no-op
+        unless a paused screen is open" rule): in CvC mode, U with no
+        paused screen open — mid-game OR on the win screen — performs
+        the undo and sets `cvc_autoplay_halted`, so the AIs don't
+        replay over the undone position and U/Y stay enabled for
+        further stepping. Esc resumes autoplay. Undoing with a paused
+        screen open (pgn dialog / mode menu / reset confirm) still
+        works as before and does not set the halt — closing the
+        screen resumes autoplay as always. U still never auto-opens
+        the pgn dialog (that pre-2026-05-30 design remains reverted).
+        In HvH / HvAI undo always works.
         """
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            if self.winner is None:
-                return  # CvC mid-game + no paused state -> U is a no-op
             self.cvc_autoplay_halted = True
         self.undo()
 
     def _handle_redo_key(self):
-        """Y as redo: same CvC gating + win-screen exception as undo
-        above."""
+        """Y as redo: same CvC autoplay-halt behavior as undo above."""
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            if self.winner is None:
-                return
             self.cvc_autoplay_halted = True
         self.redo()
 
@@ -2028,8 +2021,8 @@ class Game:
         predicate so callers reading "is autoplay paused?" don't have
         to think about whether menus block autoplay (they always do).
 
-        Additionally honors `cvc_autoplay_halted` (win-screen undo:
-        after undoing a finished CvC game, the AIs must not instantly
+        Additionally honors `cvc_autoplay_halted` (CvC undo/redo,
+        mid-game or on the win screen: the AIs must not instantly
         replay over the undone position; Esc resumes)."""
         return self.is_any_menu_open() or self.cvc_autoplay_halted
 

--- a/tests/test_cvc_keys_and_undo_gating.py
+++ b/tests/test_cvc_keys_and_undo_gating.py
@@ -117,10 +117,14 @@ def test_r_opens_reset_confirm_during_cvc():
 # Section 2 — NEW undo/redo gating: blocked in CvC unless paused state open
 # ===========================================================================
 
-def test_undo_blocked_in_cvc_with_no_paused_state():
-    """NEW (2026-05-30 user spec): in CvC + no menu/dialog/confirm,
-    U is a NO-OP — does NOT undo and does NOT open the pgn dialog
-    (the previous design auto-opened the dialog; that's reverted)."""
+def test_undo_halts_autoplay_in_cvc_with_no_paused_state():
+    """Spec revision 2026-07-20 (supersedes the 2026-05-30 no-op
+    rule): in CvC + no menu/dialog/confirm, U now performs the undo
+    and HALTS autoplay (cvc_autoplay_halted) so the AIs don't replay
+    over the undone position — same behavior as the win-screen undo
+    of #127, now applied mid-game too. It still does NOT auto-open
+    the pgn dialog (that older design remains reverted). Esc
+    resumes autoplay."""
     random.seed(401)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -128,12 +132,17 @@ def test_undo_blocked_in_cvc_with_no_paused_state():
     assert g.board.turn_number == 3
     assert g.is_autoplay_paused() is False  # no menu open
     g.handle_keydown(pygame.K_u)
-    # Nothing changed.
-    assert g.board.turn_number == 3
-    assert g.pgn_dialog_open is False  # did NOT auto-open
+    assert g.board.turn_number < 3          # the undo happened
+    assert g.cvc_autoplay_halted is True
+    assert g.is_autoplay_paused() is True   # AIs held
+    assert g.pgn_dialog_open is False       # still no auto-open
+    # Esc resumes autoplay.
+    g.handle_keydown(pygame.K_ESCAPE)
+    assert g.cvc_autoplay_halted is False
+    assert g.is_autoplay_paused() is False
 
 
-def test_redo_blocked_in_cvc_with_no_paused_state():
+def test_redo_halts_autoplay_in_cvc_with_no_paused_state():
     random.seed(403)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -141,9 +150,10 @@ def test_redo_blocked_in_cvc_with_no_paused_state():
     g.undo()
     assert g.board.turn_number == 3
     g.handle_keydown(pygame.K_y)
-    # Y is NOT intercepted as 'yes' (no reset confirm pending), but
-    # it ALSO doesn't redo because CvC + no paused state.
-    assert g.board.turn_number == 3
+    # Y is NOT intercepted as 'yes' (no reset confirm pending); it
+    # redoes and halts autoplay (2026-07-20 spec revision).
+    assert g.board.turn_number == 4
+    assert g.cvc_autoplay_halted is True
     assert g.pgn_dialog_open is False
 
 
@@ -231,17 +241,17 @@ def test_undo_works_in_hvai_no_paused_state():
 # ===========================================================================
 
 def test_u_in_cvc_no_paused_state_does_not_auto_open_dialog():
-    """Previous (now-reverted) behaviour: U in CvC auto-opened the
-    PGN dialog. New behaviour: U is suppressed — the user must
-    EXPLICITLY open a paused state first."""
+    """The pre-2026-05-30 behaviour (U auto-opened the PGN dialog)
+    stays reverted under the 2026-07-20 spec revision too: U undoes
+    and halts autoplay, but never opens the dialog itself."""
     random.seed(431)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     _advance_cvc(g, 2)
     g.handle_keydown(pygame.K_u)
     assert g.pgn_dialog_open is False
-    # board state unchanged
-    assert g.board.turn_number == 2
+    assert g.board.turn_number < 2          # the undo happened
+    assert g.cvc_autoplay_halted is True
 
 
 def test_y_in_cvc_no_paused_state_does_not_auto_open_dialog():

--- a/tests/test_game_keydown_dispatch.py
+++ b/tests/test_game_keydown_dispatch.py
@@ -223,10 +223,10 @@ def test_y_redoes_in_hvh_no_dialog_open():
     assert g.pgn_dialog_open is False
 
 
-def test_u_in_cvc_no_paused_state_is_noop():
-    """REVERTED 2026-05-30: U in CvC without a paused state is now
-    a NO-OP. The previous "auto-open the dialog" behaviour required
-    the user to explicitly open a paused state first."""
+def test_u_in_cvc_no_paused_state_undoes_and_halts():
+    """Spec revision 2026-07-20 (supersedes the 2026-05-30 no-op
+    rule): U in CvC without a paused state undoes and halts autoplay
+    (cvc_autoplay_halted); it still does NOT auto-open the dialog."""
     random.seed(107)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -235,10 +235,11 @@ def test_u_in_cvc_no_paused_state_is_noop():
     assert g.board.turn_number == 3
     g.handle_keydown(pygame.K_u)
     assert g.pgn_dialog_open is False  # NOT auto-opened
-    assert g.board.turn_number == 3   # NOT undone
+    assert g.board.turn_number < 3     # undone
+    assert g.cvc_autoplay_halted is True
 
 
-def test_y_in_cvc_no_paused_state_is_noop():
+def test_y_in_cvc_no_paused_state_redoes_and_halts():
     random.seed(109)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -248,8 +249,8 @@ def test_y_in_cvc_no_paused_state_is_noop():
               # can_undo guard
     g.handle_keydown(pygame.K_y)
     assert g.pgn_dialog_open is False
-    # board state unchanged (Y did not redo).
-    assert g.board.turn_number == 3
+    assert g.board.turn_number == 4    # Y redid the undone turn
+    assert g.cvc_autoplay_halted is True
 
 
 def test_u_in_cvc_with_dialog_open_undoes_normally():

--- a/tests/test_winscreen_undo.py
+++ b/tests/test_winscreen_undo.py
@@ -153,18 +153,22 @@ def test_reset_clears_halt():
     assert g.cvc_autoplay_halted is False
 
 
-# ---- the original mid-game gating is preserved ---------------------------
+# ---- mid-game: the hold applies there too (2026-07-20 revision) ----------
 
-def test_midgame_cvc_undo_still_gated():
-    """2026-05-30 spec unchanged: during live CvC play (no winner,
-    no paused screen), U remains a no-op."""
+def test_midgame_cvc_undo_halts_autoplay():
+    """Spec revision 2026-07-20: during live CvC play (no winner, no
+    paused screen), U performs the undo and halts autoplay — the
+    win-screen hold now applies mid-game too. Esc resumes."""
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     for _ in range(2):
         assert g.current_ai_controller().take_turn(g)
     depth = len(g._history)
     g.handle_keydown(pygame.K_u)
-    assert len(g._history) == depth
+    assert len(g._history) < depth
+    assert g.cvc_autoplay_halted is True
+    assert g.is_autoplay_paused() is True
+    g._handle_escape()
     assert g.cvc_autoplay_halted is False
 
 


### PR DESCRIPTION
Closes #128. Follow-up to #127 per user request: the autoplay hold now also applies mid-game.

Spec revision (supersedes the 2026-05-30 "U/Y are no-ops in CvC unless a paused screen is open" rule): U/Y during live CvC play with no paused screen performs the undo/redo and sets `cvc_autoplay_halted` — the same win-screen behavior from #127 — so the AIs don't replay over the undone position and U/Y stay enabled for stepping. **Esc resumes autoplay** (existing cascade entry). Paused-screen undo/redo is unchanged, U still never auto-opens the pgn dialog, and HvH/HvAI are untouched.

Implementation: remove the winner-set condition in `_handle_undo_key`/`_handle_redo_key`; docstrings updated. No main.py changes (its autoplay condition and 600 ms wait loop already consult `is_autoplay_paused`).

Tests updated first (red → green) across `test_winscreen_undo.py`, `test_cvc_keys_and_undo_gating.py`, and `test_game_keydown_dispatch.py` — the old no-op assertions flipped to undo/redo + halt + Esc-resume, keeping the no-auto-open-dialog assertions. Regression batch: 270 passed + `test_piece_movement.py` alone 350 passed, all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)