### PR TITLE
Pause dialog: unverified preview + state-fingerprint cache (250x faster)

### DIFF
--- a/src/game.py
+++ b/src/game.py
@@ -513,6 +513,9 @@ class Game:
         # expires. _copied_button is 'save' or 'fen'.
         self._copied_at_ms = None
         self._copied_button = None
+        # Pause-dialog preview cache: (state_fingerprint, lines).
+        # See _pgn_dialog_preview_lines (issue #164).
+        self._pgn_preview_cache = None
         # Per-side player choice — the primary mode state. Both default to
         # 'human' (HvH). `user_side`, `opponent`, `ai_color`,
         # `ai_controller` are derived @property values kept for back-compat
@@ -836,6 +839,7 @@ class Game:
         self.reset_confirm_pending = False
         self.pgn_dialog_open = True
         self.pgn_dialog_status = None  # fresh dialog: no stale "Copied!" etc.
+        self._pgn_preview_cache = None  # recompute for the new session
 
     def close_pgn_dialog(self):
         """Close the dialog and drop its click rects + status message."""
@@ -862,21 +866,37 @@ class Game:
 
         Lines are short enough to fit the panel without further wrapping
         in the typical 800-px-wide window. Wrapping under unusual sizes
-        is handled visually by the renderer trimming each line."""
-        text = self.serialize_to_text()
+        is handled visually by the renderer trimming each line.
+
+        PERFORMANCE (issue #164): this runs on EVERY rendered frame
+        while the dialog is open. The preview therefore (a) uses the
+        UNVERIFIED serializer (no whole-game replay — that froze the
+        pause screen and made undo/redo crawl) and (b) is cached
+        under a state fingerprint so unchanged frames don't
+        re-serialize at all; undo/redo/new turns change the
+        fingerprint and recompute once. The Copy button is unrelated
+        and keeps the fully self-verified serialization."""
+        fingerprint = (len(self._history), len(self._redo_stack),
+                       self.board.turn_number, self.winner)
+        if (self._pgn_preview_cache is not None
+                and self._pgn_preview_cache[0] == fingerprint):
+            return self._pgn_preview_cache[1]
+        text = self.serialize_to_text(verify=False)
         # Keep first 3 header lines verbatim; then peek at the first
         # encoded line. The body is the base64 payload — a single very
         # long line. We show its prefix only.
         all_lines = text.split('\n')
         cap = self._PGN_PREVIEW_BODY_LINES
         if len(all_lines) <= cap:
-            return list(all_lines)
+            self._pgn_preview_cache = (fingerprint, list(all_lines))
+            return self._pgn_preview_cache[1]
         out = all_lines[:cap]
         # Replace the last visible line with a brief truncation marker
         # so the user knows there's more.
         out.append(
             f'... ({len(all_lines) - cap} more lines truncated — '
             f'use Copy)')
+        self._pgn_preview_cache = (fingerprint, out)
         return out
 
     # Panel dimensions for the centered dialog. The semi-transparent
@@ -1683,7 +1703,7 @@ class Game:
     _copy_to_clipboard = staticmethod(_default_copy_to_clipboard)
     _read_clipboard = staticmethod(_default_read_clipboard)
 
-    def serialize_to_text(self):
+    def serialize_to_text(self, verify=True):
         """Serialize the entire game state to text. Round-trips
         perfectly through `deserialize_from_text` / `load_from_text`.
 
@@ -1701,13 +1721,20 @@ class Game:
         standard initial position (e.g. loaded from a FEN or a
         truncated legacy save) — falls back to the V2 container
         below. ~10x smaller again than V2 on top of V2's ~40x.
+        `verify` (default True) controls the save-time self-check:
+        the movetext is replayed on a scratch game and every state
+        hash compared. Pass verify=False ONLY for throwaway display
+        (the pause dialog renders a preview every frame — issue #164;
+        replaying the whole game per frame froze the UI). Inference
+        failures fall back to V2 identically on both paths; anything
+        COPIED or SAVED must use the default verified path.
         """
         try:
-            return self._serialize_v3()
+            return self._serialize_v3(verify=verify)
         except Exception:
             return self._serialize_v2()
 
-    def _serialize_v3(self):
+    def _serialize_v3(self, verify=True):
         """Royal-notation writer. Raises (notation.NotationError or
         anything else) when the game cannot be represented — the
         caller falls back to _serialize_v2."""
@@ -1754,18 +1781,22 @@ class Game:
 
         # Self-verify: replay the movetext on the scratch game and
         # compare every resulting state against the live timeline.
