### PR TITLE
V3 saves for FEN-started games via StartFEN header

### DIFF
--- a/docs/royal-notation.md
+++ b/docs/royal-notation.md
@@ -72,8 +72,18 @@ ___VARIANT_SAVE_V3_END___
 - **`Winner`** records the live winner at CurrentTurn. It is normally
   re-derived by the replay; the header stays authoritative so winner
   states always round-trip.
+- **`StartFEN`** (only for games begun from a loaded FEN) carries the
+  starting position — the counterpart of standard chess's
+  `[SetUp "1"]` / `[FEN "..."]` PGN tags. The loader replays the
+  movetext from this position instead of the standard setup. The
+  serializer proves at save time that the FEN reconstructs the
+  game's actual starting state exactly (state-hash comparison, which
+  covers royal/transformed queen markers, freeze, invulnerability,
+  and boulder state); positions the FEN summary cannot express fall
+  back to the V2 container.
 - Move numbers count full move pairs (white then black), like a
-  standard PGN.
+  standard PGN. A game starting from a FEN with Black to move simply
+  has Black's turn as the first token.
 
 ## Correctness & compatibility
 

--- a/src/game.py
+++ b/src/game.py
@@ -1065,6 +1065,13 @@ class Game:
         full save (serialize_to_text) is the source of truth for
         perfect replay. The FEN is a compact human-shareable summary.
         """
+        return self._fen_for_board(self.board, self.next_player)
+
+    @classmethod
+    def _fen_for_board(cls, board, next_player):
+        """FEN writer parameterized on an arbitrary board — used by
+        to_fen (the live board) and by the V3 serializer's StartFEN
+        header (a timeline-bottom snapshot board)."""
         rank_strings = []
         for rank in range(8, 0, -1):
             # board's internal rows: row 0 == rank 8, row 7 == rank 1
@@ -1072,13 +1079,13 @@ class Game:
             run = []
             empties = 0
             for col in range(8):
-                sq = self.board.squares[row][col]
+                sq = board.squares[row][col]
                 if sq.has_piece():
                     if empties:
                         run.append(str(empties))
                         empties = 0
                     piece = sq.piece
-                    code = self._FEN_PIECE_CODES.get(
+                    code = cls._FEN_PIECE_CODES.get(
                         type(piece).__name__, '?')
                     if piece.color == 'black':
                         code = code.lower()
@@ -1090,10 +1097,10 @@ class Game:
             rank_strings.append(''.join(run))
         placement = '/'.join(rank_strings)
 
-        turn_color = 'w' if self.next_player == 'white' else 'b'
+        turn_color = 'w' if next_player == 'white' else 'b'
 
         # Boulder annotation.
-        boulder = self.board.boulder
+        boulder = board.boulder
         if boulder is not None and boulder.on_intersection:
             b_sq = 'int'
             b_cd = boulder.cooldown
@@ -1104,7 +1111,7 @@ class Game:
             found_boulder = None
             for r in range(8):
                 for c in range(8):
-                    p = self.board.squares[r][c].piece
+                    p = board.squares[r][c].piece
                     if p is not None and type(p).__name__ == 'Boulder':
                         b_sq = f'{chr(ord("a") + c)}{8 - r}'
                         b_cd = getattr(p, 'cooldown', 0)
@@ -1115,7 +1122,7 @@ class Game:
 
         return (
             f'{placement} {turn_color} '
-            f'turn:{self.board.turn_number} '
+            f'turn:{board.turn_number} '
             f'boulder:{b_sq}:{b_cd}'
         )
 
@@ -1564,19 +1571,43 @@ class Game:
             raise notation.NotationError('empty timeline')
         bottom = timeline[0]
         fresh = Board()
-        if (bottom['next_player'] != 'white'
-                or bottom['winner'] is not None
-                or bottom['board'].turn_number != 0
-                or bottom['board'].get_state_hash('white')
-                != fresh.get_state_hash('white')):
-            raise notation.NotationError(
-                'timeline does not start at the initial position')
+        standard_start = (
+            bottom['next_player'] == 'white'
+            and bottom['winner'] is None
+            and bottom['board'].turn_number == 0
+            and bottom['board'].get_state_hash('white')
+            == fresh.get_state_hash('white'))
+
+        # Non-standard start (a FEN-loaded game): carry the starting
+        # position in a StartFEN header — the counterpart of standard
+        # chess's [SetUp]/[FEN] PGN tags — and prove below that the
+        # FEN summary reconstructs the bottom state EXACTLY. States
+        # the FEN cannot express (non-default freeze/invulnerability/
+        # queen markers, boulder memory — e.g. a truncated legacy
+        # timeline) fail the hash check and fall back to V2.
+        start_fen = None
+        scratch = Game()
+        if not standard_start:
+            if bottom['winner'] is not None:
+                raise notation.NotationError(
+                    'timeline starts at a finished state')
+            start_fen = self._fen_for_board(bottom['board'],
+                                            bottom['next_player'])
+            if not scratch.load_from_fen(start_fen):
+                raise notation.NotationError('start FEN not loadable')
+            if (scratch.next_player != bottom['next_player']
+                    or scratch.board.turn_number
+                    != bottom['board'].turn_number
+                    or scratch.board.get_state_hash(scratch.next_player)
+                    != bottom['board'].get_state_hash(
+                        bottom['next_player'])):
+                raise notation.NotationError(
+                    'start position is not FEN-reconstructable')
 
         tokens = notation.infer_timeline_tokens(timeline)
 
-        # Self-verify: replay the movetext on a scratch game and
+        # Self-verify: replay the movetext on the scratch game and
         # compare every resulting state against the live timeline.
-        scratch = Game()
         for i, token in enumerate(tokens):
             notation.apply_token(scratch, token)
             expect = timeline[i + 1]
@@ -1597,6 +1628,8 @@ class Game:
             f'CurrentTurn: {len(self._history) - 1}',
             f'Timeline: {len(tokens)}',
         ]
+        if start_fen:
+            header_lines.append(f'StartFEN: {start_fen}')
         if self._perspective_side != 'white':
             header_lines.append(f'Perspective: {self._perspective_side}')
         # The LIVE winner at the current position (matches V2 payload
@@ -1728,6 +1761,7 @@ class Game:
         current = re.search(r'CurrentTurn:\s*(\d+)', header)
         perspective = re.search(r'Perspective:\s*(white|black)', header)
         saved_winner = re.search(r'Winner:\s*(white|black)', header)
+        start_fen = re.search(r'^StartFEN:\s*(.+)$', header, re.MULTILINE)
         white_player = players.group(1) if players else 'human'
         black_player = players.group(2) if players else 'human'
         valid_players = {opt['key'] for opt in self.PLAYER_OPTIONS}
@@ -1741,8 +1775,12 @@ class Game:
                              f'{len(tokens)}-turn timeline')
 
         # Replay on a scratch game first — self is untouched until the
-        # whole movetext replays cleanly.
+        # whole movetext replays cleanly. A StartFEN header replays
+        # from that position instead of the standard setup.
         scratch = Game()
+        if start_fen:
+            if not scratch.load_from_fen(start_fen.group(1).strip()):
+                raise ValueError('bad StartFEN in save header')
         for token in tokens:
             notation.apply_token(scratch, token)
 

--- a/tests/test_royal_notation.py
+++ b/tests/test_royal_notation.py
@@ -326,15 +326,59 @@ def test_v2_container_still_loads():
     assert len(g2._history) == len(g._history)
 
 
-def test_fen_loaded_game_falls_back_to_v2():
-    """A game whose timeline does not start at the standard initial
-    position cannot be a movetext replay — serialize falls back to
-    the V2 container, which still round-trips."""
+def test_fen_started_game_serializes_v3_with_startfen():
+    """A game begun from a loaded FEN now serializes as V3 with a
+    StartFEN header (the counterpart of standard chess's
+    [SetUp]/[FEN] PGN tags): the loader replays the movetext from
+    that position instead of the standard setup."""
     src = _play_random(Game(), 12, seed=51)
     fen = src.to_fen()
     g = Game()
     assert g.load_from_fen(fen) is True
-    _play_random(g, 4, seed=52)
+    _play_random(g, 6, seed=52)
+    text = _assert_roundtrip(g)
+    header = text[:text.find(_SAVE_V3_BEGIN)]
+    assert 'StartFEN:' in header
+
+
+def test_fen_started_game_mid_timeline_roundtrip():
+    """Undo/redo positioning (CurrentTurn) works for FEN-started
+    games too."""
+    src = _play_random(Game(), 10, seed=53)
+    g = Game()
+    assert g.load_from_fen(src.to_fen()) is True
+    _play_random(g, 8, seed=54)
+    for _ in range(2):
+        assert g.undo() is True
+    text = _assert_roundtrip(g)
+    g2 = Game()
+    assert g2.load_from_text(text) is True
+    assert g2.can_redo()
+    assert g2.redo() is True
+
+
+def test_non_fen_expressible_bottom_falls_back_to_v2():
+    """A timeline whose bottom state carries flags the FEN summary
+    cannot express (here: a manipulation freeze) must still fall
+    back to the V2 container — the self-verify rejects the FEN
+    reconstruction via the state hash."""
+    g = Game()
+    seen = _play_greedy(
+        g, prefer=[lambda t: t.turn_type == 'manipulation'],
+        max_turns=40)
+    assert 'manipulation' in seen    # setup sanity
+    frozen_at = None
+    for i, snap in enumerate(g._history):
+        board = snap['board']
+        if any(getattr(board.squares[r][c].piece, 'moved_by_queen', False)
+               for r in range(8) for c in range(8)
+               if board.squares[r][c].piece is not None):
+            frozen_at = i
+            break
+    assert frozen_at is not None and frozen_at > 0
+    # Truncate the timeline so the frozen state becomes the bottom.
+    g._history = g._history[frozen_at:]
+    g._redo_stack = []
     text = g.serialize_to_text()
     assert _SAVE_V3_BEGIN not in text
     assert _SAVE_V2_BEGIN in text


### PR DESCRIPTION
Closes #146. Games begun from a loaded FEN now serialize as readable V3 PGNs: a `StartFEN:` header line carries the starting position (the counterpart of standard chess's `[SetUp "1"]`/`[FEN "..."]` tags), and the loader replays the movetext from `load_from_fen(...)` instead of the standard setup.

Safety is unchanged and proved at save time: the serializer FEN-encodes the timeline bottom (via a new board-parameterized `_fen_for_board`, extracted from `to_fen`), reconstructs it on a scratch game, and requires an exact state-hash match (covering royal/transformed queen markers, freeze, invulnerability, boulder state) before the usual per-turn self-verified replay. Positions the FEN summary can't express — e.g. a truncated timeline whose bottom has a manipulation freeze — still fall back to the V2 container.

Tests written first: StartFEN round-trip (full timeline), mid-timeline CurrentTurn + redo for FEN-started games, and a genuine non-expressible-bottom fallback case. Batches: 18 + 134 + 350 passed, `--cache-clear`. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)