### PR TITLE
LGMEF experiment harness: variants, metrics, well-formedness gate, entry point

### DIFF
--- a/docs/lgmef-experiments.md
+++ b/docs/lgmef-experiments.md
@@ -1,0 +1,57 @@
+# LGMEF experiment harness
+
+Infrastructure for the ISEF study "Quantifying Strategic Impact of Game
+Mechanics Using a Logic-Based Game Mechanic Evaluation Framework"
+(issue #168).
+
+## Architecture
+
+- **GDL step files** (`docs/gdl/`) are the formal *specification* of
+  each ablation (e.g. *No Boulder* ≈ building without
+  `step6_add_boulder.gdl`).
+- **The Python engine** is the *execution substrate*: ~35× faster than
+  the GDL resolver (measured 196 vs 5.7 moves/s), and already
+  cross-validated against the GDL (`src/ggp/cross_validation.py`).
+- **`src/experiments/variants.py`** defines variant *identity*: one
+  named `VariantSpec` per ablation, expressed as `GameEngine` kwargs.
+
+## Variants
+
+| Name | Ablation |
+|---|---|
+| `full` | Complete v2 rule set |
+| `no_boulder` | Boulder removed from the initial position |
+| `no_tiny_endgame` | Tiny-endgame rule never activates |
+| `no_queen_manipulation` | Manipulation turns not generated |
+| `no_knight_redesign` | Legacy knight (no radius-2/jump-capture/invulnerability) |
+| `baseline` | All four ablations at once |
+| `control_inert` | Negative control — identical to `full`; MCI must read ~0 |
+| `control_double_move` | Positive control — mover repeats every 10th turn; MCI must flag it |
+
+## Running
+
+```bash
+# Well-formedness gate only (random playouts, no training):
+python src/run_experiment.py --variant no_boulder --check
+
+# One (variant, seed) training run — gate runs first, then training:
+python src/run_experiment.py --variant no_boulder --seed 2 --iters 50
+```
+
+Outputs land in `models/experiments/<variant>/seed<k>/`:
+`experiment.json` (provenance), `wellformedness.json`,
+`model_iter_*.pt`, `training_history.json`, and `games/iter_*.jsonl`
+whose rows carry a `metrics` dict (avg/max branching factor, executed
+turn-type counts = mechanic usage, captures, tiny-endgame activation,
+repetition/endgame blocks).
+
+## Notes
+
+- `no_queen_manipulation` semantics: the no-legal-moves loss check
+  still uses full rules, so a position whose only legal turns are
+  manipulations surfaces as an empty turn list → treated as a draw.
+- Move entropy of the trained policy is an analysis-time metric
+  (evaluate checkpoints on a fixed position set), not logged per game.
+- ISEF logistics: Forms 1/1A/1B and the research plan must be approved
+  before data-collection runs; the gate and infrastructure tests are
+  fine to run now.

--- a/src/engine.py
+++ b/src/engine.py
@@ -170,7 +170,10 @@ class GameEngine:
         record = engine.get_game_record()
     """
 
-    def __init__(self, max_turns=1000, manipulation_mode='freeze'):
+    def __init__(self, max_turns=1000, manipulation_mode='freeze',
+                 knight_mode=Board.KNIGHT_MODE_V2, enable_boulder=True,
+                 enable_tiny_endgame=True, enable_manipulation=True,
+                 extra_move_every=0):
         # The default manipulation_mode is 'freeze' (v2 rulebook
         # semantics): a manipulated piece is held in place — no
         # spatial move on its immediate next turn. The 'original'
@@ -186,7 +189,42 @@ class GameEngine:
             raise ValueError(f"Invalid manipulation_mode: {manipulation_mode!r}. "
                              f"Must be one of {valid_modes}.")
         self.manipulation_mode = manipulation_mode
-        self.board = Board()
+        # --- LGMEF ablation switches (issue #168) ---
+        # Each switch removes ONE mechanic relative to the full v2 rule
+        # set, so matched self-play runs can measure that mechanic's
+        # strategic impact. Defaults preserve the full game.
+        #   knight_mode:          Board.KNIGHT_MODE_LEGACY = pre-v2 knight
+        #                         (no radius-2 / jump-capture /
+        #                         invulnerability) = "No Knight Redesign".
+        #   enable_boulder:       False removes the neutral boulder from
+        #                         the initial position entirely.
+        #   enable_tiny_endgame:  False prevents the tiny-endgame rule
+        #                         from ever activating.
+        #   enable_manipulation:  False removes queen-manipulation turns
+        #                         from generation. NOTE: the no-legal-
+        #                         moves loss check still uses the full
+        #                         rules (board.has_legal_moves), so a
+        #                         player whose ONLY legal turns are
+        #                         manipulations yields an empty turn
+        #                         list without a loss — callers treat
+        #                         that as a draw, which is the intended
+        #                         ablation semantics.
+        #   extra_move_every:     N > 0 grants the player who completed
+        #                         turn number k (k % N == 0) an
+        #                         immediate second turn. This is the
+        #                         POSITIVE CONTROL — a deliberately
+        #                         broken, obviously advantageous
+        #                         mechanic that the MCI metric must
+        #                         flag. Never part of a real variant.
+        self.enable_tiny_endgame = enable_tiny_endgame
+        self.enable_manipulation = enable_manipulation
+        self.extra_move_every = extra_move_every
+        self._extra_granted_last = False
+        self.board = Board(knight_mode=knight_mode)
+        if not enable_boulder:
+            # The boulder starts on the central intersection, referenced
+            # only via board.boulder (not on any square).
+            self.board.boulder = None
         self.current_player = 'white'
         self.winner = None
         self.loss_reason = None
@@ -281,7 +319,7 @@ class GameEngine:
                                 transform_target=opt,
                             ))
 
-                elif piece.color == opponent:
+                elif piece.color == opponent and self.enable_manipulation:
                     # Enemy piece — check queen manipulation
                     self._generate_piece_turns(piece, row, col, 'manipulation', color, turns)
 
@@ -503,7 +541,9 @@ class GameEngine:
         # Tiny endgame rule
         if self.board.tiny_endgame_active:
             self.board.update_distance_count(captured=False)
-        if not self.board.tiny_endgame_active and self.board.is_tiny_endgame():
+        if (self.enable_tiny_endgame
+                and not self.board.tiny_endgame_active
+                and self.board.is_tiny_endgame()):
             self.board.init_tiny_endgame()
             self.game_record.tiny_endgame_activated = True
             self.game_record.tiny_endgame_activation_turn = self.turn_number
@@ -571,7 +611,7 @@ class GameEngine:
                 self.winner = self.board.check_winner()
                 if self.winner:
                     self.loss_reason = 'royals_captured'
-            if self.board.is_tiny_endgame():
+            if self.enable_tiny_endgame and self.board.is_tiny_endgame():
                 self.board.init_tiny_endgame()
                 self.game_record.tiny_endgame_activated = True
                 self.game_record.tiny_endgame_activation_turn = self.turn_number
@@ -601,7 +641,9 @@ class GameEngine:
         # Tiny endgame rule
         if self.board.tiny_endgame_active:
             self.board.update_distance_count(captured=captured)
-        if not self.board.tiny_endgame_active and self.board.is_tiny_endgame():
+        if (self.enable_tiny_endgame
+                and not self.board.tiny_endgame_active
+                and self.board.is_tiny_endgame()):
             self.board.init_tiny_endgame()
             self.game_record.tiny_endgame_activated = True
             self.game_record.tiny_endgame_activation_turn = self.turn_number
@@ -653,7 +695,20 @@ class GameEngine:
 
     def _next_turn(self):
         """Switch to next player, record state, check for no-legal-moves loss."""
-        self.current_player = 'white' if self.current_player == 'black' else 'black'
+        # Positive-control mechanic (extra_move_every=N): the player who
+        # completed turn k with k % N == 0 immediately moves again. The
+        # _extra_granted_last latch prevents chaining extras. Turn
+        # numbers still advance, and per-turn housekeeping (flag expiry,
+        # state recording) runs unchanged — the control is INTENDED to
+        # be crudely unbalanced, not rules-coherent.
+        grant_extra = (self.extra_move_every > 0
+                       and not self._extra_granted_last
+                       and (self.turn_number + 1) % self.extra_move_every == 0)
+        if grant_extra:
+            self._extra_granted_last = True
+        else:
+            self._extra_granted_last = False
+            self.current_player = 'white' if self.current_player == 'black' else 'black'
         self.board.turn_number += 1
         self.turn_number += 1
         # v2 knight: a knight that gained invulnerability on its owner's

--- a/src/experiments/__init__.py
+++ b/src/experiments/__init__.py
@@ -1,0 +1,6 @@
+"""LGMEF experiment harness (issue #168).
+
+Named ablation variants of Royal Chess, per-variant well-formedness
+checks, and the run_experiment entry point used for the ISEF LGMEF
+study (Logic-based Game Mechanic Evaluation Framework).
+"""

--- a/src/experiments/variants.py
+++ b/src/experiments/variants.py
@@ -1,0 +1,96 @@
+"""Named LGMEF ablation variants of Royal Chess.
+
+Each variant is the FULL v2 rule set minus exactly one mechanic (or a
+named combination), expressed as GameEngine keyword arguments. The GDL
+step files in docs/gdl/ are the formal specification of the same
+ablations (e.g. no_boulder ~ building without step6_add_boulder.gdl);
+the engine is the fast execution substrate, and the GDL cross-validation
+harness (src/ggp/cross_validation.py) is the bridge proving the two
+agree. Training runs and metric collection always go through the
+engine; variant IDENTITY is defined here so every tool (trainer,
+well-formedness gate, analysis) names variants the same way.
+
+Controls (feedback item: validate the MCI instrument before headline
+results):
+  control_inert       — identical to 'full'. A correct MCI pipeline
+                        must measure ~0 impact for it (negative
+                        control / noise floor).
+  control_double_move — extra_move_every=10: the mover gets an
+                        immediate second turn every 10th turn. A
+                        deliberately broken, obviously impactful
+                        mechanic that MCI must flag (positive
+                        control). Never a real rule proposal.
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class VariantSpec:
+    name: str
+    description: str
+    engine_kwargs: dict = field(default_factory=dict)
+    is_control: bool = False
+
+
+_SPECS = [
+    VariantSpec(
+        'full',
+        'Full Royal Chess v2 rule set (all mechanics on).'),
+    VariantSpec(
+        'no_boulder',
+        'Full rules minus the neutral boulder (removed from the '
+        'initial position).',
+        {'enable_boulder': False}),
+    VariantSpec(
+        'no_tiny_endgame',
+        'Full rules minus the tiny-endgame rule (never activates).',
+        {'enable_tiny_endgame': False}),
+    VariantSpec(
+        'no_queen_manipulation',
+        'Full rules minus queen manipulation (manipulation turns are '
+        'not generated).',
+        {'enable_manipulation': False}),
+    VariantSpec(
+        'no_knight_redesign',
+        'Full rules with the LEGACY (pre-v2) knight: no radius-2 '
+        'movement, no jump-capture, no leap invulnerability.',
+        {'knight_mode': 'legacy'}),
+    VariantSpec(
+        'baseline',
+        'All studied mechanics ablated at once: no boulder, no tiny '
+        'endgame, no manipulation, legacy knight. The closest-to-'
+        'standard-chess reference point of the study.',
+        {'enable_boulder': False, 'enable_tiny_endgame': False,
+         'enable_manipulation': False, 'knight_mode': 'legacy'}),
+    VariantSpec(
+        'control_inert',
+        'Negative control: rule-identical to full. Measured MCI must '
+        'be ~0 (noise floor of the instrument).',
+        {}, is_control=True),
+    VariantSpec(
+        'control_double_move',
+        'Positive control: the mover takes an immediate second turn '
+        'every 10th turn — deliberately broken; MCI must flag it.',
+        {'extra_move_every': 10}, is_control=True),
+]
+
+VARIANTS = {spec.name: spec for spec in _SPECS}
+
+
+def get_variant(name):
+    """Return the VariantSpec for `name`, raising with the valid list."""
+    try:
+        return VARIANTS[name]
+    except KeyError:
+        raise ValueError(
+            f'Unknown variant {name!r}. Valid: {sorted(VARIANTS)}') from None
+
+
+def make_engine(name, max_turns=1000, manipulation_mode='freeze'):
+    """Construct a GameEngine configured for the named variant."""
+    from engine import GameEngine
+    spec = get_variant(name)
+    return GameEngine(max_turns=max_turns,
+                      manipulation_mode=manipulation_mode,
+                      **spec.engine_kwargs)

--- a/src/experiments/wellformedness.py
+++ b/src/experiments/wellformedness.py
@@ -1,0 +1,122 @@
+"""Per-variant well-formedness gate (issue #168).
+
+Before any variant enters a training run, random playouts must show it
+is a playable, terminating game (feedback item #6 on the LGMEF plan:
+an ablation can silently produce a degenerate or non-terminating game,
+which would poison the MCI comparison). This module runs N random
+playouts of a named variant and checks:
+
+  - every non-terminal position offers at least one legal turn
+    (an empty turn list without a winner is recorded as a
+    'dead_position' anomaly — expected occasionally ONLY for
+    no_queen_manipulation, where the loss check still uses full rules;
+    see GameEngine.enable_manipulation),
+  - the game terminates within the turn cap or by a rule outcome,
+  - both kings survive until a 'royals_captured' outcome,
+  - ablated mechanics never fire (no boulder turns in no_boulder, no
+    manipulation turns in no_queen_manipulation, no tiny-endgame
+    activation in no_tiny_endgame).
+
+Pure engine + random.Random — no torch, no pygame, fast enough for a
+pre-run gate on Kaggle or locally.
+"""
+
+import random
+
+from experiments.variants import get_variant, make_engine
+
+
+def _royals_present(board):
+    """Both sides retain at least one ROYAL piece (king or royal
+    queen). NOTE: in Royal Chess a king can legitimately be captured
+    mid-game while the royal queen survives — the loss condition is
+    capturing ALL of a side's royals, so the invariant is per-side
+    royal count >= 1, not king presence."""
+    royals = {'white': 0, 'black': 0}
+    for row in range(8):
+        for col in range(8):
+            piece = board.squares[row][col].piece
+            if piece and getattr(piece, 'is_royal', False) \
+                    and piece.color in royals:
+                royals[piece.color] += 1
+    return royals['white'] >= 1 and royals['black'] >= 1
+
+
+def check_variant(name, n_games=20, max_turns=300, seed=0):
+    """Run random playouts of `name` and return a report dict.
+
+    Report: {variant, n_games, ok, anomalies: [str], games: [per-game
+    dicts with winner/loss_reason/turns/branching]}. `ok` is True iff
+    no anomaly was recorded.
+    """
+    spec = get_variant(name)
+    rng = random.Random(seed)
+    anomalies = []
+    games = []
+
+    for g in range(n_games):
+        engine = make_engine(name, max_turns=max_turns)
+        branching = []
+        turn_types = {}
+        dead_position = False
+
+        while not engine.is_game_over():
+            turns = engine.get_all_legal_turns()
+            if not turns:
+                dead_position = True
+                break
+            branching.append(len(turns))
+            turn = rng.choice(turns)
+            turn_types[turn.turn_type] = turn_types.get(turn.turn_type, 0) + 1
+            engine.execute_turn(turn)
+
+        record = engine.get_game_record()
+
+        if dead_position and engine.winner is None:
+            if name == 'no_queen_manipulation':
+                # Known semantics: only-manipulation-turns positions
+                # surface as empty turn lists here. Count, don't fail.
+                pass
+            else:
+                anomalies.append(
+                    f'game {g}: dead position (no legal turns, no '
+                    f'winner) at turn {engine.turn_number}')
+        if engine.winner and engine.loss_reason == 'royals_captured':
+            pass  # all royals captured IS the outcome; nothing to check after
+        elif not _royals_present(engine.board):
+            anomalies.append(
+                f'game {g}: a side lost all royals without a '
+                f'royals_captured outcome '
+                f'(loss_reason={engine.loss_reason!r})')
+
+        # Ablated mechanics must never fire.
+        if spec.engine_kwargs.get('enable_boulder', True) is False \
+                and turn_types.get('boulder'):
+            anomalies.append(f'game {g}: boulder turn in no-boulder variant')
+        if spec.engine_kwargs.get('enable_manipulation', True) is False \
+                and turn_types.get('manipulation'):
+            anomalies.append(
+                f'game {g}: manipulation turn in no-manipulation variant')
+        if spec.engine_kwargs.get('enable_tiny_endgame', True) is False \
+                and record.tiny_endgame_activated:
+            anomalies.append(
+                f'game {g}: tiny endgame activated in no-tiny-endgame variant')
+
+        games.append({
+            'winner': engine.winner,
+            'loss_reason': engine.loss_reason,
+            'total_turns': engine.turn_number,
+            'dead_position': dead_position,
+            'avg_branching': (sum(branching) / len(branching)) if branching else 0.0,
+            'turn_type_counts': turn_types,
+        })
+
+    return {
+        'variant': name,
+        'n_games': n_games,
+        'max_turns': max_turns,
+        'seed': seed,
+        'ok': not anomalies,
+        'anomalies': anomalies,
+        'games': games,
+    }

--- a/src/run_experiment.py
+++ b/src/run_experiment.py
@@ -1,0 +1,119 @@
+"""LGMEF experiment entry point (issue #168).
+
+One headless command per (variant, seed) training run, designed for
+Kaggle/Colab sessions:
+
+    python src/run_experiment.py --variant no_boulder --seed 2 --iters 50
+    python src/run_experiment.py --variant full --check          # gate only
+
+Outputs land in models/experiments/<variant>/seed<k>/:
+    experiment.json          — variant spec, seed, CLI config (provenance)
+    wellformedness.json      — the pre-run gate report
+    model_iter_*.pt, training_history.json, games/iter_*.jsonl
+                             — from trainer.training_loop (per-game
+                               JSONL rows carry the LGMEF 'metrics'
+                               dict: branching factor, mechanic-usage
+                               turn-type counts, captures)
+
+The well-formedness gate ALWAYS runs before training and aborts the run
+if it fails — a degenerate ablation must never produce data.
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from experiments.variants import VARIANTS, get_variant
+from experiments.wellformedness import check_variant
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description='Run one LGMEF training run for a named variant.')
+    parser.add_argument('--variant', required=True, choices=sorted(VARIANTS),
+                        help='Named ablation variant (see experiments/variants.py)')
+    parser.add_argument('--seed', type=int, default=0,
+                        help='Run seed (seeds python/numpy/torch RNGs)')
+    parser.add_argument('--iters', type=int, default=50,
+                        help='Training iterations')
+    parser.add_argument('--decisive-games', type=int, default=100,
+                        help='Decisive games per iteration')
+    parser.add_argument('--max-turns', type=int, default=1000,
+                        help='Turn cap per game')
+    parser.add_argument('--workers', type=int, default=4,
+                        help='Parallel self-play workers')
+    parser.add_argument('--epochs', type=int, default=10,
+                        help='Training epochs per iteration')
+    parser.add_argument('--save-dir', type=str, default=None,
+                        help='Output dir (default models/experiments/'
+                             '<variant>/seed<k>/)')
+    parser.add_argument('--resume', type=str, default=None,
+                        help='Checkpoint to resume from')
+    parser.add_argument('--check', action='store_true',
+                        help='Run ONLY the well-formedness gate and exit')
+    parser.add_argument('--check-games', type=int, default=20,
+                        help='Random playouts for the gate')
+    args = parser.parse_args(argv)
+
+    spec = get_variant(args.variant)
+    save_dir = args.save_dir or os.path.join(
+        'models', 'experiments', args.variant, f'seed{args.seed}')
+    os.makedirs(save_dir, exist_ok=True)
+
+    # --- Well-formedness gate (always) ---
+    print(f'Well-formedness gate: {args.variant} '
+          f'({args.check_games} random playouts)...')
+    report = check_variant(args.variant, n_games=args.check_games,
+                           max_turns=min(args.max_turns, 300),
+                           seed=args.seed)
+    with open(os.path.join(save_dir, 'wellformedness.json'), 'w') as f:
+        json.dump(report, f, indent=2)
+    if not report['ok']:
+        print('GATE FAILED:')
+        for a in report['anomalies']:
+            print(f'  - {a}')
+        return 1
+    decisive = sum(1 for g in report['games'] if g['winner'])
+    print(f'  ok: {decisive}/{report["n_games"]} decisive, '
+          f'avg branching '
+          f'{sum(g["avg_branching"] for g in report["games"]) / len(report["games"]):.1f}')
+    if args.check:
+        return 0
+
+    # --- Seed everything, record provenance, train ---
+    import numpy as np
+    import torch
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    with open(os.path.join(save_dir, 'experiment.json'), 'w') as f:
+        json.dump({
+            'variant': spec.name,
+            'description': spec.description,
+            'engine_kwargs': spec.engine_kwargs,
+            'is_control': spec.is_control,
+            'seed': args.seed,
+            'config': vars(args),
+        }, f, indent=2)
+
+    from trainer import training_loop
+    training_loop(
+        n_iterations=args.iters,
+        decisive_games=args.decisive_games,
+        max_turns=args.max_turns,
+        epochs_per_iteration=args.epochs,
+        save_dir=save_dir,
+        resume_from=args.resume,
+        n_workers=args.workers,
+        engine_kwargs=spec.engine_kwargs,
+    )
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/trainer.py
+++ b/src/trainer.py
@@ -283,7 +283,7 @@ class NeuralPlayer:
         return state
 
 def play_training_game(network, device, max_turns=1000, epsilon=0.1,
-                       manipulation_mode='freeze'):
+                       manipulation_mode='freeze', engine_kwargs=None):
     """Play a single self-play game and collect training data.
 
     Args:
@@ -294,22 +294,32 @@ def play_training_game(network, device, max_turns=1000, epsilon=0.1,
         manipulation_mode: defaults to 'freeze' (v2 rulebook semantics).
             'original' selects v1 (forbidden-square) semantics; other
             modes are variants used for rule research.
+        engine_kwargs: optional dict of extra GameEngine kwargs — the
+            LGMEF ablation switches (knight_mode, enable_boulder,
+            enable_tiny_endgame, enable_manipulation, extra_move_every)
+            from experiments.variants. None = full v2 game.
 
     Returns:
         states: list of encoded board states (numpy arrays)
         outcomes: list of outcomes (1.0 = win, 0.0 = loss) for the player at each state
-        game_info: dict with game metadata
+        game_info: dict with game metadata (incl. a compact 'metrics'
+            dict: branching factor, executed turn-type counts, captures
+            — the LGMEF per-game measurements)
     """
-    engine = GameEngine(max_turns=max_turns, manipulation_mode=manipulation_mode)
+    engine = GameEngine(max_turns=max_turns, manipulation_mode=manipulation_mode,
+                        **(engine_kwargs or {}))
     player = NeuralPlayer(network, device, epsilon)
 
     states = []
     players_at_state = []  # track whose perspective each state was encoded from
+    branching = []         # legal-turn count per ply
+    turn_type_counts = {}  # executed turn types (mechanic-usage frequency)
 
     while not engine.is_game_over():
         turns = engine.get_all_legal_turns()
         if not turns:
             break
+        branching.append(len(turns))
 
         # Record current position
         state = encode_board_for_player(
@@ -321,6 +331,8 @@ def play_training_game(network, device, max_turns=1000, epsilon=0.1,
         # Turn; player picks one and we execute it directly. No sub-choice
         # method calls are needed.
         turn = player.choose_turn(turns, engine)
+        turn_type_counts[turn.turn_type] = \
+            turn_type_counts.get(turn.turn_type, 0) + 1
         engine.execute_turn(turn)
 
     # Finalize and determine outcomes
@@ -331,6 +343,15 @@ def play_training_game(network, device, max_turns=1000, epsilon=0.1,
         'loss_reason': engine.loss_reason,
         'total_turns': engine.turn_number,
         'turn_cap': engine.turn_number >= max_turns,
+        'metrics': {
+            'avg_branching': (sum(branching) / len(branching)) if branching else 0.0,
+            'max_branching': max(branching) if branching else 0,
+            'turn_type_counts': turn_type_counts,
+            'captures': game_record.total_captures,
+            'tiny_endgame_activated': game_record.tiny_endgame_activated,
+            'repetition_blocks': game_record.repetition_blocks,
+            'endgame_blocks': game_record.endgame_blocks,
+        },
         'game_record': game_record.to_dict(),
     }
 
@@ -364,14 +385,16 @@ def _play_one_game_worker(args):
     """Worker entry point for multiprocessing.Pool.
 
     `args` is a tuple:
-      (state_dict, model_config, max_turns, epsilon, manipulation_mode, seed)
+      (state_dict, model_config, max_turns, epsilon, manipulation_mode,
+       seed, engine_kwargs)
 
     Returns (states, outcomes, game_info) — identical shape to
     play_training_game()'s return value.
     """
     import random as _random
     import torch as _torch
-    state_dict, model_config, max_turns, epsilon, manipulation_mode, seed = args
+    (state_dict, model_config, max_turns, epsilon, manipulation_mode,
+     seed, engine_kwargs) = args
     if seed is not None:
         _random.seed(seed)
         _torch.manual_seed(seed)
@@ -384,7 +407,7 @@ def _play_one_game_worker(args):
     net.load_state_dict(state_dict)
     net.eval()
     return play_training_game(
-        net, 'cpu', max_turns, epsilon, manipulation_mode)
+        net, 'cpu', max_turns, epsilon, manipulation_mode, engine_kwargs)
 
 
 def train_epoch(network, optimizer, dataloader, device):
@@ -437,6 +460,7 @@ def training_loop(
     device=None,
     manipulation_mode='freeze',
     n_workers=1,
+    engine_kwargs=None,
 ):
     """Main training loop.
 
@@ -584,6 +608,10 @@ def training_loop(
                 'loss_reason': info.get('loss_reason'),
                 'total_turns': info['total_turns'],
                 'turn_cap': info['turn_cap'],
+                # LGMEF per-game measurements (branching factor,
+                # mechanic-usage counts, captures) — see
+                # play_training_game's game_info['metrics'].
+                'metrics': info.get('metrics'),
             })
             reason = info.get('loss_reason') or 'decisive'
             loss_reason_counts[reason] = (
@@ -622,7 +650,8 @@ def training_loop(
                     args_list = [
                         (state_dict, model_config, max_turns,
                          epsilon, manipulation_mode,
-                         seed_base + batch_idx * n_workers + i)
+                         seed_base + batch_idx * n_workers + i,
+                         engine_kwargs)
                         for i in range(n_workers)
                     ]
                     batch_idx += 1
@@ -637,7 +666,7 @@ def training_loop(
             while n_decisive < decisive_games:
                 states, outcomes, info = play_training_game(
                     network_cpu, 'cpu', max_turns, epsilon,
-                    manipulation_mode)
+                    manipulation_mode, engine_kwargs)
                 _ingest_game(states, outcomes, info)
 
         play_elapsed = time.time() - play_start

--- a/tests/test_experiment_harness.py
+++ b/tests/test_experiment_harness.py
@@ -1,0 +1,161 @@
+"""LGMEF experiment harness (issue #168).
+
+Covers the engine ablation switches, the variant registry, the
+well-formedness gate, and the per-game metrics emitted by
+play_training_game. Engine-level only — no torch training epochs; the
+one play_training_game test uses epsilon=1.0 so the network is never
+consulted (network=None).
+"""
+
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+os.environ.setdefault('SDL_VIDEODRIVER', 'dummy')
+os.environ.setdefault('SDL_AUDIODRIVER', 'dummy')
+
+import pytest
+
+from board import Board
+from engine import GameEngine
+from piece import King, Rook
+from experiments.variants import VARIANTS, get_variant, make_engine
+from experiments.wellformedness import check_variant
+
+
+def _play_random(engine, rng, max_plies):
+    """Random playout helper; returns executed turn-type counts."""
+    counts = {}
+    for _ in range(max_plies):
+        if engine.is_game_over():
+            break
+        turns = engine.get_all_legal_turns()
+        if not turns:
+            break
+        turn = rng.choice(turns)
+        counts[turn.turn_type] = counts.get(turn.turn_type, 0) + 1
+        engine.execute_turn(turn)
+    return counts
+
+
+# ---- Variant registry ----------------------------------------------------
+
+def test_registry_has_all_planned_variants():
+    assert set(VARIANTS) == {
+        'full', 'no_boulder', 'no_tiny_endgame', 'no_queen_manipulation',
+        'no_knight_redesign', 'baseline', 'control_inert',
+        'control_double_move'}
+
+
+def test_unknown_variant_raises_with_valid_list():
+    with pytest.raises(ValueError, match='no_boulder'):
+        get_variant('nonsense')
+
+
+def test_control_inert_is_rule_identical_to_full():
+    assert get_variant('control_inert').engine_kwargs == \
+        get_variant('full').engine_kwargs == {}
+
+
+# ---- Engine ablation switches --------------------------------------------
+
+def test_default_engine_unchanged():
+    """The full game: boulder present, v2 knight, flags on."""
+    e = GameEngine()
+    assert e.board.boulder is not None
+    assert e.board.knight_mode == Board.KNIGHT_MODE_V2
+    assert e.enable_tiny_endgame and e.enable_manipulation
+    assert e.extra_move_every == 0
+
+
+def test_no_boulder_removes_boulder_and_boulder_turns():
+    e = make_engine('no_boulder')
+    assert e.board.boulder is None
+    counts = _play_random(e, random.Random(1), 60)
+    assert 'boulder' not in counts
+
+
+def test_no_knight_redesign_uses_legacy_board():
+    e = make_engine('no_knight_redesign')
+    assert e.board.knight_mode == Board.KNIGHT_MODE_LEGACY
+
+
+def test_no_queen_manipulation_never_offers_manipulation_turns():
+    e = make_engine('no_queen_manipulation')
+    rng = random.Random(2)
+    for _ in range(60):
+        if e.is_game_over():
+            break
+        turns = e.get_all_legal_turns()
+        if not turns:
+            break
+        assert all(t.turn_type != 'manipulation' for t in turns)
+        e.execute_turn(rng.choice(turns))
+
+
+def test_no_tiny_endgame_never_activates():
+    """Craft a board that satisfies is_tiny_endgame (K+R vs K+R, no
+    pawns) and verify the disabled engine never activates the rule
+    while the default engine does."""
+    def _make(enable):
+        e = GameEngine(enable_tiny_endgame=enable)
+        for row in range(8):
+            for col in range(8):
+                e.board.squares[row][col].piece = None
+        e.board.boulder = None
+        e.board.squares[0][0].piece = King('black')
+        e.board.squares[7][7].piece = King('white')
+        e.board.squares[0][7].piece = Rook('black')
+        e.board.squares[7][0].piece = Rook('white')
+        assert e.board.is_tiny_endgame()
+        turns = e.get_all_legal_turns()
+        e.execute_turn(random.Random(3).choice(turns))
+        return e
+
+    assert _make(True).board.tiny_endgame_active is True
+    assert _make(False).board.tiny_endgame_active is False
+
+
+def test_double_move_control_grants_consecutive_turns():
+    e = GameEngine(extra_move_every=2)
+    rng = random.Random(4)
+    players = []
+    for _ in range(8):
+        turns = e.get_all_legal_turns()
+        players.append(e.current_player)
+        e.execute_turn(rng.choice(turns))
+    # With N=2 the mover of every 2nd completed turn repeats, so some
+    # consecutive pair shares a player — impossible without the control.
+    assert any(a == b for a, b in zip(players, players[1:]))
+    # The latch prevents chained extras: never 3 in a row.
+    assert not any(a == b == c for a, b, c in
+                   zip(players, players[1:], players[2:]))
+
+
+# ---- Metrics in play_training_game ---------------------------------------
+
+def test_play_training_game_emits_metrics():
+    from trainer import play_training_game
+    # epsilon=1.0 → pure random turn choice; the network is never used.
+    states, outcomes, info = play_training_game(
+        network=None, device='cpu', max_turns=30, epsilon=1.0,
+        engine_kwargs=get_variant('no_boulder').engine_kwargs)
+    m = info['metrics']
+    assert m['avg_branching'] > 0 and m['max_branching'] >= m['avg_branching']
+    assert sum(m['turn_type_counts'].values()) == info['total_turns']
+    assert 'boulder' not in m['turn_type_counts']
+    assert 'captures' in m and 'tiny_endgame_activated' in m
+
+
+# ---- Well-formedness gate ------------------------------------------------
+
+@pytest.mark.parametrize('variant', ['full', 'baseline', 'control_double_move'])
+def test_wellformedness_gate_passes_for(variant):
+    report = check_variant(variant, n_games=3, max_turns=80, seed=5)
+    assert report['ok'], report['anomalies']
+    assert len(report['games']) == 3
+    for g in report['games']:
+        assert g['total_turns'] <= 80
+        assert g['avg_branching'] > 0


### PR DESCRIPTION
Closes #168. Infrastructure for the ISEF LGMEF study: ablation studies over Royal Chess mechanics evaluated with matched self-play agents.

## What's here

**Engine ablation switches** (opt-in `GameEngine` kwargs; defaults preserve the full v2 game):
- `knight_mode='legacy'` → No Knight Redesign
- `enable_boulder=False` → boulder removed from the initial position
- `enable_tiny_endgame=False` → rule never activates (all 3 activation sites guarded)
- `enable_manipulation=False` → manipulation turns not generated (no-legal-moves loss check keeps full-rules semantics; only-manipulation positions surface as empty turn lists → draw, documented)
- `extra_move_every=N` → positive-control broken mechanic (immediate second turn every Nth completed turn, latch prevents chaining)

**Trainer**: `engine_kwargs` threaded through `play_training_game`/worker tuple/`training_loop`; per-game `metrics` dict (avg/max branching, executed turn-type counts = mechanic usage, captures, tiny-endgame activation, repetition/endgame blocks) in `game_info` and the per-iteration `games/iter_*.jsonl`.

**New modules**:
- `src/experiments/variants.py` — named registry: `full`, `no_boulder`, `no_tiny_endgame`, `no_queen_manipulation`, `no_knight_redesign`, `baseline`, `control_inert` (negative control), `control_double_move` (positive control)
- `src/experiments/wellformedness.py` — random-playout gate: termination, nonempty turns, per-side ROYAL-count invariant (not king presence — a king can legitimately be captured while the royal queen survives), ablated-mechanic-never-fires
- `src/run_experiment.py` — one command per (variant, seed); gate always runs first and aborts on failure; provenance `experiment.json`; outputs under `models/experiments/<variant>/seed<k>/`
- `docs/lgmef-experiments.md` — usage + architecture (GDL = spec, engine = cross-validated substrate)

## Testing
- `tests/test_experiment_harness.py`: 13 passed (registry, every switch, double-move latch, metrics emission, gate on 3 variants)
- Regression: `test_ai.py` + `test_manipulation_variants.py`: 174 passed, 3 skipped
- CLI smoke: `--check` gates pass for `no_queen_manipulation` (4/5 decisive, avg branching 68.6) and `control_double_move` (3/5 decisive, 66.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)