### PR TITLE
Enriched FEN: full state-hash fidelity with per-piece markers

### DIFF
--- a/docs/royal-notation.md
+++ b/docs/royal-notation.md
@@ -72,15 +72,31 @@ ___VARIANT_SAVE_V3_END___
 - **`Winner`** records the live winner at CurrentTurn. It is normally
   re-derived by the replay; the header stays authoritative so winner
   states always round-trip.
-- **`StartFEN`** (only for games begun from a loaded FEN) carries the
-  starting position — the counterpart of standard chess's
-  `[SetUp "1"]` / `[FEN "..."]` PGN tags. The loader replays the
-  movetext from this position instead of the standard setup. The
+- **`StartFEN`** (only for games not starting at the standard setup)
+  carries the starting position — the counterpart of standard
+  chess's `[SetUp "1"]` / `[FEN "..."]` PGN tags. The loader replays
+  the movetext from this position instead of the standard setup. The
   serializer proves at save time that the FEN reconstructs the
-  game's actual starting state exactly (state-hash comparison, which
-  covers royal/transformed queen markers, freeze, invulnerability,
-  and boulder state); positions the FEN summary cannot express fall
-  back to the V2 container.
+  game's actual starting state exactly (state-hash comparison).
+
+  Since 2026-07-20 the FEN itself is **state-complete**: it encodes
+  everything in the state hash. Per-piece suffixes (canonical order
+  `'` `*` `!` `^`): `'` transformed queen (the letter shows the
+  form, e.g. `R'` = royal queen-as-rook), `*` promoted (non-royal)
+  queen — the rarer kind carries the marker, a plain `Q` is always
+  the royal queen — `!` manipulation freeze, `^` invulnerable.
+  Extra fields: `bmem:<sq>` (the boulder's no-return memory) and
+  `last:<fromto>` (the immediately preceding move, present only
+  when some rule consults it at this position — manipulation
+  Restriction 2, knight jump-capture eligibility, or bishop
+  reactive arming — since move generation consumes the literal
+  coordinates). Deliberately excluded: the repetition rule's
+  state-history counts and the tiny-endgame distance counts
+  (game-level accumulators that would encode as much data as the
+  movetext itself; loading resets them). In practice almost every
+  timeline bottom is now FEN-expressible; the V2 fallback remains
+  for the rest (e.g. a timeline truncated to a single finished
+  state).
 - Move numbers count full move pairs (white then black), like a
   standard PGN. A game starting from a FEN with Black to move simply
   has Black's turn as the first token.

--- a/src/board.py
+++ b/src/board.py
@@ -876,6 +876,44 @@ class Board:
         state.append(('invulnerable', tuple(sorted(invulnerable_squares))))
         return tuple(state)
 
+    def get_relevant_last_move(self):
+        """((from_r, from_c), (to_r, to_c)) of the immediately
+        preceding spatial move IF it affects the current legal-move
+        set, else None. Mirrors the arming logic of get_state_hash's
+        derived flags: the move matters iff an enemy base-form queen
+        has LoS to the moved piece (Restriction 2), an enemy knight
+        is at chebyshev-1 of it (jump-capture eligible), or an enemy
+        bishop has unblocked diagonal LoS to the move's INITIAL
+        square (reactive capture armed). Used by the enriched FEN
+        writer: the literal coordinates are recorded exactly when
+        they are strictly necessary to reproduce legality (move
+        generation consumes the coordinates, not the flags)."""
+        if (self.last_move is None
+                or self.last_move_turn_number is None
+                or self.last_move_turn_number != self.turn_number - 1):
+            return None
+        fr, fc = self.last_move.initial.row, self.last_move.initial.col
+        tr, tc = self.last_move.final.row, self.last_move.final.col
+        mp = self.squares[tr][tc].piece
+        if mp is None or mp.color == 'none':
+            # Moved piece captured during resolution, or boulder move —
+            # neither arms any of the three rules.
+            return None
+        enemy_of_moved = 'black' if mp.color == 'white' else 'white'
+        if (self._enemy_base_queen_has_los_to(enemy_of_moved, tr, tc)
+                or self._enemy_knight_at_chebyshev_1(
+                    enemy_of_moved, tr, tc)):
+            return ((fr, fc), (tr, tc))
+        for r in range(ROWS):
+            for c in range(COLS):
+                piece = self.squares[r][c].piece
+                if (piece is not None and isinstance(piece, Bishop)
+                        and piece.color == enemy_of_moved
+                        and self._has_unblocked_diagonal_los(
+                            r, c, fr, fc)):
+                    return ((fr, fc), (tr, tc))
+        return None
+
     def _enemy_base_queen_has_los_to(self, enemy_color, target_r, target_c):
         """True iff some base-form queen of `enemy_color` has unblocked
         rank/file/diagonal LoS to (target_r, target_c). Only base-form

--- a/src/game.py
+++ b/src/game.py
@@ -185,6 +185,7 @@ from const import *
 from board import Board
 from dragger import Dragger
 from config import Config
+from move import Move
 from square import Square
 from piece import Queen, Boulder
 from shield_polygons import SHIELD_POLYGONS
@@ -1059,11 +1060,24 @@ class Game:
             intersection (initial position), suffixed with the
             cooldown integer ticks remaining.
 
-        Per-piece flags (manipulation freeze, knight invuln, queen
-        transformation state), the no-return memory, repetition history
-        and tiny-endgame counters are NOT encoded in the FEN — the
-        full save (serialize_to_text) is the source of truth for
-        perfect replay. The FEN is a compact human-shareable summary.
+        2026-07-20 enriched FEN (user spec): the FEN encodes
+        EVERYTHING in the current state hash. Per-piece suffixes in
+        canonical order ' * ! ^ — transformed queen (letter shows the
+        form, e.g. R' = royal queen-as-rook), promoted non-royal
+        queen (plain Q is always the royal queen; the rarer promoted
+        kind carries the marker), manipulation freeze, invulnerable.
+        Extra fields: bmem:<sq> (boulder no-return memory) and
+        last:<fromto> (the immediately preceding move, present ONLY
+        when some rule consults it at this position — Restriction 2,
+        knight jump-capture eligibility, or bishop reactive arming).
+
+        Deliberately NOT encoded (per the same spec): the repetition
+        rule's state-history counts and the tiny-endgame distance
+        counts (game-level accumulators that would encode as much
+        data as the movetext itself — loading resets them), and the
+        per-piece forbidden_square/forbidden_zone fields of non-UI
+        engine variant modes. The full save (serialize_to_text)
+        remains the source of truth for the whole timeline.
         """
         return self._fen_for_board(self.board, self.next_player)
 
@@ -1089,6 +1103,25 @@ class Game:
                         type(piece).__name__, '?')
                     if piece.color == 'black':
                         code = code.lower()
