### PR TITLE
Right-click on a menu option square is a no-op; only outside cancels

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -2381,6 +2381,21 @@ class Game:
         self.jump_capture_origin = None
         return True
 
+    def point_in_transform_menu(self, pos):
+        """True iff the screen-space point lies inside one of the open
+        transform menu's option squares (the same rects used for
+        left-click selection). Used by main.py to make a right-click
+        on an option a NO-OP — it is more likely a mis-pressed left
+        click than a cancel attempt — while a right-click outside the
+        options cancels. False when no menu is open (rects cleared)."""
+        return any(rect.collidepoint(pos)
+                   for rect, _ in self.transform_menu_rects)
+
+    def point_in_promotion_menu(self, pos):
+        """Promotion-menu counterpart of point_in_transform_menu."""
+        return any(rect.collidepoint(pos)
+                   for rect, _ in self.promotion_menu_rects)
+
     def cancel_transformation(self):
         """Close an open transform menu without transforming. Used by
         Esc / right-click-away / left-click-outside in the UI.

--- a/src/main.py
+++ b/src/main.py
@@ -411,21 +411,31 @@ class Main:
                             game.play_sound(captured=False)
                         continue
 
-                    # During the promotion menu: right-click cancels
-                    # (unified cancel cue, matching jump-capture); all
-                    # other interactions stay blocked.
+                    # During the promotion menu: right-click OUTSIDE the
+                    # option squares cancels (unified cancel cue); a
+                    # right-click ON an option square is a NO-OP — more
+                    # likely a mis-pressed left click (intended
+                    # selection) than a cancel attempt. All other
+                    # interactions stay blocked.
                     if game.promotion_menu:
-                        if event.button == 3:
+                        if (event.button == 3
+                                and not game.point_in_promotion_menu(
+                                    event.pos)):
                             game.cancel_promotion()
                             game.play_sound(captured=False)
                         continue
 
                     # Right-click: open transformation menu for queen/transformed piece
                     if event.button == 3:  # right-click
-                        # Right-click-away closes an open menu (unified
-                        # cancel cue). A right-click on another
+                        # A right-click ON an open menu's option square
+                        # is a NO-OP (more likely a mis-pressed left
+                        # click than a cancel attempt). Right-click
+                        # OUTSIDE the options closes the menu (unified
+                        # cancel cue); a right-click on another
                         # transformable piece falls through below and
                         # simply opens that piece's menu instead.
+                        if game.point_in_transform_menu(event.pos):
+                            continue
                         game.cancel_transformation()
                         if 0 <= clicked_row <= 7 and 0 <= clicked_col <= 7:
                             piece = board.squares[clicked_row][clicked_col].piece

--- a/tests/test_cancel_affordances.py
+++ b/tests/test_cancel_affordances.py
@@ -149,3 +149,66 @@ def test_escape_parity_across_all_three_states():
     g3._pre_jump_capture_snapshot = snap3
     g3._handle_escape()
     assert g3.jump_capture_targets is None
+
+
+# ---- right-click inside an option square is a NO-OP ----------------------
+# (user refinement 2026-07-20: a right-click on a menu option is more
+# likely a mis-pressed left click than a cancel attempt — do nothing.
+# Right-click OUTSIDE the option squares still cancels. main.py gates
+# its right-click cancel paths on these point_in_* helpers.)
+
+def _rect_probe_points(rects):
+    """(inside, outside) screen points for a populated rects list:
+    the center of the first option rect, and a point safely outside
+    the union of all rects."""
+    assert rects    # renderer must have populated them
+    first = rects[0][0]
+    inside = first.center
+    max_right = max(r.right for r, _ in rects)
+    max_bottom = max(r.bottom for r, _ in rects)
+    outside = (max_right + 50, max_bottom + 50)
+    for r, _ in rects:
+        assert not r.collidepoint(outside)
+    return inside, outside
+
+
+def test_point_in_transform_menu():
+    from const import WIDTH, HEIGHT
+    g, b, wq = _game_with_open_transform_menu()
+    surface = pygame.Surface((WIDTH, HEIGHT))
+    g.show_transform_menu(surface)       # populates transform_menu_rects
+    inside, outside = _rect_probe_points(g.transform_menu_rects)
+    assert g.point_in_transform_menu(inside) is True
+    assert g.point_in_transform_menu(outside) is False
+
+
+def test_point_in_transform_menu_without_menu_is_false():
+    g = Game()
+    assert g.point_in_transform_menu((0, 0)) is False
+
+
+def test_point_in_promotion_menu():
+    from const import WIDTH, HEIGHT
+    from piece import Pawn
+    g = Game()
+    b = g.board
+    wp = Pawn('white')
+    b.squares[0][3].piece = wp
+    g.promotion_menu = {
+        'pawn': wp,
+        'pawn_color': 'white',
+        'row': 0,
+        'col': 3,
+        'captured': False,
+        'was_manipulation': False,
+    }
+    surface = pygame.Surface((WIDTH, HEIGHT))
+    g.show_promotion_menu(surface)       # populates promotion_menu_rects
+    inside, outside = _rect_probe_points(g.promotion_menu_rects)
+    assert g.point_in_promotion_menu(inside) is True
+    assert g.point_in_promotion_menu(outside) is False
+
+
+def test_point_in_promotion_menu_without_menu_is_false():
+    g = Game()
+    assert g.point_in_promotion_menu((0, 0)) is False


### PR DESCRIPTION
Closes #134. Refinement of #133: for the promotion and transform menus, right-click OUTSIDE the option squares still cancels, but right-click ON an option square is now a no-op — more likely a mis-pressed left click (intended selection) than a cancel attempt.

- New `Game.point_in_transform_menu(pos)` / `Game.point_in_promotion_menu(pos)` hit tests over the same option rects used for left-click selection (False when no menu is open).
- main.py gates both right-click cancel paths on the point being outside the options; the transform button-3 handler short-circuits to a no-op before its close-then-maybe-reopen logic. Right-click-away/close and switching to another transformable piece's menu behave as in #133.
- Jump-capture is unaffected (its options are board squares on left-click release).

Tests written first (4 new in `test_cancel_affordances.py`, hit-testing renderer-populated rects). Regression batch 202 passed + `test_piece_movement.py` alone 350 passed, all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)