### PR TITLE
Update hover square during AI turns in HvC/CvC autoplay wait

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -210,6 +210,7 @@ class Main:
                 start = pygame.time.get_ticks()
                 _aborted = False
                 while pygame.time.get_ticks() - start < 600:
+                    _hover_changed = False
                     for event in pygame.event.get():
                         if event.type == pygame.QUIT:
                             pygame.quit()
@@ -231,6 +232,28 @@ class Main:
                             if result.get('view_changed'):
                                 self._render_frame(game, dragger)
                                 pygame.display.update()
+                        # Hover tracking during AI turns (2026-07-20
+                        # user report: the gray hover outline froze
+                        # while the computer was moving in HvC/CvC —
+                        # MOUSEMOTION was silently dropped here).
+                        # Mirrors the main loop's motion branch:
+                        # screen-coord bounds + flip translation via
+                        # set_hover_screen. Rendering is deferred to
+                        # once per 15 ms tick (below) so a burst of
+                        # motion events can't lag the AI's schedule.
+                        if event.type == pygame.MOUSEMOTION:
+                            motion_row = event.pos[1] // SQSIZE
+                            motion_col = event.pos[0] // SQSIZE
+                            if (0 <= motion_row <= 7
+                                    and 0 <= motion_col <= 7):
+                                _prev_hover = game.hovered_sqr
+                                game.set_hover_screen(motion_row,
+                                                      motion_col)
+                                if game.hovered_sqr is not _prev_hover:
+                                    _hover_changed = True
+                    if _hover_changed:
+                        self._render_frame(game, dragger)
+                        pygame.display.update()
                     if game.is_autoplay_paused():
                         _aborted = True
                         break


### PR DESCRIPTION
Closes #156. The autoplay wait loop only dispatched QUIT/KEYDOWN, silently dropping MOUSEMOTION — so the gray hover outline froze whenever an AI was on move (same event-starvation family as the old "all keys disabled in CvC" bug). The wait loop now mirrors the main loop's motion branch (bounds + flip translation via `set_hover_screen`) and re-renders inline at most once per 15 ms tick, only when the hovered square actually changed — so motion bursts can't delay the AI's schedule. Suites: cvc mode/keys, flip board, ai controller green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)