+                    # State-marker suffixes (2026-07-20 enriched FEN;
+                    # canonical order ' * ! ^):
+                    #   '  transformed queen (the letter shows the form)
+                    #   *  promoted (non-royal) queen — the rarer kind
+                    #      carries the marker; a plain Q is always the
+                    #      royal queen
+                    #   !  manipulation freeze (moved_by_queen)
+                    #   ^  invulnerable
+                    if getattr(piece, 'is_transformed', False):
+                        code += "'"
+                    is_queen_kind = (
+                        type(piece).__name__ == 'Queen'
+                        or getattr(piece, 'is_transformed', False))
+                    if is_queen_kind and not piece.is_royal:
+                        code += '*'
+                    if getattr(piece, 'moved_by_queen', False):
+                        code += '!'
+                    if getattr(piece, 'invulnerable', False):
+                        code += '^'
                     run.append(code)
                 else:
                     empties += 1
@@ -1120,10 +1153,41 @@ class Game:
                 if found_boulder is not None:
                     break
 
+        # Extra state fields (2026-07-20 enriched FEN):
+        #   bmem:<sq>      boulder no-return memory (its last square)
+        #   last:<fromto>  the immediately preceding move, included
+        #                  ONLY when it affects current legality (some
+        #                  rule consults it — Restriction 2, knight
+        #                  jump-capture eligibility, or bishop reactive
+        #                  arming); move generation consumes the
+        #                  literal coordinates, so they are strictly
+        #                  necessary exactly then.
+        # Memory lives on the ON-SQUARE boulder piece (board.boulder is
+        # None once the boulder has left the intersection; an
+        # intersection boulder has never moved, so its memory is None).
+        extras = ''
+        mem_holder = boulder if boulder is not None else found_boulder
+        if (mem_holder is not None
+                and getattr(mem_holder, 'last_square', None) is not None):
+            mr, mc = mem_holder.last_square
+            # A boulder fresh off the intersection remembers the
+            # (-1, -1) sentinel — not a returnable square, so the
+            # no-return rule can never consult it. Only on-board
+            # memory is encoded (mirrors the hash's effective-memory
+            # logic, which nulls ineffective memory).
+            if 0 <= mr <= 7 and 0 <= mc <= 7:
+                extras += f' bmem:{chr(ord("a") + mc)}{8 - mr}'
+        relevant = board.get_relevant_last_move()
+        if relevant is not None:
+            (fr, fc), (tr, tc) = relevant
+            extras += (f' last:{chr(ord("a") + fc)}{8 - fr}'
+                       f'{chr(ord("a") + tc)}{8 - tr}')
+
         return (
             f'{placement} {turn_color} '
             f'turn:{board.turn_number} '
             f'boulder:{b_sq}:{b_cd}'
+            f'{extras}'
         )
 
     def copy_fen_to_clipboard_action(self):
