### PR TITLE
Toggle-close check precedes the option-rect no-op; drop the geometry guard

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -461,17 +461,19 @@ class Main:
                         # cancel cue); a right-click on another
                         # transformable piece falls through below and
                         # simply opens that piece's menu instead.
-                        if game.point_in_transform_menu(event.pos):
-                            continue
                         # Right-click on the open menu's own piece
                         # square: close WITHOUT reopening (toggle) —
                         # right-clicking a queen twice opens then
-                        # closes its menu. The piece's own square is
-                        # not a menu option, so this doesn't collide
-                        # with the option no-op zone above.
+                        # closes its menu. Checked FIRST, before the
+                        # option-rect no-op, so the toggle works
+                        # regardless of where the menu strip is drawn
+                        # (per user 2026-07-20: same-queen is the
+                        # deciding fact, not menu geometry).
                         if game.is_transform_menu_piece_square(
                                 clicked_row, clicked_col):
                             game.cancel_transformation()
+                            continue
+                        if game.point_in_transform_menu(event.pos):
                             continue
                         game.cancel_transformation()
                         if 0 <= clicked_row <= 7 and 0 <= clicked_col <= 7:

--- a/tests/test_cancel_affordances.py
+++ b/tests/test_cancel_affordances.py
@@ -228,23 +228,11 @@ def test_is_transform_menu_piece_square():
 
 
 def test_is_transform_menu_piece_square_without_menu_is_false():
+    """The toggle check runs BEFORE the option-rect no-op check in
+    main.py (user 2026-07-20): same-queen is the deciding fact, so
+    the toggle never depends on where the menu strip is drawn."""
     g = Game()
     assert g.is_transform_menu_piece_square(5, 3) is False
-
-
-def test_piece_square_is_not_inside_option_rects():
-    """Geometry guard: the option strip anchors one square away from
-    the piece, so the piece's own square must never fall inside the
-    option rects — otherwise the right-click no-op zone would shadow
-    the toggle-close zone and right-click-twice could not close."""
-    from const import WIDTH, HEIGHT, SQSIZE
-    g, b, wq = _game_with_open_transform_menu()
-    surface = pygame.Surface((WIDTH, HEIGHT))
-    g.show_transform_menu(surface)       # populates transform_menu_rects
-    sr, sc = g.board_to_screen(5, 3)
-    queen_center = (sc * SQSIZE + SQSIZE // 2, sr * SQSIZE + SQSIZE // 2)
-    assert g.point_in_transform_menu(queen_center) is False
-    assert g.is_transform_menu_piece_square(5, 3) is True
 
 
 # ---- jump-capture choice squares (board-space no-op zone) ----------------


### PR DESCRIPTION
Closes #140. Per feedback on #139: the same-queen toggle close is now checked before the option-rect no-op, so it works regardless of menu layout; the geometry-guard test is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)