### PR TITLE
First-class last-move flags: begin-time reactive arming + pinned capture target

### DIFF
--- a/RULEBOOK_v2.md
+++ b/RULEBOOK_v2.md
@@ -155,8 +155,8 @@ The state includes:
   - **Royal flag** and **transformed flag** (queen markers — form and identity).
   - **Manipulation freeze** — a piece frozen by Restriction 1 may not make a spatial move on its next turn.
   - **Invulnerability** — an invulnerable piece cannot be captured this turn.
-  - **Moved-last-turn** — true for a piece IF it moved on the immediately preceding turn AND some rule consults this fact at the current position (an enemy base-form queen has queen line-of-sight to the piece, blocking manipulation under Restriction 2; OR an enemy knight is at chebyshev-1 of the piece, making jump-capture eligible).
-  - **Reactive-armed** (bishops and queens-as-bishop only) — true for a bishop IF it is enemy of the piece that moved on the immediately preceding turn AND has unblocked diagonal line-of-sight to that move's INITIAL square.
+  - **Moved-last-turn** — true for a piece IF it moved on the immediately preceding turn AND some rule consults this fact at the current position (an enemy base-form queen has queen line-of-sight to the piece, blocking manipulation under Restriction 2; OR an enemy knight is at chebyshev-1 of the piece, making jump-capture eligible; OR any bishop is reactive-armed — the moved piece is that bishop's capture target, so its identity affects the legal-move set).
+  - **Reactive-armed** (bishops and queens-as-bishop only) — true for a bishop IF it is enemy of the piece that moved on the immediately preceding turn AND had unblocked diagonal line-of-sight to that move's INITIAL square **at the moment the move began** (matching the reactive-capture rule's "begins its move on a square within the bishop's diagonal line-of-sight" — a mover that lands on the bishop's line does not disarm it).
 - **Boulder state:** position, cooldown, and no-return memory. The no-return memory is part of the state ONLY when it would restrict the boulder's legal moves — i.e., the boulder is not on cooldown, the memory square is adjacent to the boulder, and that square is empty.
 - **Whose turn it is.**
 

--- a/docs/design-notes/project_state_hash_design.md
+++ b/docs/design-notes/project_state_hash_design.md
@@ -39,6 +39,55 @@ Edge cases handled:
 - The tiny endgame rule's distance counts.
 These are game-level rule-tracking, not properties of the current position. Including them would conflate the rule mechanisms with the positions they apply to.
 
+## 2026-07-20 refinement: FIRST-CLASS flags (supersedes coordinate derivation)
+
+Two gaps were found in the derived-flag implementation (user question "can
+per-piece flags determine legality?" led to the discovery):
+
+1. **CONFIRMED begin-time gap:** generation granted bishop reactive capture by
+   BEGIN-time LoS (assassin cache; rulebook: the piece "begins its move on a
+   square within the bishop's diagonal LoS"), but the hash re-derived
+   `reactive_armed` from POST-move LoS. A mover landing on its own trail
+   (knight 2-diagonal jump along the bishop's diagonal) was capturable live
+   while the armed and unarmed states hashed equal; a FEN reload lost the
+   capture.
+2. **Target-pinning gap:** `moved_last_turn` was hashed only under
+   queen-LoS / knight-adjacency consultation, never for an armed bishop — so
+   the armed bishop's capture TARGET was not pinned (same armed set +
+   different movers could hash equal with different legal captures).
+
+Fix (PR #151, issue #150): `piece.moved_last_turn` and
+`piece.reactive_armed` are now FIRST-CLASS piece attributes — set by
+`Board.move` at the end of every spatial move (armed-ness computed from the
+PRE-move position), expired by the next turn including non-spatial actions
+(`Board.record_action_turn`, called by every real transformation applier),
+transferred to the promoted piece by `Board.promote`, and cleared-without-
+setting by boulder moves. They are the single source of truth consumed by:
+
+- **Move generation**: bishop reactive eligibility (armed flag + the flagged
+  piece as target — replaces the assassin-cache + post-move LoS paths and
+  uniformly covers double manipulation), knight jump-capture eligibility
+  (jumped piece's flag), manipulation Restriction 2 (target's flag).
+- **The hash**: `reactive_armed` hashed as stored; `moved_last_turn` hashed
+  conditionally when consulted — queen LoS, knight chebyshev-1, OR any
+  reactive-armed bishop (the new third condition pins the target).
+- **The FEN**: per-piece suffixes `~` (moved last turn) and `+`
+  (reactive-armed); the `last:<fromto>` field is gone (still parsed as
+  legacy input). A FEN-loaded game shows NO last-move highlight (user
+  decision — the highlight needs the origin square, which is pure history).
+
+`board.last_move` / `last_move_turn_number` still exist but serve ONLY the
+UI highlight. The repetition simulations (`would_cause_repetition`,
+`would_transformation_cause_repetition`) mirror the flag lifecycle via
+`snapshot_turn_flags`/`restore_turn_flags`; the transformation simulation
+previously never mirrored the turn-number increment (stale-is_preceding
+bug) — the explicit flag clear fixes that too. Hash tuple SHAPE is
+unchanged (same fields, corrected values), so V2-loaded games' recorded
+histories remain comparable except in the fixed edge cases.
+
+**Do not re-derive the flags from `last_move` coordinates post-move** —
+that reintroduces gap 1.
+
 ## Why this redesign (2026-05-26)
 
 The previous "positional only" design (2026-05-13) included only `is_royal`/`is_transformed` for queen markers and explicitly EXCLUDED `last_move` history. The user identified that this omits flags that materially change legal moves:

--- a/docs/key-rule-differences.md
+++ b/docs/key-rule-differences.md
@@ -193,18 +193,22 @@ A neutral piece, not present in standard chess.
 - **State hash includes**: piece positions/types/colors; queen markers
   (is_royal / is_transformed / current form); per-piece **manipulation
   freeze** (`moved_by_queen`, Restriction 1); currently-invulnerable
-  pieces; two DERIVED last-move flags — `moved_last_turn` (this piece
-  moved on the immediately preceding turn AND an enemy base-form queen has
-  LoS to it [Restriction 2] OR an enemy knight is at chebyshev-1
-  [jump-capture eligible]) and `reactive_armed` (bishops/queens-as-bishop
-  only: enemy of the moved piece AND unblocked diagonal LoS to the move's
-  INITIAL square); boulder state (position + cooldown + no-return memory,
-  the memory included only when it actually restricts a legal boulder
-  move); and whose turn it is.
+  pieces; the two FIRST-CLASS last-move flags (2026-07-20 redesign —
+  stored on pieces by `Board.move`, no longer derived from
+  coordinates): `moved_last_turn` (hashed when consulted: an enemy
+  base-form queen has LoS to the piece [Restriction 2], an enemy
+  knight is at chebyshev-1 [jump-capture eligible], OR any bishop is
+  reactive-armed [the moved piece is its capture target]) and
+  `reactive_armed` (bishops/queens-as-bishop only: BEGIN-time clear
+  diagonal LoS to the move's initial square — a mover landing on the
+  bishop's line does not disarm it); boulder state (position +
+  cooldown + no-return memory, the memory included only when it
+  actually restricts a legal boulder move); and whose turn it is.
 - **State hash does NOT include**: the literal `last_move` coordinates
-  (last-move relevance is captured entirely by the derived flags above —
-  same flags ⇒ same legal moves ⇒ same hash), the repetition rule's own
-  counts, or the tiny endgame distance counts.
+  (they exist only for the UI highlight — every rule consequence
+  lives in the first-class flags; same flags ⇒ same legal moves ⇒
+  same hash), the repetition rule's own counts, or the tiny endgame
+  distance counts.
 - If all legal turns produce a 3rd repetition, the player loses.
 
 ### Tiny Endgame Rule
@@ -300,7 +304,7 @@ These are mistakes I (Claude) have made repeatedly. Re-read this list before any
 - ❌ **Knights move in L-shape only (8 destinations).** No — radius-2 pattern, 16 destinations.
 - ❌ **Pawn promotion is always to a base-form queen.** No — promoting player can pick any queen form (base or transformed rook/bishop/knight, with the standard transformation capture-availability constraint).
 - ❌ **Invulnerability blocks reactive captures mid-move (interrupting the opponent's turn).** No — reactive captures fire on the bishop's NEXT turn. The opponent's turn is never interrupted; reactive captures are deferred to the bishop's own turn.
-- ❌ **The repetition state hash is "positional + invulnerability only".** Stale — that was the 2026-05-13 design. Since the 2026-05-26 redesign (PRs #77–#79) the hash is the full legal-move-determining state: it also includes the manipulation freeze flag (`moved_by_queen`) and the derived last-move flags `moved_last_turn` / `reactive_armed`. Do not re-revert to the positional-only framing.
+- ❌ **The repetition state hash is "positional + invulnerability only".** Stale — that was the 2026-05-13 design. Since the 2026-05-26 redesign (PRs #77–#79) the hash is the full legal-move-determining state: it also includes the manipulation freeze flag (`moved_by_queen`) and the last-move flags `moved_last_turn` / `reactive_armed`. Do not re-revert to the positional-only framing. Since 2026-07-20 those two flags are FIRST-CLASS piece attributes set by `Board.move` (begin-time arming, target pinned via the any-armed-bishop consult condition) — not derived from `last_move` coordinates; do not re-derive them post-move (that reintroduces the self-blocking-trail gap).
 - ❌ **The "manipulated piece moved on preceding turn" restriction applies even after intervening actions.** No — only SPATIAL moves on the immediately preceding turn count. A transformation in between clears the restriction.
 - ❌ **The king's special capture overrides invulnerability.** No — invulnerability is universal protection; even friendly or enemy kings cannot capture invulnerable pieces.
 - ❌ **The repetition rule's state includes the literal last-move squares.** No — the literal `last_move.initial` / `last_move.final` coordinates are never hashed. But last-move RELEVANCE is hashed via the derived flags (`moved_last_turn`, `reactive_armed`): two states differing only in a way no rule consults hash identically; two states where a rule is armed differently hash differently.

--- a/docs/royal-notation.md
+++ b/docs/royal-notation.md
@@ -81,22 +81,24 @@ ___VARIANT_SAVE_V3_END___
 
   Since 2026-07-20 the FEN itself is **state-complete**: it encodes
   everything in the state hash. Per-piece suffixes (canonical order
-  `'` `*` `!` `^`): `'` transformed queen (the letter shows the
-  form, e.g. `R'` = royal queen-as-rook), `*` promoted (non-royal)
-  queen — the rarer kind carries the marker, a plain `Q` is always
-  the royal queen — `!` manipulation freeze, `^` invulnerable.
-  Extra fields: `bmem:<sq>` (the boulder's no-return memory) and
-  `last:<fromto>` (the immediately preceding move, present only
-  when some rule consults it at this position — manipulation
-  Restriction 2, knight jump-capture eligibility, or bishop
-  reactive arming — since move generation consumes the literal
-  coordinates). Deliberately excluded: the repetition rule's
-  state-history counts and the tiny-endgame distance counts
-  (game-level accumulators that would encode as much data as the
-  movetext itself; loading resets them). In practice almost every
-  timeline bottom is now FEN-expressible; the V2 fallback remains
-  for the rest (e.g. a timeline truncated to a single finished
-  state).
+  `'` `*` `!` `^` `~` `+`): `'` transformed queen (the letter shows
+  the form, e.g. `R'` = royal queen-as-rook), `*` promoted
+  (non-royal) queen — the rarer kind carries the marker, a plain
+  `Q` is always the royal queen — `!` manipulation freeze, `^`
+  invulnerable, `~` moved on the immediately preceding turn
+  (exactly one piece), `+` reactive-armed bishop (begin-time LoS to
+  the preceding move's initial square). The `~`/`+` flags are the
+  FIRST-CLASS last-move state — the literal coordinates exist only
+  for the UI highlight and are not in the FEN, so a FEN-loaded game
+  shows no last-move highlight (`last:<fromto>` is still parsed as
+  legacy input from older saves). Extra field: `bmem:<sq>` (the
+  boulder's no-return memory). Deliberately excluded: the
+  repetition rule's state-history counts and the tiny-endgame
+  distance counts (game-level accumulators that would encode as
+  much data as the movetext itself; loading resets them). In
+  practice almost every timeline bottom is FEN-expressible; the V2
+  fallback remains for the rest (e.g. a timeline truncated to a
+  single finished state).
 - Move numbers count full move pairs (white then black), like a
   standard PGN. A game starting from a FEN with Black to move simply
   has Black's turn as the first token.

--- a/src/ai_controller.py
+++ b/src/ai_controller.py
@@ -108,6 +108,8 @@ class AIController:
         board.transform_queen(board.squares[row][col].piece, row, col,
                               turn.transform_target,
                               record_highlight=True)
+        # First-class flags: an action turn expires all last-move flags.
+        board.record_action_turn()
         board.update_assassin_squares(mover)
         board.decrement_boulder_cooldown()
         if board.tiny_endgame_active:

--- a/src/board.py
+++ b/src/board.py
@@ -37,11 +37,94 @@ class Board:
         self._add_pieces('black')
         self._add_boulder()
 
+    # ---- first-class last-move flags (2026-07-20 redesign) ---------------
+    #
+    # `piece.moved_last_turn` / `piece.reactive_armed` are the single
+    # source of truth for every rule that consults the immediately
+    # preceding move (manipulation Restriction 2, knight jump-capture
+    # eligibility, bishop reactive capture). They are maintained HERE so
+    # every apply path (UI, AI controller, engine, notation replay)
+    # inherits them, and mirrored by the repetition simulations.
+    # Armed-ness is computed from the PRE-move position (rulebook: the
+    # piece "begins its move on a square within the bishop's diagonal
+    # line-of-sight") — this fixes the former hash gap where a mover
+    # landing on its own trail blocked the post-move LoS check.
+
+    def _compute_armed_bishops(self, piece, initial):
+        """PRE-move: every enemy bishop (incl. queens-as-bishop) of the
+        about-to-move piece with clear diagonal LoS to its starting
+        square. Returns piece refs (stable across the mutation). The
+        neutral boulder arms nothing."""
+        if piece.color == 'none' or initial.row < 0 or initial.col < 0:
+            return []
+        armed = []
+        for r in range(ROWS):
+            for c in range(COLS):
+                p = self.squares[r][c].piece
+                if (p is not None and isinstance(p, Bishop)
+                        and p.color != piece.color
+                        and self._has_unblocked_diagonal_los(
+                            r, c, initial.row, initial.col)):
+                    armed.append(p)
+        return armed
+
+    def clear_turn_flags(self):
+        """Clear moved_last_turn / reactive_armed on every piece."""
+        for r in range(ROWS):
+            for c in range(COLS):
+                p = self.squares[r][c].piece
+                if p is not None:
+                    p.moved_last_turn = False
+                    p.reactive_armed = False
+
+    def _record_turn_flags(self, piece, armed_bishops):
+        """End of a spatial move: expire the previous turn's flags,
+        mark the mover, arm the pre-computed bishops. A boulder move
+        ('none' color) expires flags without setting any."""
+        self.clear_turn_flags()
+        if piece.color != 'none':
+            piece.moved_last_turn = True
+        for b in armed_bishops:
+            b.reactive_armed = True
+
+    def record_action_turn(self):
+        """A non-spatial action turn (transformation) completed: the
+        previous move is no longer 'the immediately preceding turn',
+        so all last-move flags expire. Called by every REAL
+        transformation applier (main.py, AI controller, engine,
+        notation replay) — NOT by transform_queen itself, which the
+        repetition filter also calls in simulation."""
+        self.clear_turn_flags()
+
+    def snapshot_turn_flags(self):
+        """Small save for simulations: the (piece, moved, armed)
+        triples of currently-flagged pieces (at most the mover plus a
+        few bishops)."""
+        flagged = []
+        for r in range(ROWS):
+            for c in range(COLS):
+                p = self.squares[r][c].piece
+                if p is not None and (p.moved_last_turn or p.reactive_armed):
+                    flagged.append((p, p.moved_last_turn, p.reactive_armed))
+        return flagged
+
+    def restore_turn_flags(self, flagged):
+        """Inverse of snapshot_turn_flags (call after positions are
+        restored)."""
+        self.clear_turn_flags()
+        for p, moved, armed in flagged:
+            p.moved_last_turn = moved
+            p.reactive_armed = armed
+
     def move(self, piece, move, testing=False):
         initial = move.initial
         final = move.final
 
         final_square_empty = self.squares[final.row][final.col].isempty()
+
+        # First-class flags: armed-ness is a BEGIN-time fact — compute
+        # before any mutation.
+        armed_bishops = self._compute_armed_bishops(piece, initial)
 
         # Record capture (before overwriting the square)
         # Transformed queens are recorded as 'queen' (their true identity)
@@ -93,6 +176,7 @@ class Board:
                             piece.clear_moves()
                             self.last_move = move
                             self.last_move_turn_number = self.turn_number
+                            self._record_turn_flags(piece, armed_bishops)
                             return targets
             else:
                 # v2 knight rules:
@@ -125,6 +209,7 @@ class Board:
                             piece.clear_moves()
                             self.last_move = move
                             self.last_move_turn_number = self.turn_number
+                            self._record_turn_flags(piece, armed_bishops)
                             return [(jumped_row, jumped_col)]
                         elif final_square_empty and self._invuln_grant_condition(
                             piece, final.row, final.col, jumped_row, jumped_col
@@ -162,10 +247,13 @@ class Board:
         # clear valid moves
         piece.clear_moves()
 
-        # set last move (spatial) and clear action highlight
+        # set last move (spatial) and clear action highlight. The
+        # literal coordinates remain ONLY for the UI highlight — every
+        # rule consults the first-class flags below instead.
         self.last_move = move
         self.last_move_turn_number = self.turn_number
         self.last_action = None
+        self._record_turn_flags(piece, armed_bishops)
 
     # Radius-2 move offsets (must match knight_moves())
     KNIGHT_DIFFS = [
@@ -213,27 +301,16 @@ class Board:
         Returns True iff:
         - the jumped square holds an enemy piece (not friendly, not boulder,
           and not currently invulnerable), AND
-        - that piece made a spatial move on the immediately preceding turn.
-
-        The "immediately preceding turn" check uses last_move_turn_number,
-        which is set whenever a spatial move executes. If the preceding turn
-        was a non-spatial action, last_move_turn_number will be older than
-        turn_number - 1 and this check correctly fails.
+        - that piece made a spatial move on the immediately preceding turn
+          (its first-class `moved_last_turn` flag — set by Board.move,
+          expired by the next turn including non-spatial actions).
         """
         # Enemy + uncapturable filters all live in has_capturable_enemy_piece (boulder,
         # friendly, and invulnerable pieces are all rejected there).
         if not self.squares[jumped_row][jumped_col].has_capturable_enemy_piece(knight.color):
             return False
-        # Must have a recorded last move that targets this exact square,
-        # and it must have happened on the immediately preceding turn.
-        if self.last_move is None or self.last_move_turn_number is None:
-            return False
-        if self.last_move_turn_number != self.turn_number - 1:
-            return False
-        last_final = self.last_move.final
-        if last_final.row != jumped_row or last_final.col != jumped_col:
-            return False
-        return True
+        jumped_piece = self.squares[jumped_row][jumped_col].piece
+        return bool(jumped_piece is not None and jumped_piece.moved_last_turn)
 
     def get_jump_capture_targets(self, piece, landing_row, landing_col):
         """Return list of (row, col) of enemy pieces eligible for the knight's
@@ -743,21 +820,26 @@ class Board:
           - `invulnerable`: piece cannot be captured (filters opposing
             captures); a transient per-piece status that materially
             changes the legal-move set this turn
-          - `moved_last_turn` (DERIVED): True iff this piece moved on the
-            immediately preceding turn AND some rule consults it at this
+          - `moved_last_turn` (from the FIRST-CLASS per-piece flag,
+            2026-07-20 redesign; hashed CONDITIONALLY): True iff the
+            piece carries the flag AND some rule consults it at this
             position. "Consults" means an enemy base-form queen has
-            queen-LoS to this piece (Restriction 2 blocks manipulation)
-            OR an enemy knight is at chebyshev-1 of this piece (knight
-            reactive jump-capture eligible). The flag is False otherwise
-            (including when the piece moved but no rule consults — same
-            legal-move set as a non-moved piece in that situation).
-          - `reactive_armed` (DERIVED, bishops/queen-as-bishop only): True
-            iff this bishop is enemy of the piece that moved on the
-            immediately preceding turn AND has unblocked diagonal LoS to
-            that move's INITIAL square. Bishop reactive eligibility is
-            armed at this bishop. The flag is False for non-bishops and
-            for bishops not enemy of moved piece or not on initial's
-            diagonal LoS.
+            queen-LoS to this piece (Restriction 2 blocks
+            manipulation), OR an enemy knight is at chebyshev-1
+            (knight jump-capture eligible), OR any bishop is
+            reactive-armed (the flagged piece is that bishop's capture
+            TARGET — this third condition pins the target and closes
+            the former gap where two states with the same armed set
+            but different movers hashed equal). The hash stays
+            conditional so states whose preceding move affects no rule
+            hash identically to no-move states (same legal moves).
+          - `reactive_armed` (from the FIRST-CLASS per-bishop flag):
+            set by Board.move at BEGIN-time — the bishop had clear
+            diagonal LoS to the move's initial square when the move
+            began. Hashing the stored flag (rather than re-deriving
+            from the post-move position) closes the former gap where a
+            mover landing on its own trail blocked the post-move LoS
+            check while generation still offered the capture.
 
         Hashed at game-state level:
           - boulder state (cooldown + last_square + intersection flag)
@@ -766,10 +848,8 @@ class Board:
 
         NOT hashed:
           - the literal coordinates of `last_move.final` or
-            `last_move.initial` — captured via derived per-piece flags
-            above. Two states with the same per-piece flags but different
-            last_move squares produce the same legal moves and thus the
-            same hash.
+            `last_move.initial` — they exist only for the UI
+            highlight; all rule consequences live in the flags.
           - the prior history of states (the repetition rule's own
             counting machinery)
           - the tiny endgame distance counts (the tiny endgame rule's
@@ -777,29 +857,13 @@ class Board:
           The last two are game-state restrictions accumulating across
           turns, not properties of the current position.
         """
-        # Step 1: derive context for last-move flags (if last move was on
-        # the immediately preceding turn AND the moved piece is still on
-        # the board AND is not the boulder).
-        is_preceding = (
-            self.last_move is not None
-            and self.last_move_turn_number is not None
-            and self.last_move_turn_number == self.turn_number - 1
-        )
-        moved_final_r = moved_final_c = -1
-        moved_initial_r = moved_initial_c = -1
-        enemy_of_moved = None  # color whose pieces could consult last_move
-        if is_preceding:
-            moved_final_r = self.last_move.final.row
-            moved_final_c = self.last_move.final.col
-            moved_initial_r = self.last_move.initial.row
-            moved_initial_c = self.last_move.initial.col
-            mp = self.squares[moved_final_r][moved_final_c].piece
-            if mp is None or mp.color == 'none':
-                # Moved piece was captured during resolution, or boulder
-                # moved (boulder doesn't trigger any of the three rules).
-                is_preceding = False
-            else:
-                enemy_of_moved = 'black' if mp.color == 'white' else 'white'
+        # Does any bishop hold a begin-time arming? If so, the flagged
+        # moved piece is its capture target and must be pinned by the
+        # hash regardless of queen/knight consultation.
+        any_reactive_armed = any(
+            self.squares[r][c].piece is not None
+            and self.squares[r][c].piece.reactive_armed
+            for r in range(ROWS) for c in range(COLS))
 
         state = []
         for row in range(ROWS):
@@ -807,30 +871,17 @@ class Board:
                 piece = self.squares[row][col].piece
                 if piece is None:
                     continue
-                # `moved_last_turn` flag: True iff this piece moved on
-                # the immediately preceding turn AND some enemy queen has
-                # LoS (R2) or some enemy knight is at chebyshev-1
-                # (jump-capture). Captures R2 + knight-jump-capture
-                # eligibility consequences for this piece.
                 moved_last_turn = False
-                if (is_preceding and row == moved_final_r
-                        and col == moved_final_c):
-                    if (self._enemy_base_queen_has_los_to(
+                if piece.moved_last_turn:
+                    enemy_of_moved = ('black' if piece.color == 'white'
+                                      else 'white')
+                    if (any_reactive_armed
+                            or self._enemy_base_queen_has_los_to(
                                 enemy_of_moved, row, col)
                             or self._enemy_knight_at_chebyshev_1(
                                 enemy_of_moved, row, col)):
                         moved_last_turn = True
-                # `reactive_armed` flag (bishop only): True iff this
-                # bishop is enemy of moved piece AND has unblocked
-                # diagonal LoS to last_move.initial. Captures bishop
-                # reactive eligibility being armed at this bishop.
-                reactive_armed = False
-                if (is_preceding and isinstance(piece, Bishop)
-                        and piece.color == enemy_of_moved):
-                    if self._has_unblocked_diagonal_los(
-                            row, col,
-                            moved_initial_r, moved_initial_c):
-                        reactive_armed = True
+                reactive_armed = piece.reactive_armed
                 entry = (row, col, piece.name, piece.color,
                          piece.is_royal, piece.is_transformed,
                          piece.moved_by_queen,
@@ -875,44 +926,6 @@ class Board:
                     invulnerable_squares.append((row, col))
         state.append(('invulnerable', tuple(sorted(invulnerable_squares))))
         return tuple(state)
-
-    def get_relevant_last_move(self):
-        """((from_r, from_c), (to_r, to_c)) of the immediately
-        preceding spatial move IF it affects the current legal-move
-        set, else None. Mirrors the arming logic of get_state_hash's
-        derived flags: the move matters iff an enemy base-form queen
-        has LoS to the moved piece (Restriction 2), an enemy knight
-        is at chebyshev-1 of it (jump-capture eligible), or an enemy
-        bishop has unblocked diagonal LoS to the move's INITIAL
-        square (reactive capture armed). Used by the enriched FEN
-        writer: the literal coordinates are recorded exactly when
-        they are strictly necessary to reproduce legality (move
-        generation consumes the coordinates, not the flags)."""
-        if (self.last_move is None
-                or self.last_move_turn_number is None
-                or self.last_move_turn_number != self.turn_number - 1):
-            return None
-        fr, fc = self.last_move.initial.row, self.last_move.initial.col
-        tr, tc = self.last_move.final.row, self.last_move.final.col
-        mp = self.squares[tr][tc].piece
-        if mp is None or mp.color == 'none':
-            # Moved piece captured during resolution, or boulder move —
-            # neither arms any of the three rules.
-            return None
-        enemy_of_moved = 'black' if mp.color == 'white' else 'white'
-        if (self._enemy_base_queen_has_los_to(enemy_of_moved, tr, tc)
-                or self._enemy_knight_at_chebyshev_1(
-                    enemy_of_moved, tr, tc)):
-            return ((fr, fc), (tr, tc))
-        for r in range(ROWS):
-            for c in range(COLS):
-                piece = self.squares[r][c].piece
-                if (piece is not None and isinstance(piece, Bishop)
-                        and piece.color == enemy_of_moved
-                        and self._has_unblocked_diagonal_los(
-                            r, c, fr, fc)):
-                    return ((fr, fc), (tr, tc))
-        return None
 
     def _enemy_base_queen_has_los_to(self, enemy_color, target_r, target_c):
         """True iff some base-form queen of `enemy_color` has unblocked
@@ -1070,20 +1083,13 @@ class Board:
                 if p:
                     saved_invulnerable[(row, col)] = p.invulnerable
 
-        # 2026-05-31 fix part 2: save last_move + turn_number so we can
-        # mirror what Game.next_turn does (board.move sets last_move +
-        # last_move_turn_number; Game.next_turn increments turn_number;
-        # record_state then sees both updated). Without this, the
-        # simulated state hash's derived `moved_last_turn` and
-        # `reactive_armed` flags consult the PREVIOUS turn's last_move
-        # rather than the simulated move — so the simulated hash never
-        # matches the actual recorded hash in any position where these
-        # flags differ between the two perspectives. User reported the
-        # rule failing to fire on a long queen-bouncing cycle without
-        # manipulation; this is the most likely root cause.
-        saved_last_move = self.last_move
-        saved_last_move_turn_number = self.last_move_turn_number
-        saved_turn_number = self.turn_number
+        # First-class flags (2026-07-20): mirror what Board.move does —
+        # compute BEGIN-time armed bishops before mutating, then after
+        # the mutation expire the previous flags and set the new ones.
+        # Snapshot the current flags for restoration (small: at most
+        # the mover plus a few bishops).
+        saved_turn_flags = self.snapshot_turn_flags()
+        sim_armed_bishops = self._compute_armed_bishops(piece, initial)
 
         # Apply move
         if isinstance(piece, Boulder) and piece.on_intersection:
@@ -1108,16 +1114,11 @@ class Board:
         if piece.color != 'none' and piece.color != next_player:
             piece.moved_by_queen = True
 
-        # Mirror board.move's last_move + last_move_turn_number update,
-        # and Game.next_turn's turn_number increment. The state hash's
-        # derived flags (moved_last_turn, reactive_armed) depend on
-        # both. Without this, the simulated hash uses the PREVIOUS
-        # turn's last_move (one turn stale) — see the comment block
-        # at the top of would_cause_repetition for the full bug
-        # explanation.
-        self.last_move = move
-        self.last_move_turn_number = self.turn_number
-        self.turn_number += 1
+        # Mirror Board.move's first-class flag update: expire previous
+        # flags, mark the simulated mover, arm the begin-time bishops.
+        # The hash reads these flags directly, so the simulated hash
+        # matches what record_state would record after a real move.
+        self._record_turn_flags(piece, sim_armed_bishops)
 
         # Simulate boulder side effects (same as board.move does)
         if isinstance(piece, Boulder):
@@ -1206,10 +1207,8 @@ class Board:
                 p.invulnerable = invuln
         # Restore the manipulation-simulation's moved_by_queen change.
         piece.moved_by_queen = saved_moved_by_queen
-        # Restore last_move + turn_number.
-        self.last_move = saved_last_move
-        self.last_move_turn_number = saved_last_move_turn_number
-        self.turn_number = saved_turn_number
+        # Restore the first-class last-move flags.
+        self.restore_turn_flags(saved_turn_flags)
 
         return count >= 2
 
@@ -1240,6 +1239,13 @@ class Board:
             new_piece.is_royal = False
 
         new_piece.moved = True
+        # First-class flags: the promoted piece REPLACES the pawn that
+        # just moved, so it inherits the moved-last-turn status (a
+        # bishop armed against the promoting pawn's move captures the
+        # promoted piece; a knight's jump-capture window likewise
+        # follows the new piece). It is never reactive_armed itself —
+        # it was not a bishop when the move began.
+        new_piece.moved_last_turn = piece.moved_last_turn
         self.squares[row][col].piece = new_piece
 
     def get_promotion_options(self, color):
@@ -1405,6 +1411,16 @@ class Board:
         # Apply transformation
         self.transform_queen(piece, row, col, target_type)
 
+        # Mirror record_action_turn (first-class flags, 2026-07-20): a
+        # real transformation expires all last-move flags — the
+        # preceding move is no longer "the immediately preceding turn"
+        # after an action. The old code skipped this, so the simulated
+        # hash could disagree with the recorded one whenever the
+        # preceding move's flags were armed (stale-is_preceding bug,
+        # fixed by the redesign).
+        saved_turn_flags = self.snapshot_turn_flags()
+        self.clear_turn_flags()
+
         # Simulate boulder cooldown decrement (same as main.py does after transformation)
         for r in range(ROWS):
             for c in range(COLS):
@@ -1434,6 +1450,9 @@ class Board:
             self.boulder.last_square = saved_boulder_intersection[1]
             self.boulder.first_move = saved_boulder_intersection[2]
             self.boulder.on_intersection = saved_boulder_intersection[3]
+
+        # Restore the first-class last-move flags (positions are back).
+        self.restore_turn_flags(saved_turn_flags)
 
         return count >= 2
 
@@ -2417,27 +2436,13 @@ class Board:
             return
 
         # Cannot manipulate a piece that moved on the immediately
-        # preceding turn. The "immediately preceding turn" qualifier is
-        # important: `last_move` is only updated for SPATIAL moves, so
-        # if intervening turns were non-spatial actions (e.g., the
-        # manipulated player transforming a piece on their frozen turn),
-        # `last_move` will still point at the manipulation target's
-        # square from a turn that is now 2+ turns ago. Without checking
-        # the turn number, the restriction would incorrectly fire.
-        #
-        # We use `last_move_turn_number` (set alongside `last_move`
-        # whenever a spatial move executes) and compare against
-        # `turn_number - 1`. If the recorded turn is older than the
-        # immediately preceding turn, the target did NOT move on the
-        # preceding turn (the preceding turn was an action or the
-        # target's owner moved a different piece), and manipulation
-        # is allowed.
-        if (self.last_move is not None
-                and self.last_move_turn_number is not None
-                and self.last_move_turn_number == self.turn_number - 1):
-            last_final = self.last_move.final
-            if last_final.row == row and last_final.col == col:
-                return
+        # preceding turn (Restriction 2). The first-class
+        # `moved_last_turn` flag captures exactly this: Board.move sets
+        # it on the mover and the NEXT turn expires it — including
+        # non-spatial action turns (record_action_turn), so a
+        # transformation in between correctly lifts the restriction.
+        if enemy_piece.moved_last_turn:
+            return
 
         args = [enemy_piece, row, col]
 
@@ -2606,47 +2611,33 @@ class Board:
                         move = Move(initial, final)
                         piece.add_move(move)
 
-        # Assassin capture (independent of teleportation safety)
-        if self.last_move:
-            last_move_initial = self.last_move.initial
-            last_move_final = self.last_move.final
-            last_move_piece = self.squares[last_move_final.row][last_move_final.col].piece
-
-            # The piece that just moved is eligible for reactive capture iff it
-            # began its move on a square within this bishop's diagonal LOS.
-            # Normally this is read from the cached `assassin_squares` (computed
-            # right after this bishop's owner last moved). BUT in the double-
-            # manipulation case — where the bishop's OWN side manipulated an
-            # enemy piece off this bishop's LOS on the immediately preceding
-            # turn — the post-manipulation `update_assassin_squares(mover)` call
-            # recomputes this bishop's assassin_squares against the new board
-            # and drops the vacated square. So we ALSO accept the capture when
-            # the vacated square (`last_move_initial`) lies on the bishop's
-            # current clear diagonal LOS. (Computed with the bishop temporarily
-            # off the board, so it doesn't self-block.) This makes the bishop's
-            # reactive capture handle manipulation-induced moves consistently
-            # with the knight's jump-capture (rulebook Bishop section,
-            # "Reactive Capture and Manipulation"). The capturing bishop is
-            # always enemy-colored relative to the captured piece (the
-            # has_capturable_enemy_piece check below), so this never produces a
-            # same-color capture.
-            diag_los = self.straightline_of_sight_squares(
-                row, col, incrs=[(-1, 1), (1, 1), (1, -1), (-1, -1)])
-            on_diag_los = any(
-                s.row == last_move_initial.row and s.col == last_move_initial.col
-                for s in diag_los)
-
-            eligible = (last_move_initial in piece.assassin_squares or on_diag_los)
-            if eligible and last_move_initial != last_move_final:
-                # Only assassin-capture enemy pieces (boulder is friendly to both)
-                if self.squares[last_move_final.row][last_move_final.col].has_capturable_enemy_piece(piece.color):
-                    # create initial and final move squares
-                    initial = Square(row, col)
-                    final_piece = last_move_piece
-                    final = Square(last_move_final.row, last_move_final.col, final_piece)
-                    # create a new move
-                    move = Move(initial, final)
-                    piece.add_move(move)
+        # Assassin capture (independent of teleportation safety).
+        #
+        # First-class flags (2026-07-20 redesign): this bishop's
+        # `reactive_armed` flag was set by Board.move at BEGIN-time —
+        # the moved piece started its move on this bishop's clear
+        # diagonal LoS (rulebook semantics; fixes the old post-move
+        # LoS gap where a mover landing on its own trail escaped the
+        # hash while remaining capturable via the assassin cache).
+        # The capture destination is the piece carrying
+        # `moved_last_turn` (exactly one board-wide). This uniformly
+        # covers the double-manipulation case too — arming happens at
+        # the manipulation move itself, no cache staleness involved.
+        if piece.reactive_armed:
+            target = next(
+                ((tr, tc) for tr in range(ROWS) for tc in range(COLS)
+                 if self.squares[tr][tc].piece is not None
+                 and self.squares[tr][tc].piece.moved_last_turn),
+                None)
+            # Only assassin-capture enemy pieces (boulder is friendly
+            # to both; invulnerable pieces rejected).
+            if (target is not None
+                    and self.squares[target[0]][target[1]]
+                    .has_capturable_enemy_piece(piece.color)):
+                tr, tc = target
+                initial = Square(row, col)
+                final = Square(tr, tc, self.squares[tr][tc].piece)
+                piece.add_move(Move(initial, final))
 
         # Put bishop back on the board
         self.squares[row][col].piece = piece

--- a/src/engine.py
+++ b/src/engine.py
@@ -495,6 +495,8 @@ class GameEngine:
         record.transform_target = turn.transform_target
 
         self.board.transform_queen(piece, row, col, turn.transform_target)
+        # First-class flags: an action turn expires all last-move flags.
+        self.board.record_action_turn()
         self.board.update_assassin_squares(self.current_player)
         self.board.decrement_boulder_cooldown()
 

--- a/src/game.py
+++ b/src/game.py
@@ -1104,13 +1104,17 @@ class Game:
                     if piece.color == 'black':
                         code = code.lower()
                     # State-marker suffixes (2026-07-20 enriched FEN;
-                    # canonical order ' * ! ^):
+                    # canonical order ' * ! ^ ~ +):
                     #   '  transformed queen (the letter shows the form)
                     #   *  promoted (non-royal) queen — the rarer kind
                     #      carries the marker; a plain Q is always the
                     #      royal queen
                     #   !  manipulation freeze (moved_by_queen)
                     #   ^  invulnerable
+                    #   ~  moved on the immediately preceding turn
+                    #      (first-class flag; exactly one piece)
+                    #   +  reactive-armed bishop (begin-time LoS to the
+                    #      preceding move's initial square)
                     if getattr(piece, 'is_transformed', False):
                         code += "'"
                     is_queen_kind = (
@@ -1122,6 +1126,10 @@ class Game:
                         code += '!'
                     if getattr(piece, 'invulnerable', False):
                         code += '^'
+                    if getattr(piece, 'moved_last_turn', False):
+                        code += '~'
+                    if getattr(piece, 'reactive_armed', False):
+                        code += '+'
                     run.append(code)
                 else:
                     empties += 1
@@ -1154,14 +1162,12 @@ class Game:
                     break
 
         # Extra state fields (2026-07-20 enriched FEN):
-        #   bmem:<sq>      boulder no-return memory (its last square)
-        #   last:<fromto>  the immediately preceding move, included
-        #                  ONLY when it affects current legality (some
-        #                  rule consults it — Restriction 2, knight
-        #                  jump-capture eligibility, or bishop reactive
-        #                  arming); move generation consumes the
-        #                  literal coordinates, so they are strictly
-        #                  necessary exactly then.
+        #   bmem:<sq>  boulder no-return memory (its last square).
+        # The preceding move's rule effects are carried entirely by the
+        # per-piece ~ / + suffixes above (first-class flags) — the
+        # literal last-move coordinates exist only for the UI highlight
+        # and are deliberately NOT in the FEN, so a FEN-loaded game
+        # shows no last-move highlight (user decision 2026-07-20).
         # Memory lives on the ON-SQUARE boulder piece (board.boulder is
         # None once the boulder has left the intersection; an
         # intersection boulder has never moved, so its memory is None).
@@ -1177,11 +1183,6 @@ class Game:
             # logic, which nulls ineffective memory).
             if 0 <= mr <= 7 and 0 <= mc <= 7:
                 extras += f' bmem:{chr(ord("a") + mc)}{8 - mr}'
-        relevant = board.get_relevant_last_move()
-        if relevant is not None:
-            (fr, fc), (tr, tc) = relevant
-            extras += (f' last:{chr(ord("a") + fc)}{8 - fr}'
-                       f'{chr(ord("a") + tc)}{8 - tr}')
 
         return (
             f'{placement} {turn_color} '
@@ -1326,9 +1327,10 @@ class Game:
                         f"({rank_str!r})")
                 # Consume state-marker suffixes (enriched FEN):
                 #   ' transformed queen, * promoted (non-royal) queen,
-                #   ! manipulation freeze, ^ invulnerable.
+                #   ! manipulation freeze, ^ invulnerable,
+                #   ~ moved last turn, + reactive-armed bishop.
                 sufs = ''
-                while i < len(rank_str) and rank_str[i] in "'*!^":
+                while i < len(rank_str) and rank_str[i] in "'*!^~+":
                     sufs += rank_str[i]
                     i += 1
                 transformed = "'" in sufs
@@ -1366,6 +1368,13 @@ class Game:
                     piece.moved_by_queen = True
                 if '^' in sufs:
                     piece.invulnerable = True
+                if '~' in sufs:
+                    piece.moved_last_turn = True
+                if '+' in sufs:
+                    if not isinstance(piece, Bishop):
+                        raise ValueError(
+                            f"reactive-armed marker on non-bishop {ch!r}")
+                    piece.reactive_armed = True
                 new_board.squares[row][col].piece = piece
                 col += 1
             if col != 8:
@@ -1432,14 +1441,27 @@ class Game:
                         if boulder_mem is not None:
                             p.last_square = boulder_mem
                         break
-        # Legality-relevant last move (enriched FEN): restore the
-        # literal coordinates and stamp it as the immediately
-        # preceding turn so Restriction 2 / jump-capture / bishop
-        # reactive generation all see it.
+        # LEGACY last:<fromto> field (pre-first-class-flags FENs,
+        # incl. StartFEN headers of older V3 saves): translate the
+        # coordinates into the per-piece flags. The piece at the final
+        # square carries moved_last_turn; bishops with clear diagonal
+        # LoS to the initial square become reactive_armed (the old
+        # post-move approximation — new FENs carry the exact begin-time
+        # flags as ~ / + suffixes instead). last_move itself stays None:
+        # a FEN-loaded game shows no last-move highlight.
         if last_move_sqs is not None:
             (fr, fc), (tr, tc) = last_move_sqs
-            new_board.last_move = Move(Square(fr, fc), Square(tr, tc))
-            new_board.last_move_turn_number = turn_number - 1
+            moved_piece = new_board.squares[tr][tc].piece
+            if moved_piece is not None and moved_piece.color != 'none':
+                moved_piece.moved_last_turn = True
+                for r in range(8):
+                    for c in range(8):
+                        p = new_board.squares[r][c].piece
+                        if (p is not None and isinstance(p, Bishop)
+                                and p.color != moved_piece.color
+                                and new_board._has_unblocked_diagonal_los(
+                                    r, c, fr, fc)):
+                            p.reactive_armed = True
         new_board.turn_number = turn_number
         next_player = 'white' if turn == 'w' else 'black'
         return new_board, next_player, turn_number

--- a/src/main.py
+++ b/src/main.py
@@ -346,6 +346,9 @@ class Main:
                             )
                             game.transform_menu = None
                             game.transform_menu_rects = []
+                            # First-class flags: an action turn expires
+                            # all last-move flags.
+                            board.record_action_turn()
                             board.update_assassin_squares(game.next_player)
                             board.decrement_boulder_cooldown()
                             # tiny endgame rule (unchanged from v0)

--- a/src/notation.py
+++ b/src/notation.py
@@ -324,6 +324,8 @@ def apply_token(game, token):
                                 f'{square_name(r, c)}')
         board.transform_queen(piece, r, c, tok['target'],
                               record_highlight=True)
+        # First-class flags: an action turn expires all last-move flags.
+        board.record_action_turn()
         board.update_assassin_squares(mover)
         board.decrement_boulder_cooldown()
         if board.tiny_endgame_active:

--- a/src/piece.py
+++ b/src/piece.py
@@ -17,6 +17,14 @@ class Piece:
         self.forbidden_zone = None   # list of (row, col) — squares piece cannot move to (exclusion_zone variant)
         self.moved_by_queen = False  # True if the piece was moved by queen manipulation last turn and may not make a spatial move on its immediate next turn
         self.invulnerable = False    # True if the piece cannot be captured by enemies (set, e.g., on a knight that jumped over a surviving piece, or on a manipulated piece in invulnerable-manipulation variants)
+        # First-class last-move flags (2026-07-20 redesign). Set by
+        # Board.move at the end of every spatial turn, cleared by the
+        # next turn (spatial or action). These are the single source of
+        # truth consumed by move generation, the repetition state hash,
+        # and the FEN — the literal last-move coordinates remain only
+        # for the UI highlight.
+        self.moved_last_turn = False  # this piece made the immediately preceding spatial move (exactly one piece board-wide)
+        self.reactive_armed = False   # bishops/queens-as-bishop only: this bishop had clear diagonal LoS to the preceding move's INITIAL square at the moment the move began (rulebook begin-time semantics) — its reactive capture of the moved piece is armed
         self.texture = texture
         self.set_texture()
         self.texture_rect = texture_rect

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -347,9 +347,9 @@ class TestCombinationEvaluation:
         board.squares[5][2].piece = knight   # c3
         bq = Queen('black')
         board.squares[4][3].piece = bq       # d4
-        prev = Move(Square(4, 4), Square(4, 3))  # came from e4
-        board.last_move = prev
-        board.last_move_turn_number = 4
+        # First-class flag (2026-07-20): jump-capture eligibility
+        # consults the jumped piece's moved_last_turn flag.
+        bq.moved_last_turn = True
         board.turn_number = 5
         board.update_assassin_squares('white')
 

--- a/tests/test_fen_state_markers.py
+++ b/tests/test_fen_state_markers.py
@@ -183,41 +183,38 @@ def test_boulder_memory_field():
 
 # ---- legality-relevant last move ----------------------------------------
 
-def test_last_move_encoded_when_queen_consults():
-    """Enemy base-form queen has LOS to the piece that just moved ->
-    Restriction 2 is armed -> the FEN must carry last:<fromto>."""
+def test_moved_flag_encoded_and_no_highlight_after_reload():
+    """First-class flags: the moved piece carries ~ in the FEN; the
+    literal last-move coordinates are NOT encoded, so a FEN-loaded
+    game shows no last-move highlight (user decision 2026-07-20)."""
     g, b = _bare_game(turn_number=10, next_player='white')
-    b.squares[4][4].piece = Pawn('black')          # moved last turn
+    moved = Pawn('black')
+    moved.moved_last_turn = True                   # moved last turn
+    b.squares[4][4].piece = moved
     b.squares[4][1].piece = Queen('white', is_royal=True)  # LOS along rank
-    b.last_move = Move(Square(3, 4), Square(4, 4))
-    b.last_move_turn_number = 9
     fen = g.to_fen()
-    assert 'last:e5e4' in fen
+    assert 'p~' in fen
+    assert 'last:' not in fen
     g2, fen = _reload(g)
-    assert g2.board.last_move is not None
-    assert (g2.board.last_move.initial.row,
-            g2.board.last_move.initial.col) == (3, 4)
-    assert g2.board.last_move_turn_number == g2.board.turn_number - 1
+    assert g2.board.squares[4][4].piece.moved_last_turn is True
+    assert g2.board.last_move is None              # no highlight
     assert _hashes_equal(g, g2)
 
 
-def test_last_move_encoded_when_bishop_armed():
-    """Enemy bishop with diagonal LOS to the move's INITIAL square ->
-    reactive capture armed -> last: field present, and the loaded
-    game's legal turns include the reactive capture."""
+def test_armed_bishop_flag_roundtrips_with_capture():
+    """First-class flags: an armed bishop carries + and the moved
+    piece ~; the loaded game's legal turns include the reactive
+    capture (begin-time semantics, no coordinates involved)."""
     from ai_controller import AIController
     g, b = _bare_game(turn_number=10, next_player='white')
-    b.squares[3][6].piece = Rook('black')          # moved last turn
-    # White bishop with unblocked diagonal LOS to the move's INITIAL
-    # square (3,3): (5,5)-(4,4)-(3,3) is clear — the moved piece went
-    # OFF the diagonal, so the bishop stays armed in the current
-    # position (arming is evaluated post-move, matching both the
-    # state hash and bishop_moves generation).
-    b.squares[5][5].piece = Bishop('white')
-    b.last_move = Move(Square(3, 3), Square(3, 6))
-    b.last_move_turn_number = 9
+    moved = Rook('black')
+    moved.moved_last_turn = True                   # moved last turn
+    b.squares[3][6].piece = moved
+    armed = Bishop('white')
+    armed.reactive_armed = True                    # begin-time armed
+    b.squares[5][5].piece = armed
     fen = g.to_fen()
-    assert 'last:d5g5' in fen
+    assert 'B+' in fen and 'r~' in fen
     g2, fen = _reload(g)
     assert _hashes_equal(g, g2)
     # The reactive capture is actually generated after the reload.
@@ -228,30 +225,40 @@ def test_last_move_encoded_when_bishop_armed():
     assert caps, 'reactive capture must survive the FEN round trip'
 
 
-def test_last_move_omitted_when_nothing_consults():
-    """A preceding move that no rule consults must NOT appear (the
-    hash treats it as irrelevant; the FEN stays minimal)."""
+def test_unconsulted_moved_flag_hashes_like_no_flag():
+    """The ~ suffix is emitted unconditionally (exact state restore),
+    but the hash stays conditional: with no rule consulting the moved
+    piece, the state hashes identically to the flagless twin."""
     g, b = _bare_game(turn_number=10, next_player='white')
-    b.squares[4][4].piece = Pawn('black')
-    b.last_move = Move(Square(3, 4), Square(4, 4))
-    b.last_move_turn_number = 9
+    moved = Pawn('black')
+    moved.moved_last_turn = True
+    b.squares[4][4].piece = moved
     fen = g.to_fen()
-    assert 'last:' not in fen
+    assert 'p~' in fen
     g2, fen = _reload(g)
     assert _hashes_equal(g, g2)
+    # Flagless twin hashes the same (nothing consults the move).
+    g3 = Game()
+    assert g3.load_from_fen(fen.replace('p~', 'p')) is True
+    assert (g3.board.get_state_hash('white')
+            == g.board.get_state_hash('white'))
 
 
-def test_stale_last_move_omitted():
-    """A last move from an EARLIER turn (not the immediately
-    preceding one) never appears."""
+def test_legacy_last_field_still_parses():
+    """Old FENs (and StartFEN headers of older V3 saves) carried
+    last:<fromto>; the parser translates it into the flags: the piece
+    at the final square is marked moved, bishops with diagonal LoS to
+    the initial square become armed. last_move stays None (no
+    highlight after a FEN load)."""
     g, b = _bare_game(turn_number=10, next_player='white')
-    b.squares[4][4].piece = Pawn('black')
-    b.squares[4][1].piece = Queen('white', is_royal=True)
-    b.last_move = Move(Square(3, 4), Square(4, 4))
-    b.last_move_turn_number = 5          # stale
-    fen = g.to_fen()
-    assert 'last:' not in fen
-    assert _hashes_equal(g, _reload(g)[0])
+    b.squares[3][6].piece = Rook('black')
+    b.squares[5][5].piece = Bishop('white')
+    fen = g.to_fen() + ' last:d5g5'
+    g2 = Game()
+    assert g2.load_from_fen(fen) is True
+    assert g2.board.squares[3][6].piece.moved_last_turn is True
+    assert g2.board.squares[5][5].piece.reactive_armed is True
+    assert g2.board.last_move is None
 
 
 # ---- legality reproduction (the point of it all) -------------------------
@@ -268,8 +275,7 @@ def test_legal_turn_set_survives_reload_with_markers():
     shielded.invulnerable = True
     b.squares[3][3].piece = shielded
     b.squares[4][1].piece = Queen('white', is_royal=True)
-    b.last_move = Move(Square(3, 4), Square(4, 4))
-    b.last_move_turn_number = 9
+    b.squares[4][4].piece.moved_last_turn = True   # armed queen consult
     g2, fen = _reload(g)
     ai = AIController('white')
 

--- a/tests/test_first_class_flags.py
+++ b/tests/test_first_class_flags.py
@@ -1,0 +1,252 @@
+"""Regression tests for the first-class last-move flags redesign
+(user decision 2026-07-20, closing two state-hash gaps):
+
+  GAP 1 (confirmed): the old hash's reactive_armed evaluated bishop
+  LoS to the move's initial square in the POST-move position, while
+  generation honored BEGIN-time LoS (rulebook: the piece "begins its
+  move on a square within the bishop's diagonal line-of-sight"). A
+  mover landing on its own trail (knight 2-diagonal jump along the
+  bishop's diagonal) was capturable live, yet the armed and unarmed
+  states hashed equal — and a FEN reload lost the capture.
+
+  GAP 2: the old hash set moved_last_turn only under queen-LoS /
+  knight-adjacency consultation, never for an armed bishop — so the
+  armed bishop's capture TARGET was not pinned (two states with the
+  same armed set but different movers hashed equal with different
+  legal captures).
+
+Design: `piece.moved_last_turn` (exactly one piece) and
+`piece.reactive_armed` (bishops, from PRE-move LoS) are set by
+Board.move, expired by the next turn (including action turns via
+record_action_turn), consumed by generation, the hash, and the FEN.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import pytest
+
+from game import Game
+from ai_controller import AIController
+from piece import King, Queen, Rook, Bishop, Knight, Pawn
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+    if not pygame.font.get_init():
+        pygame.font.init()
+
+
+def _bare_game(next_player, turn_number=10):
+    g = Game()
+    b = g.board
+    for r in range(8):
+        for c in range(8):
+            b.squares[r][c].piece = None
+    b.boulder = None
+    b.squares[0][0].piece = King('black')
+    b.squares[0][7].piece = King('white')
+    b.turn_number = turn_number
+    b.last_move = None
+    b.last_move_turn_number = None
+    b.clear_turn_flags()
+    g.next_player = next_player
+    return g, b
+
+
+def _ai():
+    return AIController('white')
+
+
+# ---- GAP 1: begin-time arming (the confirmed bug) ------------------------
+
+def test_self_blocking_trail_stays_armed_and_roundtrips():
+    """Knight jumps along the bishop's diagonal, landing between the
+    bishop and its own start square: begin-time LoS was clear, so the
+    reactive capture is live — and must survive hashing and the FEN
+    round trip (the old post-move LoS check lost it)."""
+    g, b = _bare_game(next_player='black')
+    wb = Bishop('white')
+    b.squares[7][7].piece = wb
+    b.squares[3][3].piece = Knight('black')
+
+    ai = _ai()
+    jump = [t for t in ai.legal_turns(g)
+            if t.turn_type == 'move' and t.from_sq == (3, 3)
+            and t.to_sq == (5, 5)]
+    assert jump, 'setup: the 2-diagonal jump must be legal'
+    ai._apply_turn(g, jump[0])
+
+    # Flags: begin-time armed, mover marked.
+    assert wb.reactive_armed is True
+    assert b.squares[5][5].piece.moved_last_turn is True
+    # Live reactive capture offered.
+    live = [t for t in ai.legal_turns(g)
+            if t.from_sq == (7, 7) and t.to_sq == (5, 5)]
+    assert live, 'reactive capture must be offered live'
+
+    # FEN round trip preserves the capture and the hash.
+    fen = g.to_fen()
+    assert 'B+' in fen and 'n~' in fen
+    g2 = Game()
+    assert g2.load_from_fen(fen) is True
+    re = [t for t in ai.legal_turns(g2)
+          if t.from_sq == (7, 7) and t.to_sq == (5, 5)]
+    assert re, 'reactive capture must survive the FEN round trip'
+    assert (g.board.get_state_hash('white')
+            == g2.board.get_state_hash('white'))
+
+    # The armed state hashes DIFFERENTLY from the flagless twin —
+    # this inequality is exactly what the old design got wrong.
+    g3 = Game()
+    assert g3.load_from_fen(fen.replace('B+', 'B')
+                            .replace('n~', 'n')) is True
+    assert (g.board.get_state_hash('white')
+            != g3.board.get_state_hash('white'))
+
+
+# ---- GAP 2: the armed bishop's target is pinned --------------------------
+
+def test_armed_bishop_target_is_pinned_by_hash():
+    """Two states with the identical placement and the same armed
+    bishop but DIFFERENT moved pieces must hash differently — the
+    armed bishop's legal capture differs."""
+    def build(moved_sq):
+        g, b = _bare_game(next_player='white')
+        armed = Bishop('white')
+        armed.reactive_armed = True
+        b.squares[5][5].piece = armed
+        b.squares[1][0].piece = Rook('black')
+        b.squares[1][2].piece = Knight('black')
+        b.squares[moved_sq[0]][moved_sq[1]].piece.moved_last_turn = True
+        return g
+
+    ga = build((1, 0))       # the rook moved
+    gb = build((1, 2))       # the knight moved
+    assert (ga.board.get_state_hash('white')
+            != gb.board.get_state_hash('white')), (
+        'the armed capture target must be pinned by the hash')
+
+
+# ---- lifecycle -----------------------------------------------------------
+
+def test_transformation_expires_flags():
+    """A real transformation (action turn) expires both flags — the
+    previous move is no longer the immediately preceding turn."""
+    g, b = _bare_game(next_player='black')
+    wb = Bishop('white')
+    b.squares[7][7].piece = wb
+    b.squares[3][3].piece = Knight('black')
+    bq = Queen('black', is_royal=True)
+    b.squares[0][2].piece = bq
+    b.captured_pieces['black'].append('rook')
+
+    ai = _ai()
+    jump = [t for t in ai.legal_turns(g)
+            if t.turn_type == 'move' and t.from_sq == (3, 3)
+            and t.to_sq == (5, 5)]
+    ai._apply_turn(g, jump[0])
+    assert wb.reactive_armed is True
+
+    # White transforms nothing — it's white's turn; give white a
+    # transformable queen instead and transform it.
+    wq = Queen('white', is_royal=True)
+    b.squares[7][0].piece = wq
+    b.captured_pieces['white'].append('rook')
+    trans = [t for t in ai.legal_turns(g)
+             if t.turn_type == 'transformation' and t.from_sq == (7, 0)]
+    assert trans, 'setup: white queen must be able to transform'
+    ai._apply_turn(g, trans[0])
+
+    assert wb.reactive_armed is False
+    assert b.squares[5][5].piece.moved_last_turn is False
+
+
+def test_boulder_move_expires_without_setting():
+    """A boulder turn expires the previous flags and sets none (the
+    neutral boulder arms no rule)."""
+    g, b = _bare_game(next_player='black')
+    b.squares[3][3].piece = Knight('black')
+    from piece import Boulder
+    o = Boulder()
+    o.on_intersection = False
+    o.first_move = False
+    b.squares[6][6].piece = o
+
+    ai = _ai()
+    jump = [t for t in ai.legal_turns(g)
+            if t.turn_type == 'move' and t.from_sq == (3, 3)]
+    ai._apply_turn(g, jump[0])
+    moved = [p for r in range(8) for c in range(8)
+             for p in [b.squares[r][c].piece]
+             if p is not None and p.moved_last_turn]
+    assert len(moved) == 1
+
+    boulder_turns = [t for t in ai.legal_turns(g)
+                     if t.turn_type == 'boulder']
+    assert boulder_turns, 'setup: white must have a boulder move'
+    ai._apply_turn(g, boulder_turns[0])
+    flagged = [p for r in range(8) for c in range(8)
+               for p in [b.squares[r][c].piece]
+               if p is not None and (p.moved_last_turn or p.reactive_armed)]
+    assert flagged == []
+
+
+def test_promotion_transfers_moved_flag():
+    """The promoted piece replaces the pawn that just moved — it
+    inherits moved_last_turn so armed bishops / knight windows still
+    target it."""
+    g, b = _bare_game(next_player='white')
+    wp = Pawn('white')
+    wp.moved = True
+    b.squares[1][3].piece = wp
+
+    ai = _ai()
+    promo = [t for t in ai.legal_turns(g)
+             if t.promo_choice == 'queen' and t.from_sq == (1, 3)]
+    assert promo, 'setup: promotion must be available'
+    ai._apply_turn(g, promo[0])
+    promoted = b.squares[0][3].piece
+    assert isinstance(promoted, Queen)
+    assert promoted.moved_last_turn is True
+
+
+def test_double_manipulation_arms_bishop():
+    """A manipulates B's piece off A's bishop's LoS: arming happens at
+    the manipulation move itself (begin-time), replacing the old
+    stale-cache workaround."""
+    g, b = _bare_game(next_player='white')
+    wb = Bishop('white')
+    b.squares[7][7].piece = wb
+    # Black rook on the white bishop's diagonal; white queen with LoS
+    # to it for the manipulation.
+    br = Rook('black')
+    b.squares[4][4].piece = br
+    wq = Queen('white', is_royal=True)
+    b.squares[4][6].piece = wq          # rank LoS to the rook
+
+    ai = _ai()
+    manip = [t for t in ai.legal_turns(g)
+             if t.turn_type == 'manipulation' and t.from_sq == (4, 4)]
+    assert manip, 'setup: manipulation of the rook must be available'
+    off_diag = [t for t in manip if t.to_sq[0] != t.to_sq[1]]
+    target = off_diag[0] if off_diag else manip[0]
+    ai._apply_turn(g, target)
+    assert wb.reactive_armed is True
+    moved_sq = target.to_sq
+    assert b.squares[moved_sq[0]][moved_sq[1]].piece.moved_last_turn is True

--- a/tests/test_piece_movement.py
+++ b/tests/test_piece_movement.py
@@ -788,11 +788,9 @@ class TestQueen(unittest.TestCase):
         queen = place(board, "a1", Queen('white'))
         board.update_lines_of_sight()
         enemy_rook = place(board, "a4", Rook('black'))
-        board.last_move = Move(Square(*sq("a5")), Square(*sq("a4")))
-        # Pin the turn-number-pairing so the restriction fires: the
-        # recorded move was on turn N and the current turn is N+1.
-        board.last_move_turn_number = 1
-        board.turn_number = 2
+        # First-class flag (2026-07-20): the target moved on the
+        # immediately preceding turn.
+        enemy_rook.moved_last_turn = True
         board.queen_moves_enemy(enemy_rook, *sq("a4"))
         dests = get_move_destinations(enemy_rook)
         self.assertEqual(len(dests), 0, "Piece that just moved should not be manipulable")
@@ -886,9 +884,9 @@ class TestQueen(unittest.TestCase):
         queen = place(board, "a1", Queen('white'))
         board.update_lines_of_sight()
         enemy_rook = place(board, "a4", Rook('black'))
-        board.last_move = Move(Square(*sq("a5")), Square(*sq("a4")))
-        board.last_move_turn_number = 2
-        board.turn_number = 3  # preceding turn (turn 2) was the rook's move
+        # First-class flag: the rook genuinely moved on the
+        # immediately preceding turn.
+        enemy_rook.moved_last_turn = True
         board.queen_moves_enemy(enemy_rook, *sq("a4"))
         dests = get_move_destinations(enemy_rook)
         self.assertEqual(len(dests), 0, (
@@ -1637,9 +1635,11 @@ class TestBishop(unittest.TestCase):
         """Bishop on e4 can capture a piece that left its diagonal (c6 -> c5)."""
         board = empty_board()
         bishop = place(board, "e4", Bishop('white'))
-        bishop.assassin_squares = [Square(*sq("c6"))]
-        place(board, "c5", Pawn('black'))
-        board.last_move = Move(Square(*sq("c6")), Square(*sq("c5")))
+        # First-class flags (2026-07-20): the bishop was armed at
+        # begin-time and the pawn is the moved piece.
+        bishop.reactive_armed = True
+        pawn = place(board, "c5", Pawn('black'))
+        pawn.moved_last_turn = True
         board.bishop_moves(bishop, *sq("e4"))
         dests = get_move_destinations(bishop)
         self.assertIn(sq("c5"), dests)
@@ -1713,12 +1713,13 @@ class TestBishop(unittest.TestCase):
         knight.invulnerable = False
 
         # Black's turn: knight moves from c6 to somewhere off the diagonal
-        # (say a5). It's a plain move, no jump, so it stays capturable.
+        # (say a5) via the REAL move path — Board.move computes the
+        # begin-time armed bishops (the white bishop has diagonal LoS
+        # to c6) and sets the first-class flags.
         new_row, new_col = sq("a5")
-        board.squares[sq("c6")[0]][sq("c6")[1]].piece = None
-        board.squares[new_row][new_col].piece = knight
-        board.last_move = Move(Square(*sq("c6")), Square(new_row, new_col))
-        board.last_move_turn_number = 1
+        board.move(knight, Move(Square(*sq("c6")), Square(new_row, new_col)))
+        self.assertTrue(bishop.reactive_armed)
+        self.assertTrue(knight.moved_last_turn)
 
         # White's next turn: bishop generates moves; should be able to
         # assassin-capture the knight at a5.
@@ -2102,12 +2103,9 @@ class TestKnight(unittest.TestCase):
         was the v0/v1 rule, replaced in v2."""
         board = empty_board()
         knight = place(board, "e4", Knight('white'))
-        place(board, "e5", Pawn('black'))  # jumped piece
+        jumped = place(board, "e5", Pawn('black'))  # jumped piece
+        jumped.moved_last_turn = True  # moved on the preceding turn
         place(board, "d6", Rook('black'))  # adjacent to landing e6 — NOT a target in v2
-        # Simulate: black's pawn moved to e5 on the immediately preceding turn
-        board.turn_number = 2
-        board.last_move = Move(Square(*sq("e7")), Square(*sq("e5")))
-        board.last_move_turn_number = 1
         board.knight_moves(knight, *sq("e4"))
         move = Move(Square(*sq("e4")), Square(*sq("e6")))
         targets = board.move(knight, move)
@@ -2161,12 +2159,10 @@ class TestKnight(unittest.TestCase):
         board until execute_jump_capture is called."""
         board = empty_board()
         knight = place(board, "e4", Knight('white'))
-        place(board, "e5", Pawn('black'))   # jumped piece (eligible after recent move)
+        jumped = place(board, "e5", Pawn('black'))   # jumped piece (eligible after recent move)
+        jumped.moved_last_turn = True
         place(board, "d6", Rook('black'))   # adjacent to landing e6 — irrelevant in v2
         place(board, "f6", Bishop('black')) # also adjacent — irrelevant in v2
-        board.turn_number = 2
-        board.last_move = Move(Square(*sq("e7")), Square(*sq("e5")))
-        board.last_move_turn_number = 1
         board.knight_moves(knight, *sq("e4"))
         move = Move(Square(*sq("e4")), Square(*sq("e6")))
         targets = board.move(knight, move)
@@ -2197,11 +2193,9 @@ class TestKnight(unittest.TestCase):
         under the new rule the jumped-piece-color gate denies it."""
         board = empty_board()
         knight = place(board, "e4", Knight('white'))
-        place(board, "e5", Pawn('black'))  # jumped piece (eligible enemy)
+        jumped = place(board, "e5", Pawn('black'))  # jumped piece (eligible enemy)
+        jumped.moved_last_turn = True
         place(board, "d6", Rook('black'))  # adjacent to landing e6
-        board.turn_number = 2
-        board.last_move = Move(Square(*sq("e7")), Square(*sq("e5")))
-        board.last_move_turn_number = 1
         board.knight_moves(knight, *sq("e4"))
         move = Move(Square(*sq("e4")), Square(*sq("e6")))
         targets = board.move(knight, move)
@@ -2226,10 +2220,8 @@ class TestKnight(unittest.TestCase):
         candidates as in v0/v1). When eligible, it's the single capture option."""
         board = empty_board()
         knight = place(board, "e4", Knight('white'))
-        place(board, "e5", Rook('black'))  # jumped piece
-        board.turn_number = 2
-        board.last_move = Move(Square(*sq("e7")), Square(*sq("e5")))
-        board.last_move_turn_number = 1
+        jumped = place(board, "e5", Rook('black'))  # jumped piece
+        jumped.moved_last_turn = True
         board.knight_moves(knight, *sq("e4"))
         move = Move(Square(*sq("e4")), Square(*sq("e6")))
         targets = board.move(knight, move)
@@ -3439,10 +3431,9 @@ class TestRepetitionRule(unittest.TestCase):
         # a4=(4,0), d4=(4,3), e4=(4,4).
         board1 = empty_board()
         place(board1, "a4", Queen('white'))  # base-form queen
-        place(board1, "d4", Rook('black'))
+        moved1 = place(board1, "d4", Rook('black'))
+        moved1.moved_last_turn = True   # first-class flag (2026-07-20)
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)  # e4(4,4) → d4(4,3)
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
@@ -3460,11 +3451,10 @@ class TestRepetitionRule(unittest.TestCase):
         # c3=(2,2), d4=(4,3); chebyshev distance from c3 to d4 = max(|2-4|,|2-3|)=2. NOT chebyshev-1.
         # Need a knight closer. Use c5=(4,2) (chebyshev-1 of d4): max(|4-4|,|2-3|)=1. ✓
         board1 = empty_board()
-        place(board1, "d4", Rook('black'))
+        moved1 = place(board1, "d4", Rook('black'))
+        moved1.moved_last_turn = True   # first-class flag
         place(board1, "c5", Knight('white'))   # chebyshev-1 of d4
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
@@ -3483,19 +3473,17 @@ class TestRepetitionRule(unittest.TestCase):
         # e4=(4,4) (the e4-h1 diagonal: e4, f3, g2, h1 with Δfile=Δrank).
         # f3=(2,5), g2=(1,6), h1=(0,7). Path e4→h1 needs f3 and g2 empty. ✓
         board1 = empty_board()
-        place(board1, "d4", Rook('black'))
-        place(board1, "h1", Bishop('white'))
+        moved1 = place(board1, "d4", Rook('black'))
+        moved1.moved_last_turn = True   # first-class flags: armed pair
+        armed1 = place(board1, "h1", Bishop('white'))
+        armed1.reactive_armed = True
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4 → final d4
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
         place(board2, "d4", Rook('black'))
         place(board2, "h1", Bishop('white'))
         board2.turn_number = 5
-        board2.last_move = None
-        board2.last_move_turn_number = None
         hash2 = board2.get_state_hash('white')
         self.assertNotEqual(hash1, hash2)
 
@@ -3507,10 +3495,9 @@ class TestRepetitionRule(unittest.TestCase):
         board1 = empty_board()
         place(board1, "e1", King('white'))
         place(board1, "e8", King('black'))
-        place(board1, "d4", Rook('black'))
+        moved1 = place(board1, "d4", Rook('black'))
+        moved1.moved_last_turn = True   # first-class flag, unconsulted
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
@@ -3527,14 +3514,16 @@ class TestRepetitionRule(unittest.TestCase):
         """last_move from 2+ turns ago hashes identically to no last_move
         — what matters is specifically "on the immediately preceding turn"
         for all three rules (R2, jump-capture, bishop reactive)."""
-        # Enemy queen IS positioned to make last_move relevant IF preceding-turn,
-        # but the recorded last_move is older. So hash should match no-last-move.
+        # First-class flags: an older move means the flag has already
+        # been expired (the next turn cleared it — including action
+        # turns via record_action_turn). Simulate the lifecycle: set
+        # the flag, expire it, hash.
         board1 = empty_board()
         place(board1, "a4", Queen('white'))
-        place(board1, "d4", Rook('black'))
+        moved1 = place(board1, "d4", Rook('black'))
+        moved1.moved_last_turn = True
+        board1.record_action_turn()      # an action turn expires it
         board1.turn_number = 10
-        board1.last_move = self._StubMove(4, 4, 4, 3)
-        board1.last_move_turn_number = 5  # ancient, not the preceding turn
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
@@ -3559,44 +3548,44 @@ class TestRepetitionRule(unittest.TestCase):
         not the literal initial coordinate."""
         # h1=(7,7). Both e4=(4,4) and c6=(2,2) are on h1's a8-h1 diagonal.
         # So h1 is armed in both states.
+        # First-class flags: the literal initial square no longer
+        # exists anywhere — identical flags trivially hash equal. Kept
+        # as a regression guard on the flag-only contract.
         board1 = empty_board()
-        place(board1, "d4", Rook('black'))
-        place(board1, "h1", Bishop('white'))
+        m1 = place(board1, "d4", Rook('black'))
+        m1.moved_last_turn = True
+        a1 = place(board1, "h1", Bishop('white'))
+        a1.reactive_armed = True
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4 → final d4
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
-        place(board2, "d4", Rook('black'))
-        place(board2, "h1", Bishop('white'))
+        m2 = place(board2, "d4", Rook('black'))
+        m2.moved_last_turn = True
+        a2 = place(board2, "h1", Bishop('white'))
+        a2.reactive_armed = True
         board2.turn_number = 5
-        # initial c6=(2,2) is also on h1's diagonal. h1 is still armed.
-        board2.last_move = self._StubMove(2, 2, 4, 3)
-        board2.last_move_turn_number = 4
         hash2 = board2.get_state_hash('white')
         self.assertEqual(hash1, hash2)
 
     def test_board_state_hash_different_armed_bishop_set_different_hash(self):
         """Two states with DIFFERENT sets of armed bishops hash DIFFERENTLY.
         State1: bishop at h1 armed. State2: bishop at h1 NOT armed."""
-        # state1: initial e4 on h1 diagonal → h1 armed.
+        # state1: h1 armed (first-class flag).
         board1 = empty_board()
-        place(board1, "d4", Rook('black'))
-        place(board1, "h1", Bishop('white'))
+        m1 = place(board1, "d4", Rook('black'))
+        m1.moved_last_turn = True
+        a1 = place(board1, "h1", Bishop('white'))
+        a1.reactive_armed = True
         board1.turn_number = 5
-        board1.last_move = self._StubMove(4, 4, 4, 3)  # initial e4
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
-        # state2: initial b3=(5,1). h1=(7,7) to b3=(5,1) diff (-2,-6).
-        # NOT diagonal (|Δr|≠|Δc|). h1 NOT armed.
+        # state2: same placement + moved piece, h1 NOT armed.
         board2 = empty_board()
-        place(board2, "d4", Rook('black'))
+        m2 = place(board2, "d4", Rook('black'))
+        m2.moved_last_turn = True
         place(board2, "h1", Bishop('white'))
         board2.turn_number = 5
-        board2.last_move = self._StubMove(5, 1, 4, 3)
-        board2.last_move_turn_number = 4
         hash2 = board2.get_state_hash('white')
         self.assertNotEqual(hash1, hash2)
 
@@ -3628,23 +3617,22 @@ class TestRepetitionRule(unittest.TestCase):
         # B at a1=(7,0): diff (-2, 0). Same file but Δr=2, Δc=0. NOT diag.
         # Both NOT armed. Different from state1 (B armed in state1, no one in state2).
         board1 = empty_board()
-        place(board1, "d4", Rook('black'))
+        m1 = place(board1, "d4", Rook('black'))
+        m1.moved_last_turn = True
         place(board1, "h1", Bishop('white'))
-        place(board1, "a1", Bishop('white'))
+        b1 = place(board1, "a1", Bishop('white'))
+        b1.reactive_armed = True               # armed set {a1}
         board1.turn_number = 5
-        board1.last_move = self._StubMove(6, 1, 4, 3)  # initial b2 — B (a1) armed
-        board1.last_move_turn_number = 4
         hash1 = board1.get_state_hash('white')
 
         board2 = empty_board()
-        place(board2, "d4", Rook('black'))
+        m2 = place(board2, "d4", Rook('black'))
+        m2.moved_last_turn = True
         place(board2, "h1", Bishop('white'))
-        place(board2, "a1", Bishop('white'))
+        place(board2, "a1", Bishop('white'))    # armed set {}
         board2.turn_number = 5
-        board2.last_move = self._StubMove(5, 0, 4, 3)  # initial a3 — no bishop armed
-        board2.last_move_turn_number = 4
         hash2 = board2.get_state_hash('white')
-        # Different armed sets ({B} vs {}) → different hash.
+        # Different armed sets ({a1} vs {}) → different hash.
         self.assertNotEqual(hash1, hash2)
 
     # 2026-05-26 boulder no-return-memory refinement: last_square only
@@ -4194,20 +4182,20 @@ class TestRepetitionRule(unittest.TestCase):
         # moved_last_turn flag (True here: the white base-form queen on e1
         # has file LoS to e3).
         manip_move = Move(Square(*sq("e4")), Square(*sq("e3")))
+        # First-class flags (2026-07-20): mirror what the simulation
+        # now does — begin-time armed bishops (none here) + the flag
+        # update, instead of last_move/turn-number mirroring.
+        armed = board._compute_armed_bishops(black_rook, Square(*sq("e4")))
         board.squares[sq("e4")[0]][sq("e4")[1]].piece = None
         place(board, "e3", black_rook)
         black_rook.moved_by_queen = True
-        board.last_move = manip_move
-        board.last_move_turn_number = board.turn_number
-        board.turn_number += 1
+        board._record_turn_flags(black_rook, armed)
         # Simulate boulder decrement (no boulder = no-op) and end_turn's
         # clear_invulnerable_for_color('black') (nothing invulnerable = no-op)
         state_after = board.get_state_hash('black')
         board.state_history[state_after] = 2
         # Restore
-        board.turn_number -= 1
-        board.last_move = None
-        board.last_move_turn_number = None
+        board.clear_turn_flags()
         black_rook.moved_by_queen = False
         board.squares[sq("e3")[0]][sq("e3")[1]].piece = None
         place(board, "e4", black_rook)

--- a/tests/test_repetition_manipulation_bug.py
+++ b/tests/test_repetition_manipulation_bug.py
@@ -205,6 +205,10 @@ def test_would_cause_repetition_catches_manipulation_cycle():
     # Helper: apply move + mirror what game.next_turn does, record.
     def apply_and_record(piece, fr, fc, tr, tc, mover):
         other = 'black' if mover == 'white' else 'white'
+        # First-class flags (2026-07-20): mirror board.move — compute
+        # begin-time armed bishops BEFORE mutating, record the flags
+        # after (the hash reads the flags, not last_move).
+        armed = b._compute_armed_bishops(piece, Square(fr, fc))
         b.squares[fr][fc].piece = None
         b.squares[tr][tc].piece = piece
         # If manipulation (piece's color != mover): set moved_by_queen.
@@ -214,6 +218,7 @@ def test_would_cause_repetition_catches_manipulation_cycle():
         b.last_move = Move(Square(fr, fc), Square(tr, tc))
         b.last_move_turn_number = b.turn_number
         b.turn_number += 1
+        b._record_turn_flags(piece, armed)
         b.clear_moved_by_queen_for_opponent(other)
         b.clear_invulnerable_for_color(other)
         h = b.get_state_hash(other)
@@ -221,7 +226,8 @@ def test_would_cause_repetition_catches_manipulation_cycle():
         return h
 
     def undo_to(piece, fr, fc, tr, tc, prev_last_move, prev_turn_num):
-        """Undo the moved piece + restore last_move + turn_number."""
+        """Undo the moved piece + restore last_move + turn_number +
+        the first-class flags (the setup state carried none)."""
         b.squares[tr][tc].piece = None
         b.squares[fr][fc].piece = piece
         piece.moved_by_queen = False
@@ -229,6 +235,7 @@ def test_would_cause_repetition_catches_manipulation_cycle():
         b.last_move_turn_number = (
             (prev_turn_num - 1) if prev_last_move is not None else None)
         b.turn_number = prev_turn_num
+        b.clear_turn_flags()
 
     # Apply manipulation: pawn e2->d2.
     saved_last_move = b.last_move

--- a/tests/test_v2_knight.py
+++ b/tests/test_v2_knight.py
@@ -109,6 +109,15 @@ def _set_last_move(board, from_rc, to_rc, turn_number_at_move):
     to_sq = Square(*to_rc)
     board.last_move = Move(from_sq, to_sq)
     board.last_move_turn_number = turn_number_at_move
+    # First-class flags (2026-07-20): the rules consult the per-piece
+    # moved_last_turn flag, not the coordinates. Mark the piece at the
+    # destination iff the pairing says the move happened on the
+    # immediately preceding turn (set board.turn_number BEFORE calling,
+    # as every test in this file does).
+    p = board.squares[to_rc[0]][to_rc[1]].piece
+    if p is not None:
+        p.moved_last_turn = (
+            turn_number_at_move == board.turn_number - 1)
 
 
 # -------------------------------------------------------------------------
@@ -1523,6 +1532,7 @@ def test_v2_knight_still_uses_reactive_capture_after_legacy_added():
     b.turn_number = 2
     b.last_move = Move(Square(2, 4), Square(3, 4))
     b.last_move_turn_number = 1
+    b.squares[3][4].piece.moved_last_turn = True   # first-class flag
     move = Move(Square(4, 4), Square(2, 4))
     targets = b.move(knight, move)
     assert targets == [(3, 4)], (

--- a/tests/test_v2_knight_invuln_remake.py
+++ b/tests/test_v2_knight_invuln_remake.py
@@ -328,10 +328,12 @@ def test_declined_jump_capture_over_enemy_CAN_now_grant_invuln():
                (lambda: Pawn('black'), 3, 4)],   # eligible enemy (jumped)
     )
     knight = b.squares[3][3].piece
-    # Make the jumped enemy eligible: it moved last turn.
+    # Make the jumped enemy eligible: it moved last turn
+    # (first-class flag, 2026-07-20).
     b.last_move = Move(Square(2, 4), Square(3, 4))
     b.last_move_turn_number = 4
     b.turn_number = 5
+    b.squares[3][4].piece.moved_last_turn = True
     targets = b.move(knight, Move(Square(3, 3), Square(3, 5)))
     # A jump-capture offer comes back; the player DECLINES:
     assert targets, 'expected a jump-capture offer'
@@ -354,6 +356,7 @@ def test_declined_jump_capture_without_friendly_grants_nothing():
     b.last_move = Move(Square(2, 4), Square(3, 4))
     b.last_move_turn_number = 4
     b.turn_number = 5
+    b.squares[3][4].piece.moved_last_turn = True   # first-class flag
     targets = b.move(knight, Move(Square(3, 3), Square(3, 5)))
     assert targets, 'expected a jump-capture offer'
     granted = b.set_invulnerable_after_jump_decline(


### PR DESCRIPTION
Closes #150. Replaces the derived last-move machinery with two first-class per-piece flags — `moved_last_turn` and `reactive_armed` — set by `Board.move` (armed-ness from the PRE-move position, per the rulebook's begin-time semantics), expired by the next turn including actions, and consumed by move generation, the repetition hash, and the FEN. Fixes both gaps:

1. **Begin-time arming (confirmed by repro)**: a mover landing on its own trail stayed capturable live but hashed as unarmed and lost the capture on FEN reload. Now armed-ness is stored at move time; the end-to-end repro is a regression test.
2. **Pinned target**: `moved_last_turn` is now also hashed when any bishop is armed, so the armed bishop's capture target distinguishes states.

Bonus fixes along the way: the transformation repetition simulation never mirrored the turn advance (stale `is_preceding` in simulated hashes) — the explicit action-turn flag expiry closes that; and the bishop generation's stale-assassin-cache workaround for double manipulation is gone (arming happens at the manipulation move itself).

FEN: `~` / `+` suffixes replace `last:<fromto>` (legacy input still parsed); FEN-loaded games show no last-move highlight (user decision). `board.last_move` remains only for the UI highlight. Hash tuple shape unchanged (V2-loaded histories stay comparable outside the fixed edges).

Docs: RULEBOOK repetition-state bullets, key-rule-differences, royal-notation, state-hash design note (+ design-notes mirror).

**Tests**: 6 new in `test_first_class_flags.py`; stale-mechanism tests updated across 6 files (same family as #117/#120/#123). Full sweep green: 350 + 40 + 6 + 134 + 223 + 158 + 20 + manipulation-variants alone (106+3s). `test_ai`'s 6 remaining failures are pre-existing on main (identical failure sets verified; follow-up task filed). GDL cross-validation passes; auditing the GDL's own reactive-arming edge is noted as a future item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)