### PR TITLE
CvC undo/redo opens the pause screen instead of the invisible autoplay halt

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -484,16 +484,6 @@ class Game:
         # overlay is rendered by show_reset_confirm; main.py treats it like
         # any other open menu (no interactions while up).
         self.reset_confirm_pending = False
-        # CvC autoplay halt (2026-07-20). Set when the user undoes/
-        # redoes in CvC mode with no paused screen open — mid-game or
-        # on the win screen: without this flag autoplay would
-        # instantly replay over the undone position (and the
-        # pause-screen undo gating would re-close). While True,
-        # is_autoplay_paused() holds the AIs and keeps U/Y enabled so
-        # the user can step through the game. Esc (bottom of the
-        # cascade) resumes autoplay; mode changes, reset, and loading
-        # a game clear it.
-        self.cvc_autoplay_halted = False
         # Pause / PGN-FEN dialog. Opened via 'P', or implicitly when
         # undo/redo is pressed during CvC autoplay (the user-spec'd
         # "paused screen for undo/redo that doesn't interfere with CvC
@@ -1454,7 +1444,7 @@ class Game:
     def _handle_escape(self):
         """Esc cascade. Closes ONE thing per press, in priority order:
         jump-capture > promotion menu > mode menu > pgn dialog >
-        reset confirm > CvC autoplay-halt resume > no-op.
+        reset confirm > no-op.
         (Jump-capture and promotion are mutually exclusive in
         practice — knight vs pawn — and both are in-turn states, so
         they outrank the paused screens.)"""
@@ -1472,10 +1462,6 @@ class Game:
             return
         if self.reset_confirm_pending:
             self.reset_confirm_pending = False
-            return
-        if self.cvc_autoplay_halted:
-            # Resume CvC autoplay after win-screen undo stepping.
-            self.cvc_autoplay_halted = False
             return
 
     def _handle_mode_menu_toggle(self):
@@ -1502,28 +1488,36 @@ class Game:
     def _handle_undo_key(self):
         """U: undo.
 
-        Spec revision 2026-07-20 (supersedes the 2026-05-30 "no-op
-        unless a paused screen is open" rule): in CvC mode, U with no
-        paused screen open — mid-game OR on the win screen — performs
-        the undo and sets `cvc_autoplay_halted`, so the AIs don't
-        replay over the undone position and U/Y stay enabled for
-        further stepping. Esc resumes autoplay. Undoing with a paused
-        screen open (pgn dialog / mode menu / reset confirm) still
-        works as before and does not set the halt — closing the
-        screen resumes autoplay as always. U still never auto-opens
-        the pgn dialog (that pre-2026-05-30 design remains reverted).
-        In HvH / HvAI undo always works.
+        Final 2026-07-20 spec (supersedes both the 2026-05-30 "no-op
+        unless a paused screen is open" rule and the interim #129
+        autoplay-halt flag, which was confusing — an invisible paused
+        state the user had to know to Esc out of): in CvC mode, U
+        with no paused screen open — mid-game OR on the win screen —
+        performs the undo and then OPENS the pause (PGN) screen. This
+        keeps the rule "undo/redo works only while a pause screen is
+        open" consistent: the pause screen is the visible paused
+        state, further U/Y work through the normal paused-screen
+        gating, and closing it as usual (P / Esc) resumes autoplay.
+        Undo order matters: undo FIRST, then open, so the dialog
+        renders the post-undo position. With a paused screen already
+        open, undo behaves as before (no extra screen is opened). In
+        HvH / HvAI undo always works and never opens anything.
         """
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            self.cvc_autoplay_halted = True
+            self.undo()
+            self.open_pgn_dialog()
+            return
         self.undo()
 
     def _handle_redo_key(self):
-        """Y as redo: same CvC autoplay-halt behavior as undo above."""
+        """Y as redo: same CvC undo-then-open-pause behavior as undo
+        above."""
         if (self.mode == 'computer_vs_computer'
                 and not self.is_autoplay_paused()):
-            self.cvc_autoplay_halted = True
+            self.redo()
+            self.open_pgn_dialog()
+            return
         self.redo()
 
     # ---- serialization / save-load --------------------------------------
@@ -1690,7 +1684,6 @@ class Game:
         self.mode_menu = None
         self.mode_menu_rects = []
         self.reset_confirm_pending = False
-        self.cvc_autoplay_halted = False
         if self.dragger is not None:
             self.dragger.dragging = False
             self.dragger.piece = None
@@ -1826,10 +1819,6 @@ class Game:
                     f"Unknown black_player: {black_player!r}; "
                     f"valid: {sorted(valid_players)}")
             self.black_player = black_player
