### PR TITLE
Jump-capture right-click no-op on choice squares; cancel-and-open-menu fall-through

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -2396,6 +2396,20 @@ class Game:
         return any(rect.collidepoint(pos)
                    for rect, _ in self.promotion_menu_rects)
 
+    def is_jump_choice_square(self, row, col):
+        """Jump-capture counterpart of the point_in_*_menu helpers,
+        in BOARD space (the jump-capture "options" are board squares,
+        not screen rects): True iff (row, col) is one of the two
+        highlighted choice squares — the jumped piece (capture) or
+        the landing square (decline). main.py makes a right-click
+        there a NO-OP (likely a mis-pressed left click; canceling
+        would revert the knight's whole move) while a right-click
+        elsewhere cancels. False when no jump-capture is pending."""
+        if self.jump_capture_targets is None:
+            return False
+        return ((row, col) in self.jump_capture_targets
+                or (row, col) == self.jump_capture_landing)
+
     def cancel_transformation(self):
         """Close an open transform menu without transforming. Used by
         Esc / right-click-away / left-click-outside in the UI.

--- a/src/main.py
+++ b/src/main.py
@@ -416,14 +416,41 @@ class Main:
                     # right-click ON an option square is a NO-OP — more
                     # likely a mis-pressed left click (intended
                     # selection) than a cancel attempt. All other
-                    # interactions stay blocked.
+                    # interactions stay blocked. After a cancel we FALL
+                    # THROUGH to the right-click handler below, so a
+                    # right-click on a transformable queen cancels the
+                    # promotion AND opens that queen's menu in one
+                    # click — against the RESTORED position (the
+                    # snapshot restore replaces every piece object, so
+                    # the piece lookup and option/repetition filtering
+                    # below must run after the cancel, never before).
                     if game.promotion_menu:
                         if (event.button == 3
                                 and not game.point_in_promotion_menu(
                                     event.pos)):
                             game.cancel_promotion()
                             game.play_sound(captured=False)
-                        continue
+                            # fall through to the right-click handler
+                        else:
+                            continue
+
+                    # During jump-capture: right-click ON a highlighted
+                    # choice square (jumped piece / landing) is a NO-OP
+                    # — same mis-pressed-left-click reasoning, and
+                    # canceling there would revert the knight's whole
+                    # move. Right-click elsewhere cancels the jump and
+                    # FALLS THROUGH like the promotion cancel above, so
+                    # a right-click on a transformable queen opens its
+                    # menu against the restored position. (Left clicks
+                    # resolve the jump on MOUSEBUTTONUP as before.)
+                    if (game.jump_capture_targets is not None
+                            and event.button == 3):
+                        if game.is_jump_choice_square(
+                                clicked_row, clicked_col):
+                            continue
+                        game.cancel_jump_capture()
+                        game.play_sound(captured=False)
+                        # fall through to the right-click handler
 
                     # Right-click: open transformation menu for queen/transformed piece
                     if event.button == 3:  # right-click
@@ -605,9 +632,21 @@ class Main:
 
                     # Handle jump capture second click
                     if game.jump_capture_targets is not None:
-                        # Right-click during jump-capture state cancels the
-                        # in-progress turn entirely (knight returns to origin).
+                        # Right-click: NO-OP on a highlighted choice
+                        # square (jumped piece / landing — likely a
+                        # mis-pressed left click); elsewhere cancels
+                        # the in-progress turn (knight returns to
+                        # origin). Right-clicks are normally resolved
+                        # on MOUSEBUTTONDOWN already (which also
+                        # falls through to open a right-clicked
+                        # queen's transform menu); this mirrors the
+                        # same rule for the release event, which
+                        # still sees the jump state after a
+                        # choice-square no-op on the down event.
                         if event.button == 3:
+                            if game.is_jump_choice_square(
+                                    released_row, released_col):
+                                continue
                             game.cancel_jump_capture()
                             game.play_sound(captured=False)
                             continue

--- a/tests/test_cancel_affordances.py
+++ b/tests/test_cancel_affordances.py
@@ -212,3 +212,80 @@ def test_point_in_promotion_menu():
 def test_point_in_promotion_menu_without_menu_is_false():
     g = Game()
     assert g.point_in_promotion_menu((0, 0)) is False
+
+
+# ---- jump-capture choice squares (board-space no-op zone) ----------------
+# (user refinement 2026-07-20: right-click ON a highlighted choice
+# square — the jumped piece or the landing square — is a NO-OP, same
+# mis-pressed-left-click reasoning as the menus; right-click elsewhere
+# cancels. main.py consults is_jump_choice_square in BOTH mouse
+# handlers.)
+
+def test_is_jump_choice_square():
+    g = Game()
+    g.jump_capture_targets = [(3, 3)]
+    g.jump_capture_landing = (4, 4)
+    assert g.is_jump_choice_square(3, 3) is True    # jumped piece
+    assert g.is_jump_choice_square(4, 4) is True    # landing square
+    assert g.is_jump_choice_square(5, 5) is False   # elsewhere
+    assert g.is_jump_choice_square(-1, 9) is False  # off-board
+
+
+def test_is_jump_choice_square_without_jump_state_is_false():
+    g = Game()
+    assert g.is_jump_choice_square(3, 3) is False
+
+
+# ---- cancel-then-open: options must come from the RESTORED board ---------
+
+def test_promotion_cancel_then_transform_options_use_restored_board():
+    """The cancel-and-open-menu flow (right-click on a transformable
+    queen while the promotion menu is open) must re-look-up the piece
+    and recompute options AFTER the snapshot restore: the restore
+    replaces every piece object, so both the pre-cancel queen object
+    and any options computed against the mid-promotion board would be
+    stale. main.py achieves this by falling through to the normal
+    right-click handler after cancel_promotion(); this test pins the
+    Game-layer contract that makes that ordering correct."""
+    from piece import Pawn
+    g = Game()
+    b = g.board
+    for r in range(8):
+        for c in range(8):
+            b.squares[r][c].piece = None
+    b.boulder = None
+    b.squares[7][7].piece = King('white')
+    b.squares[0][0].piece = King('black')
+    wq = Queen('white', is_royal=True)
+    b.squares[5][3].piece = wq
+    b.captured_pieces['white'].append('rook')
+    wp = Pawn('white')
+    wp.moved = True
+    b.squares[1][6].piece = wp
+    b.turn_number = 10
+    g.next_player = 'white'
+
+    # Enter the promotion state exactly as main.py does.
+    snap = g._snapshot()
+    b.move(wp, Move(Square(1, 6), Square(0, 6)))
+    g.promotion_menu = {'pawn': wp, 'pawn_color': 'white', 'row': 0,
+                        'col': 6, 'captured': False,
+                        'was_manipulation': False}
+    g._pre_promotion_snapshot = snap
+
+    assert g.cancel_promotion() is True
+    # The queen object was replaced by the restore — the fall-through
+    # handler must use the CURRENT board's piece, not a stale ref.
+    restored_queen = b.squares[5][3].piece
+    assert isinstance(restored_queen, Queen)
+    assert restored_queen is not wq
+    # And options computed post-restore are valid for the restored
+    # position (rook unlocked via the captured-piece list).
+    options = b.get_transformation_options(restored_queen)
+    options = b.filter_transformation_options(
+        restored_queen, 5, 3, options, 'white')
+    assert 'rook' in options
+    # The pawn is back home; the turn did not advance.
+    assert isinstance(b.squares[1][6].piece, Pawn)
+    assert b.squares[0][6].piece is None
+    assert g.next_player == 'white'


### PR DESCRIPTION
Closes #136. Completes the unified right-click semantics across the three in-turn states:

1. **Right-click on a jump-capture choice square (jumped piece / landing) is a no-op** — same mis-pressed-left-click reasoning as the menus, and canceling there would revert the knight's whole move. Right-click elsewhere still cancels. New `Game.is_jump_choice_square(row, col)` (board-space counterpart of the `point_in_*_menu` helpers), consulted by both mouse handlers.
2. **Right-click on a transformable queen during the promotion menu cancels the promotion and opens the queen's menu in one click.** The cancel falls through to the normal right-click handler, so the piece lookup and option/repetition filtering run against the restored position (the snapshot restore replaces every piece object — ordering is the load-bearing part). A queen with no legal options still cancels and opens nothing (accepted corner).
3. **Same for jump-capture**: cancel first, then open against the restored board — also fixing a latent inconsistency where the down-event could open a menu computed on the mid-jump board while the release event canceled the jump underneath it.

Tests written first: `is_jump_choice_square` coverage + a restored-board contract test pinning cancel-then-recompute ordering. Regression batch 226 passed + `test_piece_movement.py` alone 350 passed, all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)