### PR TITLE
Royal notation: '#' marks game-ending turns

### DIFF
--- a/docs/royal-notation.md
+++ b/docs/royal-notation.md
@@ -14,8 +14,8 @@ Implementation: `src/notation.py` (grammar, inference, replay) and
 ## Token grammar
 
 ```
-Spatial turn:      [>] L ['] FROM (-|x) TO [=F] [j]
-Transformation:        L ['] SQ = F
+Spatial turn:      [>] L ['] FROM (-|x) TO [=F] [j] [#]
+Transformation:        L ['] SQ = F [#]
 ```
 
 | Element | Meaning |
@@ -27,6 +27,7 @@ Transformation:        L ['] SQ = F
 | `-` / `x` | Move to an empty square / landing capture. `x` covers every capture-by-landing: normal captures, the king taking a friendly piece or the boulder, the boulder taking a pawn, and a bishop's **reactive capture** (which is just a bishop move onto the victim's square). |
 | `=F` | On a pawn move to the last rank: the promotion form (`=Q` base queen, `=R`/`=B`/`=N` transformed). On a transformation token: the form the queen becomes (`=Q` returns to base). |
 | `j` | Accepted **jump-capture**: the knight captures the piece on its jumped square. The jumped square is never written — the rulebook derives it uniquely from FROM and TO. A token *without* `j` whose move happens to offer a jump-capture is a **decline**. |
+| `#` | The turn **ended the game** — the variant's counterpart of the checkmate mark. There is no check/checkmate here, so `#` marks any terminal turn: capturing the opponent's second royal, or leaving the opponent with no legal turn (including repetition-forced and tiny-endgame-forced losses). It can follow any token shape and is informational on load (replay re-derives the result). |
 
 Examples:
 
@@ -36,6 +37,7 @@ Nb1-b3j       accepted jump-capture      B'f5=Q     back to base form
 >Pd7-d6       manipulated enemy pawn     O**-d4     boulder leaves intersection
 R'a4xa7       queen-as-rook captures     Pe7-e8=N   promotion to queen-as-knight
 Ka2xb2        king takes (any piece)     >Pe2-e1=Q  manipulated promotion