-        # A mode change is an explicit "play on" instruction — clear any
-        # win-screen undo halt so the new configuration isn't silently
-        # blocked from moving.
-        self.cvc_autoplay_halted = False
         self._refresh_ai()
 
     def _refresh_ai(self):
@@ -2021,10 +2010,10 @@ class Game:
         predicate so callers reading "is autoplay paused?" don't have
         to think about whether menus block autoplay (they always do).
 
-        Additionally honors `cvc_autoplay_halted` (CvC undo/redo,
-        mid-game or on the win screen: the AIs must not instantly
-        replay over the undone position; Esc resumes)."""
-        return self.is_any_menu_open() or self.cvc_autoplay_halted
+        (CvC undo/redo with no paused screen open auto-opens the pgn
+        dialog — see _handle_undo_key — so stepping through a game
+        always holds the AIs via this same predicate.)"""
+        return self.is_any_menu_open()
 
     def show_reset_confirm(self, surface):
         """Render the reset-game confirmation overlay if pending."""

--- a/tests/test_cvc_keys_and_undo_gating.py
+++ b/tests/test_cvc_keys_and_undo_gating.py
@@ -117,13 +117,13 @@ def test_r_opens_reset_confirm_during_cvc():
 # Section 2 — NEW undo/redo gating: blocked in CvC unless paused state open
 # ===========================================================================
 