@@ -1245,7 +1309,10 @@ class Game:
             # rank_idx 0 = rank 8 (top of board, row 0 internally).
             row = rank_idx
             col = 0
-            for ch in rank_str:
+            i = 0
+            while i < len(rank_str):
+                ch = rank_str[i]
+                i += 1
                 if ch.isdigit():
                     col += int(ch)
                     continue
@@ -1257,23 +1324,48 @@ class Game:
                     raise ValueError(
                         f"rank {rank_idx + 1} overflows file h "
                         f"({rank_str!r})")
+                # Consume state-marker suffixes (enriched FEN):
+                #   ' transformed queen, * promoted (non-royal) queen,
+                #   ! manipulation freeze, ^ invulnerable.
+                sufs = ''
+                while i < len(rank_str) and rank_str[i] in "'*!^":
+                    sufs += rank_str[i]
+                    i += 1
+                transformed = "'" in sufs
+                promoted = '*' in sufs
                 piece_name, color = cls._FEN_CODE_TO_PIECE[ch]
                 piece_cls = cls_map[piece_name]
                 if piece_name == 'Boulder':
+                    if sufs:
+                        raise ValueError(
+                            f'boulder cannot carry markers ({sufs!r})')
                     piece = piece_cls()
                     piece.on_intersection = False
-                elif piece_name == 'Queen':
-                    # FEN can't distinguish royal vs promoted queens.
-                    # Heuristic: rulebook starting squares mark the
-                    # royal queen; everywhere else is treated as a
-                    # promoted queen. b1 (row=7, col=1) is white's
-                    # royal start; g8 (row=0, col=6) is black's.
-                    is_royal = (
-                        (color == 'white' and row == 7 and col == 1)
-                        or (color == 'black' and row == 0 and col == 6))
-                    piece = piece_cls(color, is_royal=is_royal)
-                else:
+                elif transformed:
+                    # A transformed queen: the letter is the FORM
+                    # (rook/bishop/knight instance with the queen
+                    # markers set). Royal unless also marked promoted.
+                    if piece_name not in ('Rook', 'Bishop', 'Knight'):
+                        raise ValueError(
+                            f"transformed marker on {ch!r} — only "
+                            f"R/B/N forms can be transformed queens")
                     piece = piece_cls(color)