-        for i, token in enumerate(tokens):
-            notation.apply_token(scratch, token)
-            expect = timeline[i + 1]
-            if (scratch.next_player != expect['next_player']
-                    or scratch.winner != expect['winner']
-                    or scratch.board.turn_number
-                    != expect['board'].turn_number
-                    or scratch.board.get_state_hash(scratch.next_player)
-                    != expect['board'].get_state_hash(
-                        expect['next_player'])):
-                raise notation.NotationError(
-                    f'replay diverged at turn {i + 1} ({token})')
+        # Skipped for verify=False (display preview only — the
+        # replay costs seconds on long games and the dialog renders
+        # every frame).
+        if verify:
+            for i, token in enumerate(tokens):
+                notation.apply_token(scratch, token)
+                expect = timeline[i + 1]
+                if (scratch.next_player != expect['next_player']
+                        or scratch.winner != expect['winner']
+                        or scratch.board.turn_number
+                        != expect['board'].turn_number
+                        or scratch.board.get_state_hash(scratch.next_player)
+                        != expect['board'].get_state_hash(
+                            expect['next_player'])):
+                    raise notation.NotationError(
+                        f'replay diverged at turn {i + 1} ({token})')
 
         header_lines = [
             '=== Chess Variant Save (v3 royal notation) ===',

--- a/tests/test_pause_dialog_perf.py
+++ b/tests/test_pause_dialog_perf.py
@@ -1,0 +1,107 @@
+"""Performance regression tests for the pause dialog (issue #164):
+the dialog preview must not run the V3 save's self-verifying replay
+(it renders every frame), and must cache across unchanged frames.
+The Copy button keeps the fully verified serialization.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pygame
+pygame.init()
+pygame.font.init()
+try:
+    pygame.mixer.init()
+except pygame.error:
+    pass
+
+import pytest
+
+import notation
+from game import Game
+from ai_controller import AIController
+
+
+@pytest.fixture(autouse=True)
+def _ensure_pygame_initialized():
+    if not pygame.get_init():
+        pygame.init()
+
+
+def _play(g, n, seed):
+    import random
+    rng = random.Random(seed)
+    ai = AIController('white')
+    for _ in range(n):
+        if g.winner is not None:
+            break
+        turns = ai.legal_turns(g)
+        if not turns:
+            break
+        ai._apply_turn(g, rng.choice(turns))
+    return g
+
+
+def test_unverified_serialize_matches_verified():
+    """The fast path must produce byte-identical output for a normal
+    game — only the safety re-check is skipped."""
+    g = _play(Game(), 24, seed=7)
+    assert g.serialize_to_text(verify=False) == g.serialize_to_text()
+
+
+def test_preview_does_not_replay(monkeypatch):
+    """The preview path must never run the self-verify replay:
+    apply_token exploding must not affect it (while the verified
+    path DOES replay)."""
+    g = _play(Game(), 12, seed=9)
+
+    def boom(*a, **k):
+        raise AssertionError('preview must not replay the game')
+    monkeypatch.setattr(notation, 'apply_token', boom)
+    lines = g._pgn_dialog_preview_lines()
+    assert lines, 'preview still renders without the replay'
+    # The verified path replays -> hits the explosive stub -> falls
+    # back to the V2 container (self-verify failure handling).
+    text = g.serialize_to_text()
+    assert '___VARIANT_SAVE_V2_BEGIN___' in text
+
+
+def test_preview_cached_across_unchanged_frames(monkeypatch):
+    g = _play(Game(), 12, seed=11)
+    calls = {'n': 0}
+    real = Game.serialize_to_text
+
+    def counting(self, verify=True):
+        calls['n'] += 1
+        return real(self, verify=verify)
+    monkeypatch.setattr(Game, 'serialize_to_text', counting)
+    first = g._pgn_dialog_preview_lines()
+    second = g._pgn_dialog_preview_lines()
+    assert first == second
+    assert calls['n'] == 1, 'unchanged frames must render from cache'
+    # State change (undo) invalidates the cache exactly once.
+    assert g.undo() is True
+    g._pgn_dialog_preview_lines()
+    g._pgn_dialog_preview_lines()
+    assert calls['n'] == 2
+
+
+def test_copy_still_fully_verified(monkeypatch):
+    """The Copy action keeps the verified serialization: when the
+    replay is broken, Copy falls back to V2 (proving it verified)."""
+    g = _play(Game(), 10, seed=13)
+    captured = {}
+    monkeypatch.setattr(Game, '_copy_to_clipboard',
+                        staticmethod(lambda t: captured.update(t=t) or True))
+
+    def boom(*a, **k):
+        raise AssertionError('verify replay ran (expected)')
+    monkeypatch.setattr(notation, 'apply_token', boom)
+    assert g.copy_to_clipboard_action()
+    assert '___VARIANT_SAVE_V2_BEGIN___' in captured['t'], (
+        'Copy must use the VERIFIED path (broken replay => V2 fallback)')


### PR DESCRIPTION
Closes #164. The dialog preview called `serialize_to_text()` every rendered frame — and since #143 that includes the full self-verifying replay of the game (~1 s per frame on a 150-turn game), which is why the pause screen crawled and undo/redo froze.

Fix: `serialize_to_text(verify=...)` — the preview uses `verify=False` (inference only; fallback behavior unchanged) while **Copy keeps the fully verified path** (pinned by a test that breaks the replay and watches Copy fall back to V2 while the preview is unaffected); plus a state-fingerprint cache so unchanged frames do zero work and undo/redo recompute exactly once.

Measured (150-turn game): 1.12 s verified (Copy, once) vs 4 ms first preview, ~0 ms cached frames, 15 ms undo+recompute. 121 tests green across the dialog/save suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)