### PR TITLE
Right-click on the open transform menu's own piece square closes it (toggle)

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -2396,6 +2396,18 @@ class Game:
         return any(rect.collidepoint(pos)
                    for rect, _ in self.promotion_menu_rects)
 
+    def is_transform_menu_piece_square(self, row, col):
+        """True iff (row, col) is the BOARD square of the piece whose
+        transform menu is currently open. The piece's own square is
+        not a menu option (the option strip anchors one square away),
+        so a right-click there closes the menu WITHOUT the #137
+        fall-through reopening it — right-clicking a queen twice
+        opens then closes its menu. False when no menu is open."""
+        if self.transform_menu is None:
+            return False
+        return (row, col) == (self.transform_menu['row'],
+                              self.transform_menu['col'])
+
     def is_jump_choice_square(self, row, col):
         """Jump-capture counterpart of the point_in_*_menu helpers,
         in BOARD space (the jump-capture "options" are board squares,

--- a/src/main.py
+++ b/src/main.py
@@ -463,6 +463,16 @@ class Main:
                         # simply opens that piece's menu instead.
                         if game.point_in_transform_menu(event.pos):
                             continue
+                        # Right-click on the open menu's own piece
+                        # square: close WITHOUT reopening (toggle) —
+                        # right-clicking a queen twice opens then
+                        # closes its menu. The piece's own square is
+                        # not a menu option, so this doesn't collide
+                        # with the option no-op zone above.
+                        if game.is_transform_menu_piece_square(
+                                clicked_row, clicked_col):
+                            game.cancel_transformation()
+                            continue
                         game.cancel_transformation()
                         if 0 <= clicked_row <= 7 and 0 <= clicked_col <= 7:
                             piece = board.squares[clicked_row][clicked_col].piece

--- a/tests/test_cancel_affordances.py
+++ b/tests/test_cancel_affordances.py
@@ -214,6 +214,39 @@ def test_point_in_promotion_menu_without_menu_is_false():
     assert g.point_in_promotion_menu((0, 0)) is False
 
 
+# ---- right-click on the open menu's own piece square toggles it ----------
+# (user refinement 2026-07-20: the piece's own square is NOT a menu
+# option, so a right-click there cancels — right-clicking a queen
+# twice opens then closes the menu. main.py stops the #137
+# fall-through from immediately reopening in this one case.)
+
+def test_is_transform_menu_piece_square():
+    g, b, wq = _game_with_open_transform_menu()
+    assert g.is_transform_menu_piece_square(5, 3) is True
+    assert g.is_transform_menu_piece_square(5, 4) is False
+    assert g.is_transform_menu_piece_square(0, 0) is False
+
+
+def test_is_transform_menu_piece_square_without_menu_is_false():
+    g = Game()
+    assert g.is_transform_menu_piece_square(5, 3) is False
+
+
+def test_piece_square_is_not_inside_option_rects():
+    """Geometry guard: the option strip anchors one square away from
+    the piece, so the piece's own square must never fall inside the
+    option rects — otherwise the right-click no-op zone would shadow
+    the toggle-close zone and right-click-twice could not close."""
+    from const import WIDTH, HEIGHT, SQSIZE
+    g, b, wq = _game_with_open_transform_menu()
+    surface = pygame.Surface((WIDTH, HEIGHT))
+    g.show_transform_menu(surface)       # populates transform_menu_rects
+    sr, sc = g.board_to_screen(5, 3)
+    queen_center = (sc * SQSIZE + SQSIZE // 2, sr * SQSIZE + SQSIZE // 2)
+    assert g.point_in_transform_menu(queen_center) is False
+    assert g.is_transform_menu_piece_square(5, 3) is True
+
+
 # ---- jump-capture choice squares (board-space no-op zone) ----------------
 # (user refinement 2026-07-20: right-click ON a highlighted choice
 # square — the jumped piece or the landing square — is a NO-OP, same


### PR DESCRIPTION
Closes #138. Right-clicking the queen's own square while its transform menu is open now cancels the menu — so right-clicking a queen twice opens then closes it. Previously the #137 fall-through closed and immediately reopened the menu there (visually a no-op).

This completes the uniform rule across all three intermediate states, as the user stated it: **Esc or any click outside the targets/options cancels** (right-click possibly opening a transform menu at the same time); **right-click on a target/option is a no-op**; **left-click on a target/option performs the operation**.

- New `Game.is_transform_menu_piece_square(row, col)` (board-space, symmetric with `is_jump_choice_square`).
- The button-3 handler cancels and skips the reopen fall-through when the click lands on the open menu's own piece square. Option-rect no-ops and switching to a different transformable piece's menu are unchanged.
- Tests written first: helper coverage + a geometry guard that the piece's own square never falls inside the option rects (the strip anchors one square away), which is what keeps the no-op zone from shadowing the toggle zone.

Regression batch 221 passed + `test_piece_movement.py` alone 350 passed, all `--cache-clear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)