+                    piece.is_transformed = True
+                    piece.is_royal = not promoted
+                elif piece_name == 'Queen':
+                    # A plain Q is ALWAYS the royal queen (2026-07-20:
+                    # replaces the b1/g8 starting-square heuristic);
+                    # the rarer promoted queen carries the * marker.
+                    piece = piece_cls(color, is_royal=not promoted)
+                else:
+                    if promoted:
+                        raise ValueError(
+                            f"promoted marker on non-queen {ch!r}")
+                    piece = piece_cls(color)
+                if '!' in sufs:
+                    piece.moved_by_queen = True
+                if '^' in sufs:
+                    piece.invulnerable = True
                 new_board.squares[row][col].piece = piece
                 col += 1
             if col != 8:
@@ -1281,10 +1373,18 @@ class Game:
                     f"rank {rank_idx + 1} did not fill 8 files: "
                     f"{rank_str!r} (got {col})")
 
-        # Extras: turn:<n> and boulder:<sq>:<cd>.
+        # Extras: turn:<n>, boulder:<sq>:<cd>, bmem:<sq>, last:<fromto>.
+        def _parse_alg(name):
+            if (len(name) != 2 or not ('a' <= name[0] <= 'h')
+                    or not ('1' <= name[1] <= '8')):
+                raise ValueError(f'bad square name {name!r} in FEN extras')
+            return 8 - int(name[1]), ord(name[0]) - ord('a')
+
         turn_number = 0
         boulder_sq = None
         boulder_cd = 0
+        boulder_mem = None
+        last_move_sqs = None
         for ext in parts[2:]:
             if ext.startswith('turn:'):
                 try:
@@ -1300,6 +1400,14 @@ class Game:
                     except ValueError:
                         raise ValueError(
                             f"bad boulder cooldown {sub[2]!r}")
+            elif ext.startswith('bmem:'):
+                boulder_mem = _parse_alg(ext.split(':', 1)[1])
+            elif ext.startswith('last:'):
+                spec = ext.split(':', 1)[1]
+                if len(spec) != 4:
+                    raise ValueError(f'bad last-move extra {ext!r}')
+                last_move_sqs = (_parse_alg(spec[:2]),
+                                 _parse_alg(spec[2:]))
         if boulder_sq == 'int':
             b = Boulder()
             b.cooldown = boulder_cd
@@ -1308,7 +1416,12 @@ class Game:
             new_board.boulder = b
         elif boulder_sq and boulder_sq != '-':
             # Boulder already placed via the 'O' code in the placement
-            # field; copy across the cooldown.
+            # field; copy across the cooldown (and memory below).
+            # INVARIANT: board.boulder stays None for an on-square
+            # boulder — Board.move sets it to None the moment the
+            # boulder leaves the intersection, and game code relies
+            # on `board.boulder` meaning "boulder on the
+            # intersection". Only the squares array holds it here.
             for r in range(8):
                 for c in range(8):
                     p = new_board.squares[r][c].piece
@@ -1316,7 +1429,18 @@ class Game:
                         p.cooldown = boulder_cd
                         p.on_intersection = False
                         p.first_move = False
+                        if boulder_mem is not None:
+                            p.last_square = boulder_mem
                         break
+        # Legality-relevant last move (enriched FEN): restore the
+        # literal coordinates and stamp it as the immediately
+        # preceding turn so Restriction 2 / jump-capture / bishop
+        # reactive generation all see it.
+        if last_move_sqs is not None:
+            (fr, fc), (tr, tc) = last_move_sqs
+            new_board.last_move = Move(Square(fr, fc), Square(tr, tc))
+            new_board.last_move_turn_number = turn_number - 1
+        new_board.turn_number = turn_number
         next_player = 'white' if turn == 'w' else 'black'
         return new_board, next_player, turn_number
 