+Qa2xa1#       game-ending capture        Nc3-e3j#   game-ending jump-capture
 ```
 
 Everything not written in a token is reproduced by the replay going

--- a/src/notation.py
+++ b/src/notation.py
@@ -8,8 +8,8 @@ movetext and reconstructed exactly by replaying it.
 
 TOKEN GRAMMAR (one token per turn, ASCII only):
 
-  Spatial turn:      [>] L ['] FROM (-|x) TO [=F] [j]
-  Transformation:        L ['] SQ = F
+  Spatial turn:      [>] L ['] FROM (-|x) TO [=F] [j] [#]
+  Transformation:        L ['] SQ = F [#]
 
     >    the mover manipulated an ENEMY piece (queen manipulation)
     L    piece letter as it stood BEFORE the turn:
@@ -36,8 +36,13 @@ TOKEN GRAMMAR (one token per turn, ASCII only):
          recording, tiny-endgame counts, winner checks) are
          reproduced by the replay path, not encoded.
 
+    #    the turn ended the game (a winner exists in the resulting
+         state — the variant's counterpart of the checkmate mark;
+         there is no check/checkmate, so it marks ANY terminal turn:
+         second royal captured, or opponent left with no legal turn)
+
   Examples: Pe2-e3   Nb1-b3j   >Pd7-d6   R'a4xa7   Qd4=B   O**-d4
-            Pe7-e8=N   >Pe2-e1=Q   Ka2xb2
+            Pe7-e8=N   >Pe2-e1=Q   Ka2xb2   Qa2xa1#
 
 REPLAY: `apply_token` mirrors AIController._apply_turn (which itself
 mirrors the human path in main.py) minus sounds, branching on the
@@ -126,7 +131,22 @@ def _piece_prefix(piece):
 def infer_token(snap_a, snap_b):
     """Reconstruct the royal-notation token for the single turn that
     led from snapshot A to snapshot B (Game._snapshot dicts). Raises
-    NotationError when no supported turn shape explains the diff."""
+    NotationError when no supported turn shape explains the diff.
+
+    A turn whose RESULTING state is terminal (a winner exists) gets a
+    trailing '#' — the variant's counterpart of the checkmate mark.
+    There is no check/checkmate here, so '#' marks any game-ending
+    turn: capturing the opponent's second royal, or leaving the
+    opponent with no legal turn (including repetition-forced and
+    tiny-endgame-forced losses). It can follow any token shape, since
+    the no-legal-moves check runs after every turn type."""
+    token = _infer_token_base(snap_a, snap_b)
+    if snap_b['winner'] is not None:
+        token += '#'
+    return token
+
+
+def _infer_token_base(snap_a, snap_b):
     a, b = snap_a['board'], snap_b['board']
     mover = snap_a['next_player']
 
@@ -228,9 +248,14 @@ def _spatial_token(origin, mover, from_sq, to_sq, capture, promo, jumpcap):
 def parse_token(token):
     """Token string -> dict. Keys: kind ('spatial'|'transform'),
     manip, letter, transformed, from_sq (None = intersection), to_sq,
-    capture, promo (form name or None), jumpcap; for 'transform':
-    letter, transformed, sq, target (form name)."""
+    capture, promo (form name or None), jumpcap, terminal; for
+    'transform': letter, transformed, sq, target (form name),
+    terminal. `terminal` ('#' suffix) is informational — the replay
+    re-derives the game-ending state from the moves themselves."""
     original, tok = token, token
+    terminal = tok.endswith('#')
+    if terminal:
+        tok = tok[:-1]
     manip = tok.startswith('>')
     if manip:
         tok = tok[1:]
@@ -249,7 +274,7 @@ def parse_token(token):
             raise NotationError(f'invalid transformation token: {original!r}')
         return {'kind': 'transform', 'letter': letter,
                 'transformed': transformed, 'sq': parse_square(tok[:2]),
-                'target': LETTER_TO_FORM[tok[3]]}
+                'target': LETTER_TO_FORM[tok[3]], 'terminal': terminal}
 
     if tok.startswith(INTERSECTION):
         from_sq, tok = None, tok[len(INTERSECTION):]
@@ -273,7 +298,8 @@ def parse_token(token):
 
     return {'kind': 'spatial', 'manip': manip, 'letter': letter,
             'transformed': transformed, 'from_sq': from_sq, 'to_sq': to_sq,
-            'capture': capture, 'promo': promo, 'jumpcap': jumpcap}
+            'capture': capture, 'promo': promo, 'jumpcap': jumpcap,
+            'terminal': terminal}
 
 
 # ---- replay --------------------------------------------------------------

--- a/tests/test_royal_notation.py
+++ b/tests/test_royal_notation.py
@@ -178,7 +178,17 @@ def test_parse_token_shapes():
     t = parse_token('>Pe2-e1=Q')
     assert t['manip'] and t['promo'] == 'queen'
 
-    for bad in ('Ze2-e3', 'Pe2e3', 'Pe2-e9', 'Qd4=X', 'Pe2-e3jx', '>Qd4=B'):
+    # '#' marks a game-ending turn; it can follow any token shape.
+    t = parse_token('Qa2xa1#')
+    assert t['terminal'] and t['capture']
+    t = parse_token('Nc3-e3j#')
+    assert t['terminal'] and t['jumpcap']
+    t = parse_token('Qd4=R#')
+    assert t['terminal'] and t['kind'] == 'transform'
+    assert parse_token('Pe2-e3')['terminal'] is False
+
+    for bad in ('Ze2-e3', 'Pe2e3', 'Pe2-e9', 'Qd4=X', 'Pe2-e3jx',
+                '>Qd4=B', 'Pe2-e3#j', 'Pe2#-e3'):
         with pytest.raises(NotationError):
             parse_token(bad)
 
@@ -208,6 +218,19 @@ def test_full_game_with_winner_roundtrip():
     assert g.winner is not None, 'seed expected to reach a decisive end'
     text = _assert_roundtrip(g)
     assert f'Winner: {g.winner}' in text
+    # The game-ending turn carries the '#' marker — and only that one.
+    movetext = text[text.find(_SAVE_V3_BEGIN) + len(_SAVE_V3_BEGIN):
+                    text.find('___VARIANT_SAVE_V3_END___')]
+    tokens = notation.movetext_to_tokens(movetext)
+    assert tokens[-1].endswith('#')
+    assert not any(t.endswith('#') for t in tokens[:-1])
+
+
+def test_unfinished_game_has_no_terminal_marker():
+    g = _play_random(Game(), 20, seed=13)
+    assert g.winner is None
+    text = _assert_roundtrip(g)
+    assert '#' not in text[text.find(_SAVE_V3_BEGIN):]
 
 
 def test_mid_timeline_current_turn_roundtrip():


### PR DESCRIPTION
Closes #144. Any turn whose resulting state is terminal now gets a trailing `#` — the variant's counterpart of the checkmate mark. No check/checkmate exists here, so `#` marks any game-ending turn (second royal captured, or opponent left with no legal turn, incl. repetition/tiny-endgame-forced losses) and can follow any token shape: `Qa2xa1#`, `Nc3-e3j#`, `Qd4=R#`.

Emitter: `#` appended when the post-turn snapshot has a winner. Parser: stripped into a `terminal` field that replay ignores (the result is re-derived from the moves; self-verify compares winners per state). Tests written first: parse shapes + rejections, decisive-game round trip asserting exactly the final token carries `#`, unfinished-game negative. 71 passed with `--cache-clear`; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)