-def test_undo_halts_autoplay_in_cvc_with_no_paused_state():
-    """Spec revision 2026-07-20 (supersedes the 2026-05-30 no-op
-    rule): in CvC + no menu/dialog/confirm, U now performs the undo
-    and HALTS autoplay (cvc_autoplay_halted) so the AIs don't replay
-    over the undone position — same behavior as the win-screen undo
-    of #127, now applied mid-game too. It still does NOT auto-open
-    the pgn dialog (that older design remains reverted). Esc
+def test_undo_opens_pause_screen_in_cvc_with_no_paused_state():
+    """Final 2026-07-20 spec (supersedes both the 2026-05-30 no-op
+    rule and the interim #129 halt flag): in CvC + no
+    menu/dialog/confirm, U performs the undo and then OPENS the
+    pause (PGN) screen — keeping the "undo/redo works only while a
+    pause screen is open" rule consistent, with the pause screen as
+    the visible paused state. Closing it as normal (P / Esc)
     resumes autoplay."""
     random.seed(401)
     g = Game()
@@ -133,16 +133,15 @@ def test_undo_halts_autoplay_in_cvc_with_no_paused_state():
     assert g.is_autoplay_paused() is False  # no menu open
     g.handle_keydown(pygame.K_u)
     assert g.board.turn_number < 3          # the undo happened
-    assert g.cvc_autoplay_halted is True
+    assert g.pgn_dialog_open is True        # pause screen opened
     assert g.is_autoplay_paused() is True   # AIs held
-    assert g.pgn_dialog_open is False       # still no auto-open
-    # Esc resumes autoplay.
+    # Closing the dialog resumes autoplay.
     g.handle_keydown(pygame.K_ESCAPE)
-    assert g.cvc_autoplay_halted is False
+    assert g.pgn_dialog_open is False
     assert g.is_autoplay_paused() is False
 
 
-def test_redo_halts_autoplay_in_cvc_with_no_paused_state():
+def test_redo_opens_pause_screen_in_cvc_with_no_paused_state():
     random.seed(403)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -151,10 +150,9 @@ def test_redo_halts_autoplay_in_cvc_with_no_paused_state():
     assert g.board.turn_number == 3
     g.handle_keydown(pygame.K_y)
     # Y is NOT intercepted as 'yes' (no reset confirm pending); it
-    # redoes and halts autoplay (2026-07-20 spec revision).
+    # redoes and opens the pause screen (final 2026-07-20 spec).
     assert g.board.turn_number == 4
-    assert g.cvc_autoplay_halted is True
-    assert g.pgn_dialog_open is False
+    assert g.pgn_dialog_open is True
 
 
 def test_undo_works_in_cvc_when_pgn_dialog_open():
@@ -240,27 +238,25 @@ def test_undo_works_in_hvai_no_paused_state():
 # Section 4 — pgn dialog does NOT auto-open on U/Y in CvC anymore
 # ===========================================================================
 
-def test_u_in_cvc_no_paused_state_does_not_auto_open_dialog():
-    """The pre-2026-05-30 behaviour (U auto-opened the PGN dialog)
-    stays reverted under the 2026-07-20 spec revision too: U undoes
-    and halts autoplay, but never opens the dialog itself."""
+def test_u_in_cvc_no_paused_state_auto_opens_dialog():
+    """Final 2026-07-20 spec: U in CvC with no paused screen undoes
+    FIRST, then opens the pgn dialog (undo before open — the dialog
+    must show the post-undo position)."""
     random.seed(431)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     _advance_cvc(g, 2)
     g.handle_keydown(pygame.K_u)
-    assert g.pgn_dialog_open is False
     assert g.board.turn_number < 2          # the undo happened
-    assert g.cvc_autoplay_halted is True
+    assert g.pgn_dialog_open is True
 
 
-def test_y_in_cvc_no_paused_state_does_not_auto_open_dialog():
+def test_y_in_cvc_no_paused_state_auto_opens_dialog():
     random.seed(433)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     _advance_cvc(g, 3)
-    g.undo()  # need redo stack populated... but undo is normally
-              # blocked in CvC — bypass via direct call (testing the
+    g.undo()  # populate the redo stack via direct call (testing the
               # KEYDOWN path here, not the can_undo guard)
     g.handle_keydown(pygame.K_y)
-    assert g.pgn_dialog_open is False
+    assert g.pgn_dialog_open is True

--- a/tests/test_game_keydown_dispatch.py
+++ b/tests/test_game_keydown_dispatch.py
@@ -223,10 +223,10 @@ def test_y_redoes_in_hvh_no_dialog_open():
     assert g.pgn_dialog_open is False
 
 
-def test_u_in_cvc_no_paused_state_undoes_and_halts():
-    """Spec revision 2026-07-20 (supersedes the 2026-05-30 no-op
-    rule): U in CvC without a paused state undoes and halts autoplay
-    (cvc_autoplay_halted); it still does NOT auto-open the dialog."""
+def test_u_in_cvc_no_paused_state_undoes_and_opens_dialog():
+    """Final 2026-07-20 spec (supersedes the 2026-05-30 no-op rule
+    and the interim #129 halt flag): U in CvC without a paused state
+    undoes, then opens the pgn dialog as the visible paused state."""
     random.seed(107)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -234,12 +234,11 @@ def test_u_in_cvc_no_paused_state_undoes_and_halts():
         g.current_ai_controller().take_turn(g)
     assert g.board.turn_number == 3
     g.handle_keydown(pygame.K_u)
-    assert g.pgn_dialog_open is False  # NOT auto-opened
     assert g.board.turn_number < 3     # undone
-    assert g.cvc_autoplay_halted is True
+    assert g.pgn_dialog_open is True   # pause screen opened
 
 
-def test_y_in_cvc_no_paused_state_redoes_and_halts():
+def test_y_in_cvc_no_paused_state_redoes_and_opens_dialog():
     random.seed(109)
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
@@ -248,9 +247,8 @@ def test_y_in_cvc_no_paused_state_redoes_and_halts():
     g.undo()  # via direct call — testing the keydown gate, not
               # can_undo guard
     g.handle_keydown(pygame.K_y)
-    assert g.pgn_dialog_open is False
     assert g.board.turn_number == 4    # Y redid the undone turn
-    assert g.cvc_autoplay_halted is True
+    assert g.pgn_dialog_open is True
 
 
 def test_u_in_cvc_with_dialog_open_undoes_normally():

--- a/tests/test_winscreen_undo.py
+++ b/tests/test_winscreen_undo.py
@@ -1,21 +1,20 @@
-"""Tests for undo/redo from the win screen in CvC mode
-(user report 2026-07-20: "I have a previously saved game but now I
-cannot undo from the win screen").
+"""Tests for undo/redo from the win screen and mid-game in CvC mode.
 
-ROOT CAUSE: the CvC undo/redo gating (2026-05-30 spec: undo only
-during the pause screen, mode menu, or reset confirm) did not treat
-the win screen as a paused state — `_handle_undo_key` dropped U
-whenever mode == computer_vs_computer with no menu open, even after
-the game had ended (live win screen AND loaded finished saves).
-
-FIX: when a winner is set, the game is over and no autoplay is
-running, so U/Y are allowed. The first such undo sets
-`cvc_autoplay_halted`, which `is_autoplay_paused()` honors — so
-(a) CvC autoplay does not instantly replay over the undone position
-once the winner is cleared, and (b) subsequent U/Y presses keep
-working while stepping through the finished game. Esc (bottom of
-the cascade) resumes autoplay; mode changes, reset, and loading a
-game clear the flag. Mid-game CvC gating is unchanged.
+History of the spec (user-driven):
+  - 2026-05-30: U/Y in CvC are no-ops unless a paused screen is open.
+  - 2026-07-20 (#127): that gating wrongly swallowed U on the WIN
+    SCREEN of a finished CvC game (live or loaded save).
+  - 2026-07-20 (#129): the interim fix used a cvc_autoplay_halted
+    flag (Esc to resume), extended to mid-game.
+  - 2026-07-20 (FINAL, this file): the flag was confusing (invisible
+    paused state; the user had to know to press Esc). Final spec: U/Y
+    in CvC with no paused screen performs the undo/redo and then
+    OPENS the pause (PGN) screen. This keeps the rule "undo/redo
+    works only while a pause screen is open" consistent — the pause
+    screen itself is the visible paused state, and closing it as
+    normal (P / Esc) resumes autoplay. Works identically mid-game
+    and on the win screen (the win screen renders behind paused
+    screens).
 """
 
 import os
@@ -58,107 +57,75 @@ def _cvc_game_over(n_turns=4):
     return g
 
 
-# ---- the reported bug ----------------------------------------------------
+# ---- win screen ----------------------------------------------------------
 
-def test_undo_from_cvc_win_screen():
+def test_undo_from_cvc_win_screen_opens_pause_screen():
     g = _cvc_game_over()
     depth = len(g._history)
     result = g.handle_keydown(pygame.K_u)
     assert result['consumed']
     assert g.winner is None, (
         'U on the CvC win screen must undo (the game is over — the '
-        'pause-screen gating must not apply)')
+        'pause-screen gating must not swallow it)')
     assert len(g._history) < depth
-    # Autoplay is halted so the AIs don't instantly replay over the
-    # undone position.
-    assert g.cvc_autoplay_halted is True
+    # The pause screen opened, providing the visible paused state.
+    assert g.pgn_dialog_open is True
     assert g.is_autoplay_paused() is True
 
 
 def test_undo_from_loaded_cvc_save_win_screen():
-    """The user's exact scenario: load a finished CvC save, press U."""
+    """The original #126 scenario: load a finished CvC save, press U."""
     src = _cvc_game_over()
     text = src.serialize_to_text()
     g = Game()
     assert g.load_from_text(text) is True
     assert g.mode == 'computer_vs_computer' and g.winner == 'white'
-    assert g.cvc_autoplay_halted is False   # load resets UI state
     depth = len(g._history)
     g.handle_keydown(pygame.K_u)
     assert g.winner is None
     assert len(g._history) < depth
+    assert g.pgn_dialog_open is True
 
 
-def test_subsequent_undo_redo_keep_working_while_halted():
-    """After the first win-screen undo clears the winner, the halt
-    flag keeps the gate open for further stepping."""
+def test_subsequent_undo_redo_keep_working_in_pause_screen():
+    """After the first U opens the pause screen, further U/Y work
+    through the normal paused-screen gating (no re-open needed)."""
     g = _cvc_game_over()
     g.handle_keydown(pygame.K_u)
-    assert g.winner is None
+    assert g.pgn_dialog_open is True
     depth = len(g._history)
     g.handle_keydown(pygame.K_u)            # step further back
     assert len(g._history) < depth
+    assert g.pgn_dialog_open is True        # still the same dialog
     g.handle_keydown(pygame.K_y)            # and redo forward again
     assert len(g._history) == depth
 
 
-# ---- autoplay resume / flag lifecycle ------------------------------------
+# ---- resuming autoplay ---------------------------------------------------
 
-def test_escape_resumes_cvc_autoplay():
+def test_closing_pause_screen_resumes_autoplay():
+    """The normal close controls resume autoplay — no hidden state."""
     g = _cvc_game_over()
     g.handle_keydown(pygame.K_u)
     assert g.is_autoplay_paused() is True
-    g._handle_escape()
-    assert g.cvc_autoplay_halted is False
+    g.handle_keydown(pygame.K_ESCAPE)       # Esc closes the dialog
+    assert g.pgn_dialog_open is False
     assert g.is_autoplay_paused() is False
 
 
-def test_escape_closes_menus_before_resuming_autoplay():
-    """Esc cascade: one thing per press — an open paused screen
-    closes first; the halt clears on the NEXT press."""
+def test_p_also_closes_the_auto_opened_dialog():
     g = _cvc_game_over()
     g.handle_keydown(pygame.K_u)
-    g.open_pgn_dialog()
-    g._handle_escape()
+    g.handle_keydown(pygame.K_p)            # P toggles the dialog off
     assert g.pgn_dialog_open is False
-    assert g.cvc_autoplay_halted is True
-    g._handle_escape()
-    assert g.cvc_autoplay_halted is False
+    assert g.is_autoplay_paused() is False
 
 
-def test_mode_change_clears_halt():
-    """Switching a side to human must clear the halt so HvAI/HvH
-    autoplay is not silently blocked by a stale flag."""
-    g = _cvc_game_over()
-    g.handle_keydown(pygame.K_u)
-    assert g.cvc_autoplay_halted is True
-    g.apply_mode_selection(white_player='human')
-    assert g.cvc_autoplay_halted is False
+# ---- mid-game ------------------------------------------------------------
 
-
-def test_load_clears_halt():
-    g = _cvc_game_over()
-    g.handle_keydown(pygame.K_u)
-    assert g.cvc_autoplay_halted is True
-    text = _cvc_game_over().serialize_to_text()
-    assert g.load_from_text(text) is True
-    assert g.cvc_autoplay_halted is False
-
-
-def test_reset_clears_halt():
-    g = _cvc_game_over()
-    g.handle_keydown(pygame.K_u)
-    assert g.cvc_autoplay_halted is True
-    g.reset()
-    assert g.cvc_autoplay_halted is False
-
-
-# ---- mid-game: the hold applies there too (2026-07-20 revision) ----------
-
-def test_midgame_cvc_undo_halts_autoplay():
-    """Spec revision 2026-07-20: during live CvC play (no winner, no
-    paused screen), U performs the undo and halts autoplay — the
-    win-screen hold now applies mid-game too. Esc resumes."""
+def test_midgame_cvc_undo_opens_pause_screen():
+    """Mid-game CvC: U undoes and opens the pause screen; the AIs
+    hold while it is open."""
     g = Game()
     g.apply_mode_selection(white_player='random', black_player='random')
     for _ in range(2):
@@ -166,13 +133,28 @@ def test_midgame_cvc_undo_halts_autoplay():
     depth = len(g._history)
     g.handle_keydown(pygame.K_u)
     assert len(g._history) < depth
-    assert g.cvc_autoplay_halted is True
+    assert g.pgn_dialog_open is True
     assert g.is_autoplay_paused() is True
-    g._handle_escape()
-    assert g.cvc_autoplay_halted is False
 
 
-def test_hvh_win_screen_undo_unaffected():
+def test_paused_screen_undo_does_not_stack_screens():
+    """U with the mode menu open undoes through the existing gating
+    and does NOT additionally open the pgn dialog."""
+    g = Game()
+    g.apply_mode_selection(white_player='random', black_player='random')
+    for _ in range(2):
+        assert g.current_ai_controller().take_turn(g)
+    g.open_mode_menu()
+    depth = len(g._history)
+    g.handle_keydown(pygame.K_u)
+    assert len(g._history) < depth
+    assert g.mode_menu is not None
+    assert g.pgn_dialog_open is False
+
+
+# ---- other modes unaffected ---------------------------------------------
+
+def test_hvh_undo_does_not_open_pause_screen():
     g = Game()
     ai = Game()
     ai.apply_mode_selection(white_player='random', black_player='random')
@@ -186,3 +168,4 @@ def test_hvh_win_screen_undo_unaffected():
     g.handle_keydown(pygame.K_u)
     assert g.winner is None
     assert len(g._history) < depth
+    assert g.pgn_dialog_open is False


### PR DESCRIPTION
Closes #130. Follow-up to #129 per user feedback: the `cvc_autoplay_halted` flag was an invisible paused state (nothing on screen; Esc-to-resume had to be known).

**Final spec:** U/Y in CvC with no paused screen open (mid-game or win screen) performs the undo/redo first, then opens the pause (PGN) screen. The "undo/redo works only while a pause screen is open" rule is consistent again — the pause screen is the visible paused state, further U/Y work through the normal gating, and closing it (P/Esc) resumes autoplay. With a paused screen already open, behavior is unchanged (no screen stacking). HvH/HvAI untouched.

The `cvc_autoplay_halted` flag is removed entirely (init field, `is_autoplay_paused()` term, Esc-cascade entry, mode-change/load clears). No main.py changes.

**Tests** updated first (red → green) across `test_winscreen_undo.py` (rewritten), `test_cvc_keys_and_undo_gating.py`, and `test_game_keydown_dispatch.py` — including the original #126 loaded-save scenario, stepping inside the dialog, both close paths resuming autoplay, and no-screen-stacking. Regression batch 268 passed + `test_piece_movement.py` alone 350 passed, all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)