--- a/tests/test_fen_state_markers.py
+++ b/tests/test_fen_state_markers.py
@@ -1,0 +1,290 @@
+"""Tests for the enriched FEN (user spec 2026-07-20): the FEN encodes
+EVERYTHING in the current state hash — the only exclusions are the
+repetition rule's state-history counts and the tiny-endgame distance
+counts. The literal last move is recorded only when some rule
+consults it at this position (Restriction 2, knight jump-capture
+eligibility, bishop reactive arming) — move generation consumes the
+actual coordinates, so they are strictly necessary exactly then.
+
+Per-piece suffixes (canonical order ' * ! ^):
+    '   transformed queen (class letter shows the form)
+    *   promoted (non-royal) queen — the RARER kind gets the marker;
+        plain Q/q is now always the royal queen (replaces the old
+        b1/g8 starting-square heuristic)
+    !   manipulation freeze (moved_by_queen)
+    ^   invulnerable
+Extra fields: bmem:<sq> (boulder no-return memory), last:<fromto>
+(e.g. last:e2e4, only when legality-relevant).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import pytest
+
+from game import Game
+from board import Board
+from piece import King, Queen, Rook, Bishop, Knight, Pawn
+from move import Move
+from square import Square
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+
+
+def _bare_game(turn_number=10, next_player='white'):
+    """Game whose board is emptied in place (kings only)."""
+    g = Game()
+    b = g.board
+    for r in range(8):
+        for c in range(8):
+            b.squares[r][c].piece = None
+    b.boulder = None
+    b.squares[7][7].piece = King('white')
+    b.squares[0][0].piece = King('black')
+    b.turn_number = turn_number
+    b.last_move = None
+    b.last_move_turn_number = None
+    g.next_player = next_player
+    return g, b
+
+
+def _reload(g):
+    """to_fen -> load_from_fen on a fresh game; returns the new game."""
+    fen = g.to_fen()
+    g2 = Game()
+    assert g2.load_from_fen(fen) is True, f'FEN failed to load: {fen}'
+    return g2, fen
+
+
+def _hashes_equal(g, g2):
+    return (g.board.get_state_hash(g.next_player)
+            == g2.board.get_state_hash(g2.next_player)
+            and g.next_player == g2.next_player
+            and g.board.turn_number == g2.board.turn_number)
+
+
+# ---- the common case stays identical -------------------------------------
+
+def test_initial_position_fen_unchanged():
+    g = Game()
+    assert g.to_fen() == ('bkrnnrqb/pppppppp/8/8/8/8/PPPPPPPP/BQRNNRKB '
+                          'w turn:0 boulder:int:0')
+
+
+# ---- queen markers -------------------------------------------------------
+
+def test_promoted_queen_marker_and_royal_default():
+    g, b = _bare_game()
+    b.squares[4][4].piece = Queen('white', is_royal=True)     # royal
+    pq = Queen('white', is_royal=False)                       # promoted
+    b.squares[5][5].piece = pq
+    fen = g.to_fen()
+    assert 'Q*' in fen           # promoted queen carries the marker
+    g2, fen = _reload(g)
+    assert g2.board.squares[4][4].piece.is_royal is True
+    assert g2.board.squares[5][5].piece.is_royal is False
+    assert _hashes_equal(g, g2)
+
+
+def test_plain_queen_is_royal_anywhere():
+    """The old b1/g8 heuristic is gone: an unmarked Q is the royal
+    queen wherever it stands."""
+    g2 = Game()
+    assert g2.load_from_fen('k7/8/8/4Q3/8/8/8/7K w turn:6') is True
+    q = g2.board.squares[3][4].piece
+    assert isinstance(q, Queen) and q.is_royal is True
+
+
+def test_transformed_queen_markers():
+    g, b = _bare_game()
+    rq = Rook('white')                  # royal queen in rook form
+    rq.is_transformed = True
+    rq.is_royal = True
+    b.squares[4][4].piece = rq
+    pn = Knight('black')                # promoted queen in knight form
+    pn.is_transformed = True
+    pn.is_royal = False
+    b.squares[3][3].piece = pn
+    plain = Rook('black')               # a REAL rook for contrast
+    b.squares[2][2].piece = plain
+    fen = g.to_fen()
+    assert "R'" in fen and "n'*" in fen
+    g2, fen = _reload(g)
+    r2 = g2.board.squares[4][4].piece
+    assert isinstance(r2, Rook) and r2.is_transformed and r2.is_royal
+    n2 = g2.board.squares[3][3].piece
+    assert isinstance(n2, Knight) and n2.is_transformed and not n2.is_royal
+    p2 = g2.board.squares[2][2].piece
+    assert isinstance(p2, Rook) and not p2.is_transformed
+    assert _hashes_equal(g, g2)
+
+
+# ---- freeze + invulnerability -------------------------------------------
+
+def test_freeze_and_invulnerable_markers():
+    g, b = _bare_game()
+    frozen = Pawn('black')
+    frozen.moved_by_queen = True
+    b.squares[3][3].piece = frozen
+    shielded = Knight('white')
+    shielded.invulnerable = True
+    b.squares[5][5].piece = shielded
+    fen = g.to_fen()
+    assert 'p!' in fen and 'N^' in fen
+    g2, fen = _reload(g)
+    assert g2.board.squares[3][3].piece.moved_by_queen is True
+    assert g2.board.squares[5][5].piece.invulnerable is True
+    assert _hashes_equal(g, g2)
+
+
+# ---- boulder memory ------------------------------------------------------
+
+def test_boulder_memory_field():
+    g, b = _bare_game()
+    from piece import Boulder
+    o = Boulder()
+    o.on_intersection = False
+    o.first_move = False
+    o.cooldown = 1
+    o.last_square = (4, 3)      # d4
+    b.squares[3][3].piece = o
+    # INVARIANT: board.boulder is None once the boulder is on a
+    # square (Board.move clears it when leaving the intersection);
+    # only the squares array holds it.
+    b.boulder = None
+    fen = g.to_fen()
+    assert 'bmem:d4' in fen
+    g2, fen = _reload(g)
+    assert g2.board.boulder is None          # invariant preserved
+    o2 = g2.board.squares[3][3].piece
+    assert o2.last_square == (4, 3)
+    assert o2.cooldown == 1
+    assert _hashes_equal(g, g2)
+
+
+# ---- legality-relevant last move ----------------------------------------
+
+def test_last_move_encoded_when_queen_consults():
+    """Enemy base-form queen has LOS to the piece that just moved ->
+    Restriction 2 is armed -> the FEN must carry last:<fromto>."""
+    g, b = _bare_game(turn_number=10, next_player='white')
+    b.squares[4][4].piece = Pawn('black')          # moved last turn
+    b.squares[4][1].piece = Queen('white', is_royal=True)  # LOS along rank
+    b.last_move = Move(Square(3, 4), Square(4, 4))
+    b.last_move_turn_number = 9
+    fen = g.to_fen()
+    assert 'last:e5e4' in fen
+    g2, fen = _reload(g)
+    assert g2.board.last_move is not None
+    assert (g2.board.last_move.initial.row,
+            g2.board.last_move.initial.col) == (3, 4)
+    assert g2.board.last_move_turn_number == g2.board.turn_number - 1
+    assert _hashes_equal(g, g2)
+
+
+def test_last_move_encoded_when_bishop_armed():
+    """Enemy bishop with diagonal LOS to the move's INITIAL square ->
+    reactive capture armed -> last: field present, and the loaded
+    game's legal turns include the reactive capture."""
+    from ai_controller import AIController
+    g, b = _bare_game(turn_number=10, next_player='white')
+    b.squares[3][6].piece = Rook('black')          # moved last turn
+    # White bishop with unblocked diagonal LOS to the move's INITIAL
+    # square (3,3): (5,5)-(4,4)-(3,3) is clear — the moved piece went
+    # OFF the diagonal, so the bishop stays armed in the current
+    # position (arming is evaluated post-move, matching both the
+    # state hash and bishop_moves generation).
+    b.squares[5][5].piece = Bishop('white')
+    b.last_move = Move(Square(3, 3), Square(3, 6))
+    b.last_move_turn_number = 9
+    fen = g.to_fen()
+    assert 'last:d5g5' in fen
+    g2, fen = _reload(g)
+    assert _hashes_equal(g, g2)
+    # The reactive capture is actually generated after the reload.
+    ai = AIController('white')
+    caps = [t for t in ai.legal_turns(g2)
+            if t.turn_type == 'move' and t.to_sq == (3, 6)
+            and type(t.piece).__name__ == 'Bishop']
+    assert caps, 'reactive capture must survive the FEN round trip'
+
+
+def test_last_move_omitted_when_nothing_consults():
+    """A preceding move that no rule consults must NOT appear (the
+    hash treats it as irrelevant; the FEN stays minimal)."""
+    g, b = _bare_game(turn_number=10, next_player='white')
+    b.squares[4][4].piece = Pawn('black')
+    b.last_move = Move(Square(3, 4), Square(4, 4))
+    b.last_move_turn_number = 9
+    fen = g.to_fen()
+    assert 'last:' not in fen
+    g2, fen = _reload(g)
+    assert _hashes_equal(g, g2)
+
+
+def test_stale_last_move_omitted():
+    """A last move from an EARLIER turn (not the immediately
+    preceding one) never appears."""
+    g, b = _bare_game(turn_number=10, next_player='white')
+    b.squares[4][4].piece = Pawn('black')
+    b.squares[4][1].piece = Queen('white', is_royal=True)
+    b.last_move = Move(Square(3, 4), Square(4, 4))
+    b.last_move_turn_number = 5          # stale
+    fen = g.to_fen()
+    assert 'last:' not in fen
+    assert _hashes_equal(g, _reload(g)[0])
+
+
+# ---- legality reproduction (the point of it all) -------------------------
+
+def test_legal_turn_set_survives_reload_with_markers():
+    """Full legal-turn-set equality across a FEN reload of a state
+    with a frozen piece, an invulnerable piece, and an armed queen
+    consult — the strongest form of 'the FEN captures the hash'."""
+    from ai_controller import AIController
+    g, b = _bare_game(turn_number=10, next_player='black')
+    b.squares[4][4].piece = Pawn('black')
+    b.squares[4][4].piece.moved_by_queen = True    # frozen
+    shielded = Knight('white')
+    shielded.invulnerable = True
+    b.squares[3][3].piece = shielded
+    b.squares[4][1].piece = Queen('white', is_royal=True)
+    b.last_move = Move(Square(3, 4), Square(4, 4))
+    b.last_move_turn_number = 9
+    g2, fen = _reload(g)
+    ai = AIController('white')
+
+    def turn_set(game):
+        return {(t.turn_type, t.from_sq, t.to_sq, t.transform_target,
+                 t.promo_choice, t.jump_choice)
+                for t in ai.legal_turns(game)}
+
+    assert turn_set(g) == turn_set(g2)
+
+
+# ---- old suffix-less FENs still parse ------------------------------------
+
+def test_plain_old_fen_still_loads():
+    g = Game()
+    assert g.load_from_fen('bkrnnrqb/pppppppp/8/8/8/8/PPPPPPPP/BQRNNRKB '
+                           'w turn:0 boulder:int:0') is True
+    assert g.board.turn_number == 0

--- a/tests/test_royal_notation.py
+++ b/tests/test_royal_notation.py
@@ -357,11 +357,11 @@ def test_fen_started_game_mid_timeline_roundtrip():
     assert g2.redo() is True
 
 
-def test_non_fen_expressible_bottom_falls_back_to_v2():
-    """A timeline whose bottom state carries flags the FEN summary
-    cannot express (here: a manipulation freeze) must still fall
-    back to the V2 container — the self-verify rejects the FEN
-    reconstruction via the state hash."""
+def test_frozen_bottom_now_serializes_v3_with_startfen():
+    """With the enriched FEN (state markers incl. the manipulation
+    freeze), a truncated timeline whose bottom carries a frozen piece
+    is FEN-reconstructable and serializes as a readable V3 PGN — the
+    StartFEN gate widened; the hash proof is unchanged."""
     g = Game()
     seen = _play_greedy(
         g, prefer=[lambda t: t.turn_type == 'manipulation'],
@@ -379,13 +379,23 @@ def test_non_fen_expressible_bottom_falls_back_to_v2():
     # Truncate the timeline so the frozen state becomes the bottom.
     g._history = g._history[frozen_at:]
     g._redo_stack = []
+    text = _assert_roundtrip(g)
+    assert 'StartFEN:' in text[:text.find(_SAVE_V3_BEGIN)]
+
+
+def test_finished_bottom_still_falls_back_to_v2():
+    """A timeline truncated to a single finished state has no
+    replayable movetext at all — still the V2 container."""
+    g = _play_random(Game(), 2000, seed=5)
+    assert g.winner is not None
+    g._history = g._history[-1:]
+    g._redo_stack = []
     text = g.serialize_to_text()
     assert _SAVE_V3_BEGIN not in text
     assert _SAVE_V2_BEGIN in text
     g2 = Game()
     assert g2.load_from_text(text) is True
-    assert (g2.board.get_state_hash(g2.next_player)
-            == g.board.get_state_hash(g.next_player))
+    assert g2.winner == g.winner
 
 
 def test_v3_much_smaller_than_v2():


### PR DESCRIPTION
Closes #148. The FEN now encodes everything in the current state hash; the only exclusions are the repetition state-history counts and tiny-endgame distance counts (game-level accumulators, reset on load, per spec). The literal last move is recorded only when strictly necessary — when some rule consults it at this position.

**Syntax** (canonical suffix order `' * ! ^`): `'` transformed queen (letter shows the form: `R'` = royal queen-as-rook), `*` promoted (non-royal) queen — the rarer kind carries the marker, so a plain `Q` is now always the royal queen (replaces the b1/g8 heuristic; old suffix-less FENs still parse) — `!` manipulation freeze, `^` invulnerable. Extras: `bmem:<sq>` (boulder no-return memory; the off-intersection `(-1,-1)` sentinel is never emitted since it can't restrict) and `last:<fromto>` (present iff Restriction 2, knight jump-capture eligibility, or bishop reactive arming consults it — via new `Board.get_relevant_last_move()`, which mirrors the hash's arming logic; the loader restores `last_move` stamped as the preceding turn).

**Two bugs caught by the tests during development**: the parser briefly set `board.boulder` for an on-square boulder, violating the invariant that it's `None` off the intersection (game code relies on it; the next moved piece corrupted the boulder square); and a test geometry error where the moved piece sat on the bishop→initial diagonal (arming is evaluated post-move — behavior confirmed correct, test fixed).

**Knock-on**: the V3 `StartFEN` gate widens — frozen/invulnerable/transformed/armed bottoms now serialize as readable PGNs (hash proof unchanged); a timeline truncated to a single finished state still exercises the V2 fallback.

**Tests**: 12 new in `test_fen_state_markers.py` incl. a full legal-turn-set equality check across a reload and the boulder invariant; `test_royal_notation.py` gate tests updated. Batches: 31 + 319 + 350 passed, `--cache-clear`. Docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)